### PR TITLE
feat: custom calendar appointments & admin UI improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - SPRING_DATASOURCE_PASSWORD=local_dev_password
 
       # JPA/Hibernate Configuration
-      - SPRING_JPA_HIBERNATE_DDL_AUTO=validate # update possible for changes
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=update # update possible for changes
       - SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.MariaDBDialect
       - SPRING_JPA_SHOW_SQL=true
 

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/App.tsx
+++ b/the-harry-list-admin/src/App.tsx
@@ -8,6 +8,7 @@ import { CalendarPage } from './pages/CalendarPage';
 import { ExportPage } from './pages/ExportPage';
 import { EmailTemplatesPage } from './pages/EmailTemplatesPage';
 import { FormSettingsPage } from './pages/FormSettingsPage';
+import { CalendarAppointmentsPage } from './pages/CalendarAppointmentsPage';
 import { WeekOverviewPage } from './pages/WeekOverviewPage';
 import { Layout } from './components/Layout';
 import { useGroupAuthorization } from './lib/useGroupAuthorization';
@@ -89,6 +90,7 @@ function App() {
           <Route path="calendar" element={<CalendarPage />} />
           <Route path="email-templates" element={<EmailTemplatesPage />} />
           <Route path="form-settings" element={<FormSettingsPage />} />
+          <Route path="calendar-appointments" element={<CalendarAppointmentsPage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import {
 import { useState } from 'react';
 import { clearAuth} from '../lib/api';
 import { ThemeToggle } from './ThemeToggle';
+import { version } from '../../package.json';
 
 export function Layout() {
   const { instance, accounts } = useMsal();
@@ -37,7 +38,7 @@ export function Layout() {
   ];
 
   return (
-    <div className="min-h-screen bg-dark-950 flex">
+    <div className="h-screen bg-dark-950 flex overflow-hidden">
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div
@@ -46,11 +47,11 @@ export function Layout() {
         />
       )}
 
-      {/* Sidebar */}
+      {/* Sidebar — fixed, does not scroll with content */}
       <aside className={`
         fixed lg:static inset-y-0 left-0 z-50
         w-64 bg-dark-900 border-r border-dark-800
-        transform transition-transform duration-200 ease-in-out
+        transform transition-transform duration-200 ease-in-out flex-shrink-0
         ${sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
       `}>
         <div className="flex flex-col h-full">
@@ -67,9 +68,9 @@ export function Layout() {
             </div>
           </div>
 
-          {/* Navigation */}
-          <nav className="flex-1 p-4">
-            <ul className="space-y-2">
+          {/* Navigation — scrollable if nav items overflow */}
+          <nav className="flex-1 p-3 overflow-y-auto">
+            <ul className="space-y-1">
               {navItems.map((item) => (
                 <li key={item.to}>
                   <NavLink
@@ -77,14 +78,14 @@ export function Layout() {
                     end={item.to === '/'}
                     onClick={() => setSidebarOpen(false)}
                     className={({ isActive }) => `
-                      flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all
-                      ${isActive 
-                        ? 'bg-hubble-500/20 text-hubble-400' 
+                      flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all
+                      ${isActive
+                        ? 'bg-hubble-500/20 text-hubble-400'
                         : 'text-dark-400 hover:text-white hover:bg-dark-800'
                       }
                     `}
                   >
-                    <item.icon className="w-5 h-5" />
+                    <item.icon className="w-4 h-4" />
                     {item.label}
                   </NavLink>
                 </li>
@@ -92,7 +93,7 @@ export function Layout() {
             </ul>
           </nav>
 
-          {/* User section */}
+          {/* User section — pinned to bottom */}
           <div className="p-4 border-t border-dark-800">
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs text-dark-500 uppercase tracking-wider">Settings</span>
@@ -118,12 +119,15 @@ export function Layout() {
               <LogOut className="w-5 h-5" />
               Sign Out
             </button>
+            <div className="mt-3 text-center">
+              <span className="text-[10px] text-dark-600">v{version}</span>
+            </div>
           </div>
         </div>
       </aside>
 
-      {/* Main content */}
-      <div className="flex-1 flex flex-col min-w-0">
+      {/* Main content — this is the only part that scrolls */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {/* Mobile header */}
         <header className="lg:hidden flex items-center justify-between p-4 border-b border-dark-800 bg-dark-900">
           <button
@@ -139,8 +143,8 @@ export function Layout() {
           <div className="w-10" /> {/* Spacer */}
         </header>
 
-        {/* Page content */}
-        <main className="flex-1 p-6 overflow-auto">
+        {/* Page content — scrollable */}
+        <main className="flex-1 p-6 overflow-y-auto">
           <Outlet />
         </main>
       </div>

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { useMsal } from '@azure/msal-react';
 import {
   LayoutDashboard, Calendar, CalendarDays, LogOut,
-  User, Menu, CalendarSync, FileDown, Mail, Settings
+  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings
 } from 'lucide-react';
 import { useState } from 'react';
 import { clearAuth} from '../lib/api';
@@ -31,6 +31,7 @@ export function Layout() {
     { to: '/week-overview', icon: CalendarDays, label: 'Week Overview' },
     { to: '/export', icon: FileDown, label: 'Export' },
     { to: '/calendar', icon: CalendarSync, label: 'Calendar Feeds' },
+    { to: '/calendar-appointments', icon: CalendarPlus, label: 'Appointments' },
     { to: '/email-templates', icon: Mail, label: 'Email Templates' },
     { to: '/form-settings', icon: Settings, label: 'Form Settings' },
   ];

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -130,7 +130,7 @@ async function fetchJsonWithAuth(url: string, options: RequestInit = {}): Promis
 }
 
 // Import types for proper typing
-import type { Reservation, FormConstraint, BlockedPeriod, EmailAttachment, CateringEmailRequest } from '../types/reservation';
+import type { Reservation, FormConstraint, BlockedPeriod, EmailAttachment, CateringEmailRequest, CalendarAppointment } from '../types/reservation';
 
 // API Functions
 export async function fetchReservations(): Promise<Reservation[]> {
@@ -240,6 +240,37 @@ export async function toggleBlockedPeriod(id: number): Promise<BlockedPeriod> {
 
 export async function deleteBlockedPeriod(id: number): Promise<void> {
   await fetchJsonWithAuth(`${API_BASE_URL}/api/admin/blocked-periods/${id}`, {
+    method: 'DELETE',
+  });
+}
+
+// ===== Calendar Appointments =====
+export async function fetchCalendarAppointments(): Promise<CalendarAppointment[]> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/calendar-appointments`) as Promise<CalendarAppointment[]>;
+}
+
+export async function createCalendarAppointment(appointment: CalendarAppointment): Promise<CalendarAppointment> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/calendar-appointments`, {
+    method: 'POST',
+    body: JSON.stringify(appointment),
+  }) as Promise<CalendarAppointment>;
+}
+
+export async function updateCalendarAppointment(id: number, appointment: CalendarAppointment): Promise<CalendarAppointment> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/calendar-appointments/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(appointment),
+  }) as Promise<CalendarAppointment>;
+}
+
+export async function toggleCalendarAppointment(id: number): Promise<CalendarAppointment> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/calendar-appointments/${id}/toggle`, {
+    method: 'PATCH',
+  }) as Promise<CalendarAppointment>;
+}
+
+export async function deleteCalendarAppointment(id: number): Promise<void> {
+  await fetchJsonWithAuth(`${API_BASE_URL}/api/admin/calendar-appointments/${id}`, {
     method: 'DELETE',
   });
 }

--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -1,0 +1,379 @@
+import { useState, useEffect } from 'react';
+import {
+  Plus, Trash2, Loader2, AlertCircle,
+  ToggleLeft, ToggleRight, Pencil, X, CalendarPlus, Clock, Sun, Repeat
+} from 'lucide-react';
+import {
+  fetchCalendarAppointments, createCalendarAppointment, updateCalendarAppointment,
+  toggleCalendarAppointment, deleteCalendarAppointment,
+} from '../lib/api';
+import type { CalendarAppointment, RecurrenceType } from '../types/reservation';
+
+const RECURRENCE_OPTIONS: { value: RecurrenceType; label: string }[] = [
+  { value: 'NONE', label: 'None' },
+  { value: 'DAILY', label: 'Daily' },
+  { value: 'WEEKLY', label: 'Weekly' },
+  { value: 'BIWEEKLY', label: 'Bi-weekly' },
+  { value: 'MONTHLY', label: 'Monthly' },
+  { value: 'YEARLY', label: 'Yearly' },
+];
+
+const RECURRENCE_LABELS: Record<string, string> = {
+  DAILY: 'Daily',
+  WEEKLY: 'Weekly',
+  BIWEEKLY: 'Bi-weekly',
+  MONTHLY: 'Monthly',
+  YEARLY: 'Yearly',
+};
+
+const emptyAppointment: CalendarAppointment = {
+  title: '',
+  description: '',
+  date: '',
+  allDay: false,
+  startTime: '',
+  endTime: '',
+  location: 'HUBBLE',
+  recurrenceType: 'NONE',
+  recurrenceEndDate: '',
+  enabled: true,
+};
+
+export function CalendarAppointmentsPage() {
+  const [appointments, setAppointments] = useState<CalendarAppointment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState<CalendarAppointment | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchCalendarAppointments()
+      .then(data => setAppointments(data))
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load appointments'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSave = async () => {
+    if (!editing) return;
+    setSaving(true);
+    setError(null);
+
+    // Clean empty strings to null for optional fields
+    const cleaned = {
+      ...editing,
+      description: editing.description || undefined,
+      startTime: editing.allDay ? undefined : editing.startTime || undefined,
+      endTime: editing.allDay ? undefined : editing.endTime || undefined,
+      recurrenceEndDate: editing.recurrenceType === 'NONE' ? undefined : editing.recurrenceEndDate || undefined,
+    };
+
+    try {
+      if (editing.id) {
+        const updated = await updateCalendarAppointment(editing.id, cleaned);
+        setAppointments(prev => prev.map(a => a.id === updated.id ? updated : a));
+      } else {
+        const created = await createCalendarAppointment(cleaned);
+        setAppointments(prev => [...prev, created]);
+      }
+      setEditing(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save appointment');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (id: number) => {
+    try {
+      const updated = await toggleCalendarAppointment(id);
+      setAppointments(prev => prev.map(a => a.id === id ? updated : a));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to toggle appointment');
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteCalendarAppointment(id);
+      setAppointments(prev => prev.filter(a => a.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete appointment');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="w-8 h-8 text-hubble-400 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-title font-bold text-white">Calendar Appointments</h1>
+          <p className="text-dark-400 font-light">Custom calendar entries that appear in the ICS feeds alongside reservations</p>
+        </div>
+        <button
+          onClick={() => setEditing({ ...emptyAppointment })}
+          className="btn-primary flex items-center gap-2 shrink-0"
+        >
+          <Plus className="w-4 h-4" />
+          Add Appointment
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
+          <span className="text-red-400 text-sm">{error}</span>
+          <button onClick={() => setError(null)} className="ml-auto">
+            <X className="w-4 h-4 text-red-400" />
+          </button>
+        </div>
+      )}
+
+      {/* List */}
+      {appointments.length === 0 ? (
+        <div className="card text-center py-12">
+          <CalendarPlus className="w-12 h-12 text-dark-600 mx-auto mb-3" />
+          <p className="text-dark-400">No appointments yet. Create one to add it to your calendar feeds.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {appointments.map(appointment => (
+            <div
+              key={appointment.id}
+              className={`bg-dark-900 border rounded-xl p-4 flex items-start gap-4 ${
+                appointment.enabled ? 'border-dark-800' : 'border-dark-800/50 opacity-60'
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap mb-1">
+                  <span className="text-white font-medium">{appointment.title}</span>
+                  {/* Location badge */}
+                  <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+                    appointment.location === 'HUBBLE'
+                      ? 'bg-hubble-500/20 text-hubble-400'
+                      : 'bg-meteor-500/20 text-meteor-400'
+                  }`}>
+                    {appointment.location}
+                  </span>
+                  {/* All-day or time badge */}
+                  {appointment.allDay ? (
+                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 flex items-center gap-1">
+                      <Sun className="w-3 h-3" />
+                      All day
+                    </span>
+                  ) : appointment.startTime && appointment.endTime ? (
+                    <span className="text-xs text-dark-500 flex items-center gap-1">
+                      <Clock className="w-3 h-3" />
+                      {appointment.startTime.slice(0, 5)}–{appointment.endTime.slice(0, 5)}
+                    </span>
+                  ) : null}
+                  {/* Recurrence badge */}
+                  {appointment.recurrenceType !== 'NONE' && (
+                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 flex items-center gap-1">
+                      <Repeat className="w-3 h-3" />
+                      {RECURRENCE_LABELS[appointment.recurrenceType] || appointment.recurrenceType}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-dark-500 mb-1">
+                  {appointment.date}
+                  {appointment.recurrenceType !== 'NONE' && appointment.recurrenceEndDate && (
+                    <span> → {appointment.recurrenceEndDate}</span>
+                  )}
+                </div>
+                {appointment.description && (
+                  <p className="text-sm text-dark-400 truncate">{appointment.description}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  onClick={() => setEditing({ ...appointment })}
+                  className="p-1.5 rounded-lg text-dark-400 hover:text-white hover:bg-dark-800"
+                  title="Edit"
+                >
+                  <Pencil className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={() => appointment.id && handleToggle(appointment.id)}
+                  className="p-1.5 rounded-lg"
+                  title={appointment.enabled ? 'Disable' : 'Enable'}
+                >
+                  {appointment.enabled
+                    ? <ToggleRight className="w-5 h-5 text-green-400" />
+                    : <ToggleLeft className="w-5 h-5 text-dark-500" />
+                  }
+                </button>
+                <button
+                  onClick={() => appointment.id && handleDelete(appointment.id)}
+                  className="p-1.5 rounded-lg text-dark-400 hover:text-red-400 hover:bg-red-500/10"
+                  title="Delete"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Create/Edit Modal */}
+      {editing && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+          <div className="bg-dark-900 border border-dark-700 rounded-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+            <div className="p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-white">
+                  {editing.id ? 'Edit Appointment' : 'New Appointment'}
+                </h2>
+                <button onClick={() => setEditing(null)} className="text-dark-400 hover:text-white">
+                  <X className="w-5 h-5" />
+                </button>
+              </div>
+
+              {/* Title */}
+              <div>
+                <label className="label">Title *</label>
+                <input
+                  type="text"
+                  value={editing.title}
+                  onChange={e => setEditing({ ...editing, title: e.target.value })}
+                  className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                  placeholder="e.g. Staff Meeting, Holiday Closure"
+                />
+              </div>
+
+              {/* Description */}
+              <div>
+                <label className="label">Description</label>
+                <textarea
+                  value={editing.description || ''}
+                  onChange={e => setEditing({ ...editing, description: e.target.value })}
+                  rows={2}
+                  className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                  placeholder="Optional notes or details"
+                />
+              </div>
+
+              {/* Date */}
+              <div>
+                <label className="label">Date *</label>
+                <input
+                  type="date"
+                  value={editing.date}
+                  onChange={e => setEditing({ ...editing, date: e.target.value })}
+                  className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                />
+              </div>
+
+              {/* All-day toggle */}
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setEditing({ ...editing, allDay: !editing.allDay })}
+                  className="shrink-0"
+                >
+                  {editing.allDay
+                    ? <ToggleRight className="w-6 h-6 text-amber-400" />
+                    : <ToggleLeft className="w-6 h-6 text-dark-500" />
+                  }
+                </button>
+                <span className="text-sm text-dark-300">All-day event</span>
+              </div>
+
+              {/* Time fields (hidden when all-day) */}
+              {!editing.allDay && (
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="label">Start Time *</label>
+                    <input
+                      type="time"
+                      value={editing.startTime || ''}
+                      onChange={e => setEditing({ ...editing, startTime: e.target.value })}
+                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="label">End Time *</label>
+                    <input
+                      type="time"
+                      value={editing.endTime || ''}
+                      onChange={e => setEditing({ ...editing, endTime: e.target.value })}
+                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Location */}
+              <div>
+                <label className="label">Location *</label>
+                <select
+                  value={editing.location}
+                  onChange={e => setEditing({ ...editing, location: e.target.value })}
+                  className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                >
+                  <option value="HUBBLE">Hubble</option>
+                  <option value="METEOR">Meteor</option>
+                </select>
+              </div>
+
+              {/* Recurrence */}
+              <div>
+                <label className="label">Recurrence</label>
+                <select
+                  value={editing.recurrenceType}
+                  onChange={e => setEditing({ ...editing, recurrenceType: e.target.value as RecurrenceType })}
+                  className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                >
+                  {RECURRENCE_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Recurrence end date (shown when recurrence != NONE) */}
+              {editing.recurrenceType !== 'NONE' && (
+                <div>
+                  <label className="label">Recurrence End Date</label>
+                  <input
+                    type="date"
+                    value={editing.recurrenceEndDate || ''}
+                    onChange={e => setEditing({ ...editing, recurrenceEndDate: e.target.value })}
+                    className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                  />
+                  <p className="text-xs text-dark-500 mt-1">Leave empty for indefinite recurrence</p>
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  onClick={() => setEditing(null)}
+                  className="px-4 py-2 text-sm text-dark-400 hover:text-white transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={saving || !editing.title || !editing.date || (!editing.allDay && (!editing.startTime || !editing.endTime))}
+                  className="btn-primary flex items-center gap-2"
+                >
+                  {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {editing.id ? 'Save Changes' : 'Create Appointment'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
+++ b/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import {
   ChevronLeft, ChevronRight, Loader2, AlertCircle,
-  Clock, Users, UtensilsCrossed, MapPin, Calendar, Filter
+  Clock, Users, UtensilsCrossed, MapPin, Calendar, Filter, Sun
 } from 'lucide-react';
-import { fetchReservations, updateCateringArranged } from '../lib/api';
-import type { Reservation } from '../types/reservation';
+import { fetchReservations, updateCateringArranged, fetchCalendarAppointments } from '../lib/api';
+import type { Reservation, CalendarAppointment } from '../types/reservation';
 import { HelpGuide } from '../components/HelpGuide';
 import { weekOverviewGuide } from '../lib/guideContent';
 
@@ -52,9 +52,72 @@ const STATUS_BADGE: Record<string, string> = {
   COMPLETED: 'bg-blue-500/20 text-blue-400',
 };
 
+/** Expand a recurring appointment into occurrence dates within a given week. */
+function expandAppointmentOccurrences(appointment: CalendarAppointment, weekDateStrings: string[]): string[] {
+  if (!appointment.enabled) return [];
+  const startDate = new Date(appointment.date + 'T00:00:00');
+  const weekStart = new Date(weekDateStrings[0] + 'T00:00:00');
+  const weekEnd = new Date(weekDateStrings[6] + 'T00:00:00');
+
+  if (appointment.recurrenceType === 'NONE') {
+    return weekDateStrings.includes(appointment.date) ? [appointment.date] : [];
+  }
+
+  const endDate = appointment.recurrenceEndDate
+    ? new Date(appointment.recurrenceEndDate + 'T00:00:00')
+    : new Date(weekEnd.getTime() + 365 * 86400000); // reasonable horizon
+
+  const dates: string[] = [];
+  const current = new Date(startDate);
+
+  const advanceDate = (d: Date) => {
+    switch (appointment.recurrenceType) {
+      case 'DAILY': d.setDate(d.getDate() + 1); break;
+      case 'WEEKLY': d.setDate(d.getDate() + 7); break;
+      case 'BIWEEKLY': d.setDate(d.getDate() + 14); break;
+      case 'MONTHLY': d.setMonth(d.getMonth() + 1); break;
+      case 'YEARLY': d.setFullYear(d.getFullYear() + 1); break;
+    }
+  };
+
+  // Fast-forward to near the week if far in the past
+  while (current < weekStart) {
+    advanceDate(current);
+  }
+  // Also check one step back in case we overshot
+  const stepBack = new Date(current);
+  switch (appointment.recurrenceType) {
+    case 'DAILY': stepBack.setDate(stepBack.getDate() - 1); break;
+    case 'WEEKLY': stepBack.setDate(stepBack.getDate() - 7); break;
+    case 'BIWEEKLY': stepBack.setDate(stepBack.getDate() - 14); break;
+    case 'MONTHLY': stepBack.setMonth(stepBack.getMonth() - 1); break;
+    case 'YEARLY': stepBack.setFullYear(stepBack.getFullYear() - 1); break;
+  }
+  if (stepBack >= weekStart && stepBack >= startDate) {
+    current.setTime(stepBack.getTime());
+  }
+
+  // Collect occurrences within the week
+  const maxIterations = 400;
+  let iterations = 0;
+  while (current <= weekEnd && current <= endDate && iterations < maxIterations) {
+    if (current >= startDate) {
+      const dateStr = toLocalDateString(current);
+      if (weekDateStrings.includes(dateStr)) {
+        dates.push(dateStr);
+      }
+    }
+    advanceDate(current);
+    iterations++;
+  }
+
+  return dates;
+}
+
 export function WeekOverviewPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [appointments, setAppointments] = useState<CalendarAppointment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [locationFilter, setLocationFilter] = useState('ALL');
@@ -68,9 +131,12 @@ export function WeekOverviewPage() {
   const weekDateStrings = weekDates.map(toLocalDateString);
 
   useEffect(() => {
-    fetchReservations()
-      .then(data => setReservations(data))
-      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load reservations'))
+    Promise.all([fetchReservations(), fetchCalendarAppointments()])
+      .then(([reservationData, appointmentData]) => {
+        setReservations(reservationData);
+        setAppointments(appointmentData);
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load data'))
       .finally(() => setIsLoading(false));
   }, []);
 
@@ -90,6 +156,20 @@ export function WeekOverviewPage() {
     const matchesStatus = statusFilter === 'ALL' || r.status === statusFilter;
     return inWeek && matchesLocation && matchesStatus;
   });
+
+  // Filter appointments for this week (expand recurring ones)
+  const weekAppointments: Record<string, CalendarAppointment[]> = {};
+  for (const dateStr of weekDateStrings) {
+    weekAppointments[dateStr] = [];
+  }
+  for (const appt of appointments) {
+    if (!appt.enabled) continue;
+    if (locationFilter !== 'ALL' && appt.location !== locationFilter) continue;
+    const occurrences = expandAppointmentOccurrences(appt, weekDateStrings);
+    for (const dateStr of occurrences) {
+      weekAppointments[dateStr]?.push(appt);
+    }
+  }
 
   // Group by date
   const byDate: Record<string, Reservation[]> = {};
@@ -250,8 +330,8 @@ export function WeekOverviewPage() {
                   <span className={`text-xs font-medium ${isToday ? 'text-hubble-400' : 'text-dark-500'}`}>
                     {DAY_LABELS[dayIndex]}
                   </span>
-                  {dayReservations.length > 0 && (
-                    <span className="text-xs text-dark-500">{dayReservations.length}</span>
+                  {(dayReservations.length + (weekAppointments[dateStr]?.length ?? 0)) > 0 && (
+                    <span className="text-xs text-dark-500">{dayReservations.length + (weekAppointments[dateStr]?.length ?? 0)}</span>
                   )}
                 </div>
                 <div className={`text-lg font-semibold ${isToday ? 'text-hubble-400' : 'text-white'}`}>
@@ -259,25 +339,30 @@ export function WeekOverviewPage() {
                 </div>
               </div>
 
-              {/* Reservations */}
+              {/* Reservations & Appointments */}
               <div className="flex-1 p-2 space-y-2 overflow-auto">
-                {dayReservations.length === 0 ? (
-                  <div className="text-xs text-dark-600 text-center py-4">No reservations</div>
+                {dayReservations.length === 0 && (weekAppointments[dateStr]?.length ?? 0) === 0 ? (
+                  <div className="text-xs text-dark-600 text-center py-4">No events</div>
                 ) : (
-                  dayReservations.map((reservation) => (
-                    <WeekReservationCard
-                      key={reservation.id}
-                      reservation={reservation}
-                      onCateringToggle={async (id, newValue) => {
-                        try {
-                          const updated = await updateCateringArranged(id, newValue);
-                          setReservations(prev => prev.map(r => r.id === id ? { ...r, cateringArranged: updated.cateringArranged } : r));
-                        } catch (error) {
-                          console.error('Failed to update catering status:', error);
-                        }
-                      }}
-                    />
-                  ))
+                  <>
+                    {dayReservations.map((reservation) => (
+                      <WeekReservationCard
+                        key={reservation.id}
+                        reservation={reservation}
+                        onCateringToggle={async (id, newValue) => {
+                          try {
+                            const updated = await updateCateringArranged(id, newValue);
+                            setReservations(prev => prev.map(r => r.id === id ? { ...r, cateringArranged: updated.cateringArranged } : r));
+                          } catch (error) {
+                            console.error('Failed to update catering status:', error);
+                          }
+                        }}
+                      />
+                    ))}
+                    {weekAppointments[dateStr]?.map((appt) => (
+                      <WeekAppointmentCard key={`appt-${appt.id}-${dateStr}`} appointment={appt} />
+                    ))}
+                  </>
                 )}
               </div>
             </div>
@@ -366,6 +451,55 @@ function WeekReservationCard({
             {reservation.cateringArranged ? 'OK' : '!'}
           </button>
         )}
+      </div>
+    </Link>
+  );
+}
+
+function WeekAppointmentCard({ appointment }: { appointment: CalendarAppointment }) {
+  const isHubble = appointment.location === 'HUBBLE';
+
+  return (
+    <Link
+      to="/calendar-appointments"
+      className="block rounded-lg bg-dark-800/80 hover:bg-dark-800 border-l-2 border-l-indigo-400 p-2 transition-colors"
+    >
+      {/* Appointment badge */}
+      <div className="mb-1">
+        <span className="inline-block text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400">
+          Appointment
+        </span>
+      </div>
+
+      {/* Title */}
+      <div className="mb-1">
+        <span className="text-xs font-medium text-white truncate leading-snug block">{appointment.title}</span>
+      </div>
+
+      {/* Time or All day */}
+      <div className="flex items-center gap-1 text-[11px] text-dark-400 mb-1">
+        {appointment.allDay ? (
+          <>
+            <Sun className="w-3 h-3" />
+            <span>All day</span>
+          </>
+        ) : appointment.startTime && appointment.endTime ? (
+          <>
+            <Clock className="w-3 h-3" />
+            <span>{appointment.startTime.slice(0, 5)}–{appointment.endTime.slice(0, 5)}</span>
+          </>
+        ) : null}
+      </div>
+
+      {/* Location */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${
+          isHubble
+            ? 'bg-hubble-500/20 text-hubble-400'
+            : 'bg-meteor-500/20 text-meteor-400'
+        }`}>
+          {appointment.location}
+        </span>
       </div>
     </Link>
   );

--- a/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
+++ b/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { CalendarAppointmentsPage } from '../pages/CalendarAppointmentsPage';
+
+const { mockFetch, mockCreate, mockUpdate, mockToggle, mockDelete } = vi.hoisted(() => {
+  return {
+    mockFetch: vi.fn(),
+    mockCreate: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockToggle: vi.fn(),
+    mockDelete: vi.fn(),
+  };
+});
+
+vi.mock('../lib/api', () => ({
+  fetchCalendarAppointments: mockFetch,
+  createCalendarAppointment: mockCreate,
+  updateCalendarAppointment: mockUpdate,
+  toggleCalendarAppointment: mockToggle,
+  deleteCalendarAppointment: mockDelete,
+}));
+
+const sampleAppointments = [
+  {
+    id: 1,
+    title: 'Staff Meeting',
+    description: 'Weekly team sync',
+    date: '2026-06-01',
+    allDay: false,
+    startTime: '10:00:00',
+    endTime: '11:00:00',
+    location: 'HUBBLE',
+    recurrenceType: 'WEEKLY',
+    recurrenceEndDate: '2026-12-31',
+    enabled: true,
+  },
+  {
+    id: 2,
+    title: 'Holiday Closure',
+    date: '2026-12-25',
+    allDay: true,
+    location: 'METEOR',
+    recurrenceType: 'NONE',
+    enabled: false,
+  },
+];
+
+const renderPage = () => {
+  return render(
+    <BrowserRouter>
+      <CalendarAppointmentsPage />
+    </BrowserRouter>
+  );
+};
+
+describe('CalendarAppointmentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue(sampleAppointments);
+  });
+
+  it('renders page title', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Calendar Appointments')).toBeInTheDocument();
+    });
+  });
+
+  it('shows appointment titles after loading', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+      expect(screen.getByText('Holiday Closure')).toBeInTheDocument();
+    });
+  });
+
+  it('shows location badges', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('HUBBLE')).toBeInTheDocument();
+      expect(screen.getByText('METEOR')).toBeInTheDocument();
+    });
+  });
+
+  it('shows recurrence badge for recurring appointments', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Weekly')).toBeInTheDocument();
+    });
+  });
+
+  it('shows All day badge for all-day appointments', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('All day')).toBeInTheDocument();
+    });
+  });
+
+  it('shows time range for timeboxed appointments', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('10:00–11:00')).toBeInTheDocument();
+    });
+  });
+
+  it('opens create modal on Add Appointment click', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Appointment'));
+    expect(screen.getByText('New Appointment')).toBeInTheDocument();
+  });
+
+  it('opens edit modal when edit button clicked', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    const editButtons = screen.getAllByTitle('Edit');
+    fireEvent.click(editButtons[0]);
+    expect(screen.getByText('Edit Appointment')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no appointments', async () => {
+    mockFetch.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No appointments yet/)).toBeInTheDocument();
+    });
+  });
+
+  it('hides time fields when all-day is toggled', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Appointment'));
+
+    // By default, time fields should be visible
+    expect(screen.getByText('Start Time *')).toBeInTheDocument();
+    expect(screen.getByText('End Time *')).toBeInTheDocument();
+
+    // Toggle all-day by clicking the toggle button (the parent of the icon, sibling of the text)
+    const allDayText = screen.getByText('All-day event');
+    const toggleButton = allDayText.previousElementSibling as HTMLElement;
+    fireEvent.click(toggleButton);
+
+    // Time fields should be hidden
+    expect(screen.queryByText('Start Time *')).not.toBeInTheDocument();
+    expect(screen.queryByText('End Time *')).not.toBeInTheDocument();
+  });
+
+  it('shows recurrence end date field when recurrence is set', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Appointment'));
+
+    // By default (NONE), no end date field
+    expect(screen.queryByText('Recurrence End Date')).not.toBeInTheDocument();
+
+    // Change recurrence to Weekly
+    const recurrenceSelect = screen.getByDisplayValue('None');
+    fireEvent.change(recurrenceSelect, { target: { value: 'WEEKLY' } });
+
+    expect(screen.getByText('Recurrence End Date')).toBeInTheDocument();
+  });
+
+  it('calls toggle when toggle button clicked', async () => {
+    mockToggle.mockResolvedValue({ ...sampleAppointments[0], enabled: false });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    const toggleButtons = screen.getAllByTitle('Disable');
+    fireEvent.click(toggleButtons[0]);
+    await waitFor(() => {
+      expect(mockToggle).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('calls delete when delete button clicked', async () => {
+    mockDelete.mockResolvedValue(undefined);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    const deleteButtons = screen.getAllByTitle('Delete');
+    fireEvent.click(deleteButtons[0]);
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/the-harry-list-admin/src/test/WeekOverviewPage.test.tsx
+++ b/the-harry-list-admin/src/test/WeekOverviewPage.test.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { WeekOverviewPage } from '../pages/WeekOverviewPage';
 
 // Hoist mock data so vi.mock factory can access it
-const { mockFetchReservations, mockUpdateCateringArranged, testData } = vi.hoisted(() => {
+const { mockFetchReservations, mockUpdateCateringArranged, mockFetchCalendarAppointments, testData } = vi.hoisted(() => {
   // Compute dates inside hoisted scope
   function _getMonday(): Date {
     const d = new Date();
@@ -91,6 +91,7 @@ const { mockFetchReservations, mockUpdateCateringArranged, testData } = vi.hoist
   return {
     mockFetchReservations: vi.fn().mockResolvedValue(reservations),
     mockUpdateCateringArranged: vi.fn().mockResolvedValue({ cateringArranged: true }),
+    mockFetchCalendarAppointments: vi.fn().mockResolvedValue([]),
     testData: { reservations },
   };
 });
@@ -98,6 +99,7 @@ const { mockFetchReservations, mockUpdateCateringArranged, testData } = vi.hoist
 vi.mock('../lib/api', () => ({
   fetchReservations: mockFetchReservations,
   updateCateringArranged: mockUpdateCateringArranged,
+  fetchCalendarAppointments: mockFetchCalendarAppointments,
 }));
 
 const renderPage = () => {

--- a/the-harry-list-admin/src/types/reservation.ts
+++ b/the-harry-list-admin/src/types/reservation.ts
@@ -60,6 +60,24 @@ export interface CateringEmailRequest {
   replyTo?: string;
 }
 
+export type RecurrenceType = 'NONE' | 'DAILY' | 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY' | 'YEARLY';
+
+export interface CalendarAppointment {
+  id?: number;
+  title: string;
+  description?: string;
+  date: string;
+  allDay: boolean;
+  startTime?: string;
+  endTime?: string;
+  location: string;
+  recurrenceType: RecurrenceType;
+  recurrenceEndDate?: string;
+  enabled: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface BlockedPeriod {
   id?: number;
   location?: string;

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.0.5</version>
+	<version>1.1.0</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
@@ -1,0 +1,87 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin/calendar-appointments")
+@Tag(name = "Admin - Calendar Appointments", description = "Manage custom calendar appointments that appear in ICS feeds")
+@SecurityRequirement(name = "basicAuth")
+public class AdminCalendarAppointmentController {
+
+    private final CalendarAppointmentRepository repository;
+
+    public AdminCalendarAppointmentController(CalendarAppointmentRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    @Operation(summary = "List all calendar appointments")
+    public ResponseEntity<List<CalendarAppointment>> listAll() {
+        return ResponseEntity.ok(repository.findAll());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get a calendar appointment by ID")
+    public ResponseEntity<CalendarAppointment> getById(@PathVariable Long id) {
+        return repository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @Operation(summary = "Create a new calendar appointment")
+    public ResponseEntity<CalendarAppointment> create(@RequestBody CalendarAppointment appointment) {
+        CalendarAppointment saved = repository.save(appointment);
+        return ResponseEntity.status(201).body(saved);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update a calendar appointment")
+    public ResponseEntity<CalendarAppointment> update(@PathVariable Long id, @RequestBody CalendarAppointment appointment) {
+        return repository.findById(id)
+                .map(existing -> {
+                    existing.setTitle(appointment.getTitle());
+                    existing.setDescription(appointment.getDescription());
+                    existing.setDate(appointment.getDate());
+                    existing.setAllDay(appointment.getAllDay());
+                    existing.setStartTime(appointment.getStartTime());
+                    existing.setEndTime(appointment.getEndTime());
+                    existing.setLocation(appointment.getLocation());
+                    existing.setRecurrenceType(appointment.getRecurrenceType());
+                    existing.setRecurrenceEndDate(appointment.getRecurrenceEndDate());
+                    existing.setEnabled(appointment.getEnabled());
+                    return ResponseEntity.ok(repository.save(existing));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}/toggle")
+    @Operation(summary = "Toggle a calendar appointment's enabled state")
+    public ResponseEntity<CalendarAppointment> toggle(@PathVariable Long id) {
+        return repository.findById(id)
+                .map(existing -> {
+                    existing.setEnabled(!existing.getEnabled());
+                    return ResponseEntity.ok(repository.save(existing));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a calendar appointment")
+    public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
+        if (!repository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        repository.deleteById(id);
+        return ResponseEntity.ok(Map.of("status", "deleted"));
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/CalendarAppointment.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/CalendarAppointment.java
@@ -1,0 +1,77 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * A custom calendar appointment that appears in ICS calendar feeds.
+ * Simpler than a reservation — used for staff notes, reminders, and recurring events.
+ */
+@Entity
+@Table(name = "calendar_appointments")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CalendarAppointment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "event_date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "all_day", nullable = false)
+    @Builder.Default
+    private Boolean allDay = false;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private BarLocation location;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recurrence_type", length = 20, nullable = false)
+    @Builder.Default
+    private RecurrenceType recurrenceType = RecurrenceType.NONE;
+
+    @Column(name = "recurrence_end_date")
+    private LocalDate recurrenceEndDate;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean enabled = true;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/RecurrenceType.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/RecurrenceType.java
@@ -1,0 +1,13 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+/**
+ * Recurrence pattern for calendar appointments.
+ */
+public enum RecurrenceType {
+    NONE,
+    DAILY,
+    WEEKLY,
+    BIWEEKLY,
+    MONTHLY,
+    YEARLY
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/repository/CalendarAppointmentRepository.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/repository/CalendarAppointmentRepository.java
@@ -1,0 +1,10 @@
+package com.pimvanleeuwen.the_harry_list_backend.repository;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CalendarAppointmentRepository extends JpaRepository<CalendarAppointment, Long> {
+    List<CalendarAppointment> findByEnabledTrue();
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
@@ -1,8 +1,11 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.model.SpecialActivity;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import org.springframework.stereotype.Service;
 
@@ -22,11 +25,15 @@ public class ICalendarService {
 
     private static final String TIMEZONE = "Europe/Amsterdam";
     private static final DateTimeFormatter ICS_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+    private static final DateTimeFormatter ICS_DATE_ONLY_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final ReservationRepository reservationRepository;
+    private final CalendarAppointmentRepository calendarAppointmentRepository;
 
-    public ICalendarService(ReservationRepository reservationRepository) {
+    public ICalendarService(ReservationRepository reservationRepository,
+                            CalendarAppointmentRepository calendarAppointmentRepository) {
         this.reservationRepository = reservationRepository;
+        this.calendarAppointmentRepository = calendarAppointmentRepository;
     }
 
     public String generateCalendarFeed(List<ReservationStatus> includeStatuses, String location, boolean includeConfidentialDetails) {
@@ -44,7 +51,9 @@ public class ICalendarService {
                     .toList();
         }
 
-        return buildIcsCalendar(reservations, includeConfidentialDetails);
+        List<CalendarAppointment> appointments = getFilteredAppointments(location);
+
+        return buildIcsCalendar(reservations, appointments, includeConfidentialDetails);
     }
 
     public String generateUpcomingCalendarFeed(List<ReservationStatus> includeStatuses, String location, boolean includeConfidentialDetails) {
@@ -65,10 +74,34 @@ public class ICalendarService {
                     .toList();
         }
 
-        return buildIcsCalendar(reservations, includeConfidentialDetails);
+        List<CalendarAppointment> appointments = getFilteredAppointments(location).stream()
+                .filter(a -> {
+                    if (a.getRecurrenceType() != RecurrenceType.NONE) {
+                        // Recurring: include if no end date or end date is in the future
+                        return a.getRecurrenceEndDate() == null || !a.getRecurrenceEndDate().isBefore(today);
+                    }
+                    // Non-recurring: include if date is today or in the future
+                    return !a.getDate().isBefore(today);
+                })
+                .toList();
+
+        return buildIcsCalendar(reservations, appointments, includeConfidentialDetails);
     }
 
-    private String buildIcsCalendar(List<Reservation> reservations, boolean includeConfidentialDetails) {
+    private List<CalendarAppointment> getFilteredAppointments(String location) {
+        List<CalendarAppointment> appointments = calendarAppointmentRepository.findByEnabledTrue();
+
+        if (location != null && !location.isEmpty()) {
+            appointments = appointments.stream()
+                    .filter(a -> a.getLocation() != null && a.getLocation().name().equalsIgnoreCase(location))
+                    .toList();
+        }
+
+        return appointments;
+    }
+
+    private String buildIcsCalendar(List<Reservation> reservations, List<CalendarAppointment> appointments,
+                                    boolean includeConfidentialDetails) {
         StringBuilder ics = new StringBuilder();
 
         String calendarName = includeConfidentialDetails
@@ -88,6 +121,10 @@ public class ICalendarService {
 
         for (Reservation reservation : reservations) {
             ics.append(buildEvent(reservation, includeConfidentialDetails));
+        }
+
+        for (CalendarAppointment appointment : appointments) {
+            ics.append(buildAppointmentEvent(appointment));
         }
 
         ics.append("END:VCALENDAR\r\n");
@@ -314,6 +351,94 @@ public class ICalendarService {
         sb.append("\n(Contact details available in admin portal)");
 
         return sb.toString();
+    }
+
+    private String buildAppointmentEvent(CalendarAppointment appointment) {
+        StringBuilder event = new StringBuilder();
+
+        event.append("BEGIN:VEVENT\r\n");
+
+        String uid = "appointment-" + appointment.getId() + "@harrylist.hubble.cafe";
+        event.append("UID:").append(uid).append("\r\n");
+
+        LocalDateTime now = LocalDateTime.now();
+        event.append("DTSTAMP:").append(now.format(ICS_DATE_FORMAT)).append("\r\n");
+
+        if (appointment.getCreatedAt() != null) {
+            event.append("CREATED:").append(appointment.getCreatedAt().format(ICS_DATE_FORMAT)).append("\r\n");
+        }
+        if (appointment.getUpdatedAt() != null) {
+            event.append("LAST-MODIFIED:").append(appointment.getUpdatedAt().format(ICS_DATE_FORMAT)).append("\r\n");
+        }
+
+        if (Boolean.TRUE.equals(appointment.getAllDay())) {
+            // All-day event: DATE only (no time), DTEND is next day per ICS spec
+            event.append("DTSTART;VALUE=DATE:").append(appointment.getDate().format(ICS_DATE_ONLY_FORMAT)).append("\r\n");
+            event.append("DTEND;VALUE=DATE:").append(appointment.getDate().plusDays(1).format(ICS_DATE_ONLY_FORMAT)).append("\r\n");
+        } else {
+            // Timeboxed event
+            if (appointment.getStartTime() != null) {
+                LocalDateTime startDateTime = LocalDateTime.of(appointment.getDate(), appointment.getStartTime());
+                event.append("DTSTART;TZID=").append(TIMEZONE).append(":").append(startDateTime.format(ICS_DATE_FORMAT)).append("\r\n");
+
+                if (appointment.getEndTime() != null) {
+                    LocalDateTime endDateTime = LocalDateTime.of(appointment.getDate(), appointment.getEndTime());
+                    if (appointment.getEndTime().isBefore(appointment.getStartTime())) {
+                        endDateTime = endDateTime.plusDays(1);
+                    }
+                    event.append("DTEND;TZID=").append(TIMEZONE).append(":").append(endDateTime.format(ICS_DATE_FORMAT)).append("\r\n");
+                }
+            }
+        }
+
+        event.append("SUMMARY:").append(escapeIcsText(appointment.getTitle())).append("\r\n");
+
+        if (appointment.getLocation() != null) {
+            event.append("LOCATION:").append(escapeIcsText(appointment.getLocation().getDisplayName())).append("\r\n");
+        }
+
+        if (appointment.getDescription() != null && !appointment.getDescription().isEmpty()) {
+            event.append("DESCRIPTION:").append(escapeIcsText(appointment.getDescription())).append("\r\n");
+        }
+
+        event.append("STATUS:CONFIRMED\r\n");
+
+        if (appointment.getLocation() != null) {
+            event.append("CATEGORIES:").append(appointment.getLocation().getDisplayName()).append(",Appointment\r\n");
+        }
+
+        String rrule = buildRecurrenceRule(appointment);
+        if (!rrule.isEmpty()) {
+            event.append(rrule);
+        }
+
+        event.append("END:VEVENT\r\n");
+
+        return event.toString();
+    }
+
+    private String buildRecurrenceRule(CalendarAppointment appointment) {
+        if (appointment.getRecurrenceType() == null || appointment.getRecurrenceType() == RecurrenceType.NONE) {
+            return "";
+        }
+
+        StringBuilder rrule = new StringBuilder("RRULE:FREQ=");
+        switch (appointment.getRecurrenceType()) {
+            case DAILY -> rrule.append("DAILY");
+            case WEEKLY -> rrule.append("WEEKLY");
+            case BIWEEKLY -> rrule.append("WEEKLY;INTERVAL=2");
+            case MONTHLY -> rrule.append("MONTHLY");
+            case YEARLY -> rrule.append("YEARLY");
+            default -> { return ""; }
+        }
+
+        if (appointment.getRecurrenceEndDate() != null) {
+            rrule.append(";UNTIL=").append(
+                    appointment.getRecurrenceEndDate().atTime(23, 59, 59).format(ICS_DATE_FORMAT));
+        }
+
+        rrule.append("\r\n");
+        return rrule.toString();
     }
 
     private String escapeIcsText(String text) {

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
@@ -1,0 +1,181 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminCalendarAppointmentController.class)
+@Import(SecurityConfig.class)
+class AdminCalendarAppointmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CalendarAppointmentRepository repository;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    private CalendarAppointment sampleAppointment() {
+        return CalendarAppointment.builder()
+                .id(1L)
+                .title("Staff Meeting")
+                .description("Weekly team sync")
+                .date(LocalDate.of(2026, 6, 1))
+                .allDay(false)
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(11, 0))
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.WEEKLY)
+                .recurrenceEndDate(LocalDate.of(2026, 12, 31))
+                .enabled(true)
+                .build();
+    }
+
+    private CalendarAppointment sampleAllDayAppointment() {
+        return CalendarAppointment.builder()
+                .id(2L)
+                .title("Holiday Closure")
+                .date(LocalDate.of(2026, 12, 25))
+                .allDay(true)
+                .location(BarLocation.METEOR)
+                .recurrenceType(RecurrenceType.NONE)
+                .enabled(true)
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    void listAll_shouldReturnAllAppointments() throws Exception {
+        when(repository.findAll()).thenReturn(List.of(sampleAppointment(), sampleAllDayAppointment()));
+
+        mockMvc.perform(get("/api/admin/calendar-appointments"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].title").value("Staff Meeting"))
+                .andExpect(jsonPath("$[1].title").value("Holiday Closure"));
+    }
+
+    @Test
+    void listAll_shouldRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/admin/calendar-appointments"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void getById_shouldReturnAppointment() throws Exception {
+        when(repository.findById(1L)).thenReturn(Optional.of(sampleAppointment()));
+
+        mockMvc.perform(get("/api/admin/calendar-appointments/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Staff Meeting"))
+                .andExpect(jsonPath("$.location").value("HUBBLE"))
+                .andExpect(jsonPath("$.recurrenceType").value("WEEKLY"));
+    }
+
+    @Test
+    @WithMockUser
+    void getById_shouldReturn404ForMissing() throws Exception {
+        when(repository.findById(99L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/admin/calendar-appointments/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    void create_shouldReturn201() throws Exception {
+        CalendarAppointment appointment = sampleAppointment();
+        when(repository.save(any())).thenReturn(appointment);
+
+        mockMvc.perform(post("/api/admin/calendar-appointments")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(appointment)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("Staff Meeting"));
+    }
+
+    @Test
+    @WithMockUser
+    void create_allDay_shouldReturn201() throws Exception {
+        CalendarAppointment appointment = sampleAllDayAppointment();
+        when(repository.save(any())).thenReturn(appointment);
+
+        mockMvc.perform(post("/api/admin/calendar-appointments")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(appointment)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.allDay").value(true))
+                .andExpect(jsonPath("$.startTime").isEmpty());
+    }
+
+    @Test
+    @WithMockUser
+    void toggle_shouldFlipEnabledState() throws Exception {
+        CalendarAppointment appointment = sampleAppointment();
+        appointment.setEnabled(true);
+
+        CalendarAppointment toggled = sampleAppointment();
+        toggled.setEnabled(false);
+
+        when(repository.findById(1L)).thenReturn(Optional.of(appointment));
+        when(repository.save(any())).thenReturn(toggled);
+
+        mockMvc.perform(patch("/api/admin/calendar-appointments/1/toggle").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(false));
+    }
+
+    @Test
+    @WithMockUser
+    void delete_shouldReturn200() throws Exception {
+        when(repository.existsById(1L)).thenReturn(true);
+        doNothing().when(repository).deleteById(1L);
+
+        mockMvc.perform(delete("/api/admin/calendar-appointments/1").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("deleted"));
+    }
+
+    @Test
+    @WithMockUser
+    void delete_shouldReturn404ForMissing() throws Exception {
+        when(repository.existsById(99L)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/admin/calendar-appointments/99").with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
@@ -1,6 +1,7 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
 import com.pimvanleeuwen.the_harry_list_backend.model.*;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,9 @@ class ICalendarServiceTest {
     @Mock
     private ReservationRepository reservationRepository;
 
+    @Mock
+    private CalendarAppointmentRepository calendarAppointmentRepository;
+
     @InjectMocks
     private ICalendarService iCalendarService;
 
@@ -35,6 +39,8 @@ class ICalendarServiceTest {
     @BeforeEach
     void setUp() {
         sampleReservation = createSampleReservation();
+        // Default: no appointments (existing tests should not be affected)
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(Collections.emptyList());
     }
 
     @Test
@@ -161,6 +167,209 @@ class ICalendarServiceTest {
         // Then
         assertTrue(ics.contains("Future Event"));
         assertFalse(ics.contains("Past Event"));
+    }
+
+    // ===== Calendar Appointment Tests =====
+
+    @Test
+    void generateCalendarFeed_shouldIncludeAppointments() {
+        CalendarAppointment appointment = createSampleAppointment();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("BEGIN:VEVENT"));
+        assertTrue(ics.contains("UID:appointment-1@harrylist.hubble.cafe"));
+        assertTrue(ics.contains("SUMMARY:Staff Meeting"));
+        assertTrue(ics.contains("LOCATION:Hubble Community Caf"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldRenderAllDayAppointments() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(2L)
+                .title("Holiday Closure")
+                .date(LocalDate.of(2026, 12, 25))
+                .allDay(true)
+                .location(BarLocation.METEOR)
+                .recurrenceType(RecurrenceType.NONE)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("DTSTART;VALUE=DATE:20261225"));
+        assertTrue(ics.contains("DTEND;VALUE=DATE:20261226"));
+        assertFalse(ics.contains("DTSTART;TZID="));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldRenderTimeboxedAppointments() {
+        CalendarAppointment appointment = createSampleAppointment();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("DTSTART;TZID=Europe/Amsterdam:20260601T100000"));
+        assertTrue(ics.contains("DTEND;TZID=Europe/Amsterdam:20260601T110000"));
+        assertFalse(ics.contains("DTSTART;VALUE=DATE:"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldFilterAppointmentsByLocation() {
+        CalendarAppointment hubbleAppt = createSampleAppointment();
+        CalendarAppointment meteorAppt = CalendarAppointment.builder()
+                .id(2L)
+                .title("Meteor Event")
+                .date(LocalDate.of(2026, 6, 1))
+                .allDay(false)
+                .startTime(LocalTime.of(14, 0))
+                .endTime(LocalTime.of(15, 0))
+                .location(BarLocation.METEOR)
+                .recurrenceType(RecurrenceType.NONE)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(hubbleAppt, meteorAppt));
+
+        String ics = iCalendarService.generateCalendarFeed(null, "HUBBLE", false);
+
+        assertTrue(ics.contains("Staff Meeting"));
+        assertFalse(ics.contains("Meteor Event"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeRruleForRecurring() {
+        CalendarAppointment appointment = createSampleAppointment(); // WEEKLY with end date
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=WEEKLY;UNTIL=20261231T235959"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeRruleForYearly() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(3L)
+                .title("Annual Review")
+                .date(LocalDate.of(2026, 1, 15))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.YEARLY)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=YEARLY"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeRruleForBiweekly() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(4L)
+                .title("Biweekly Sync")
+                .date(LocalDate.of(2026, 6, 1))
+                .allDay(false)
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(10, 0))
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.BIWEEKLY)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=WEEKLY;INTERVAL=2"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldExcludeDisabledAppointments() {
+        // findByEnabledTrue() already filters, so an empty result means disabled ones are excluded
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(Collections.emptyList());
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertFalse(ics.contains("appointment-"));
+    }
+
+    @Test
+    void generateUpcomingCalendarFeed_shouldExcludePastAppointments() {
+        CalendarAppointment pastAppt = CalendarAppointment.builder()
+                .id(5L)
+                .title("Past Event")
+                .date(LocalDate.now().minusDays(7))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.NONE)
+                .enabled(true)
+                .build();
+        CalendarAppointment futureAppt = CalendarAppointment.builder()
+                .id(6L)
+                .title("Future Event")
+                .date(LocalDate.now().plusDays(7))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.NONE)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(pastAppt, futureAppt));
+
+        String ics = iCalendarService.generateUpcomingCalendarFeed(null, null, false);
+
+        assertFalse(ics.contains("Past Event"));
+        assertTrue(ics.contains("Future Event"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeAppointmentDescription() {
+        CalendarAppointment appointment = createSampleAppointment();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("DESCRIPTION:Weekly team sync"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeAppointmentCategories() {
+        CalendarAppointment appointment = createSampleAppointment();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("CATEGORIES:Hubble Community Caf"));
+        assertTrue(ics.contains(",Appointment"));
+    }
+
+    private CalendarAppointment createSampleAppointment() {
+        return CalendarAppointment.builder()
+                .id(1L)
+                .title("Staff Meeting")
+                .description("Weekly team sync")
+                .date(LocalDate.of(2026, 6, 1))
+                .allDay(false)
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(11, 0))
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.WEEKLY)
+                .recurrenceEndDate(LocalDate.of(2026, 12, 31))
+                .enabled(true)
+                .build();
     }
 
     private Reservation createSampleReservation() {

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.53.1",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary           

  - **Custom Calendar Appointments** new feature to add lightweight calendar entries (staff notes, reminders, recurring events) that appear in the ICS subscriber feeds alongside reservations, without needing to create a full reservation                                                           
  - **Fixed sidebar layout** sidebar stays fixed while only the content area scrolls; version number shown at bottom
  - **Compacted nav** nav items are more compact to avoid scrolling on smaller screens

  ## New: Calendar Appointments

  ### Backend
  - New `CalendarAppointment` JPA entity with support for all-day and timeboxed events                                            
  - `RecurrenceType` enum: None, Daily, Weekly, Bi-weekly, Monthly, Yearly                                                 
  - Full CRUD admin API at `/api/admin/calendar-appointments` (secured under existing `/api/admin/**` auth)                                                                      
  - Upcoming-only feed correctly filters past non-recurring appointments and expired recurring ones                         
   
  ### Frontend (Admin)                                            
  - New **Appointments** page with list + modal create/edit, all-day toggle, recurrence controls
  - **Week Overview** now shows appointments as distinct indigo-bordered cards with "Appointment" badge, with full recurrence expansion for the displayed week
  - New nav item with CalendarPlus icon
                                                                  
  ### Tests
  - **Backend:** 20 new tests (8 controller + 12 ICalendarService), total 217 passing                          
  - **Frontend:** 13 new CalendarAppointmentsPage tests + WeekOverview mock update, total 71 passing                      
   
  ## Deployment Notes                                             
                                                                
  - Requires `spring.jpa.hibernate.ddl-auto=update` for the first deploy to create the `calendar_appointments` table. Switch back to `validate` after.
  - No changes to existing database tables or data.
  - No new environment variables required.
                                                                  
  ## Test plan
                                                                  
  - [x] Verify `calendar_appointments` table is created on deploy
  - [x] Create an all-day appointment and a timeboxed appointment via admin panel
  - [x] Verify both appear in the ICS feed (`/api/calendar/feed.ics` and `/api/calendar/staff-feed.ics`)   
  - [x] Create a recurring weekly appointment and verify it shows on multiple weeks in Week Overview                              
  - [x] Verify location filter works in both Week Overview and ICS feeds               
  - [x] Toggle an appointment to disabled and confirm it disappears from the feed                                        
  - [x] Verify sidebar stays fixed when scrolling long page content                                                         
  - [x] Verify version number displays at bottom of sidebar     
