### PR TITLE
Release V1.0.5

### DIFF
--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -273,8 +273,8 @@ export async function toggleEmailAttachmentActive(id: number, active: boolean): 
 }
 
 // ===== Catering Email =====
-export async function fetchCateringEmailPreview(reservationId: number): Promise<{ subject: string; body: string }> {
-  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/reservations/${reservationId}/catering-email/preview`) as Promise<{ subject: string; body: string }>;
+export async function fetchCateringEmailPreview(reservationId: number): Promise<{ subject: string; body: string; defaultReplyTo?: string }> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/reservations/${reservationId}/catering-email/preview`) as Promise<{ subject: string; body: string; defaultReplyTo?: string }>;
 }
 
 export async function sendCateringEmail(reservationId: number, request: CateringEmailRequest): Promise<{ status: string; message: string }> {

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -155,6 +155,7 @@ export function ReservationDetailPage() {
       ]);
       setCateringSubject(preview.subject);
       setCateringBody(preview.body);
+      if (preview.defaultReplyTo) setCateringReplyTo(preview.defaultReplyTo);
       const activeAttachments = attachments.filter(a => a.active);
       setCateringAttachments(activeAttachments);
       setSelectedAttachmentIds(activeAttachments.map(a => a.id));

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -186,7 +186,7 @@ public class AdminReservationController {
                     Map<String, String> vars = buildCateringVars(reservation);
                     String subject = emailTemplateService.getRenderedSubject(EmailTemplateType.CATERING_OPTIONS, vars);
                     String body = emailTemplateService.getRenderedBody(EmailTemplateType.CATERING_OPTIONS, vars);
-                    return ResponseEntity.ok(Map.of("subject", subject, "body", body));
+                    return ResponseEntity.ok(Map.of("subject", subject, "body", body, "defaultReplyTo", staffEmail));
                 })
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.53.1",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What does this PR do?
Quick fix so that the default catering reply-to is set to staff address since this mail is intended to reply to.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] CI / DevOps
- [ ] Other: <!-- describe -->

## Checklist
- [x] I have tested this locally (Docker Compose)
- [x] All tests pass (Also Pipeline check)
- [x] No secrets or credentials are committed
- [x] README / docs updated (if needed)

