### PR TITLE
Revise issue templates and enhance security policy documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]: Placeholder title"
+labels: bug
+assignees: ''
+type: Bug
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Browser:**
+ - Device: [e.g. iPhone6, Windows, Macos]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,20 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]: Placeholder title"
+title: "[BUG]: "
 labels: bug
 assignees: ''
 type: Bug
 
 ---
+
+**Component**
+Which part of the system is affected?
+- [ ] Backend (API / Spring Boot)
+- [ ] Admin portal
+- [ ] Public reservation form
+- [ ] Calendar feeds / ICS
+- [ ] Other: <!-- describe -->
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -14,9 +22,8 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+2. Click on '...'
+3. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -24,10 +31,10 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Browser:**
- - Device: [e.g. iPhone6, Windows, Macos]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Environment**
+ - Device: [e.g. MacBook, iPhone, Windows PC]
+ - Browser: [e.g. Chrome, Safari, Firefox]
+ - Version: [e.g. 1.0.3]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:pim@hubble.cafe
+    about: Please report security vulnerabilities privately via email, not as a public issue.
+  - name: General question
+    url: https://github.com/Hubble-Community-Cafe/the-harry-list/discussions
+    about: Ask questions and discuss ideas in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,12 +1,20 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Feature]: Placeholder Title"
+title: "[Feature]: "
 labels: enhancement
 assignees: ''
 type: Feature
 
 ---
+
+**Component**
+Which part of the system does this relate to?
+- [ ] Backend (API / Spring Boot)
+- [ ] Admin portal
+- [ ] Public reservation form
+- [ ] Calendar feeds / ICS
+- [ ] Other: <!-- describe -->
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]: Placeholder Title"
+labels: enhancement
+assignees: ''
+type: Feature
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+pim@hubble.cafe.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to The Harry List
+
+Thanks for your interest in contributing to The Harry List! This is the reservation system for [Stichting Bar Potential](https://hubble.cafe)'s community cafes — Hubble and Meteor.
+
+## Getting Started
+
+1. **Fork** the repository and clone your fork
+2. Set up local development (see [README.md](README.md#local-development))
+3. Create a feature branch from `main`:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+## Project Structure
+
+This is a monorepo with three components:
+
+| Directory | What | Stack |
+|-----------|------|-------|
+| `the-harry-list-backend` | REST API | Spring Boot, Java, MariaDB |
+| `the-harry-list-admin` | Admin portal | React, TypeScript, Vite |
+| `the-harry-list-public` | Public reservation form | React, TypeScript, Vite |
+
+## Development Workflow
+
+### Before You Code
+
+- Check the [existing issues](../../issues) to see if someone is already working on it
+- For larger changes, open an issue first to discuss the approach
+- For bug fixes, a PR is usually fine without prior discussion
+
+### Writing Code
+
+- **Tests are required** — all new features and bug fixes should include tests
+  - Backend: JUnit 5 + Mockito (`src/test/`)
+  - Frontends: Vitest + React Testing Library (`src/test/`)
+- **Run tests before pushing**:
+  ```bash
+  # Backend
+  cd the-harry-list-backend && ./mvnw test
+
+  # Admin frontend
+  cd the-harry-list-admin && npm test
+
+  # Public frontend
+  cd the-harry-list-public && npm test
+  ```
+- **Run the linter** on frontend changes:
+  ```bash
+  npm run lint
+  ```
+- Don't commit secrets, `.env` files, or credentials
+
+### Commit Messages
+
+Use clear, descriptive commit messages. We loosely follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add calendar appointment recurrence support
+fix: correct reply-to header on catering emails
+build(deps): bump spring-boot from 3.4 to 3.5
+docs: update calendar feed setup instructions
+```
+
+### Pull Requests
+
+- Open PRs against `main`
+- Fill in the PR template — describe what changed and why
+- Make sure CI passes (tests + build)
+- All PRs require review from @PimVanLeeuwen before merging
+- Keep PRs focused — one feature or fix per PR
+
+## Reporting Bugs
+
+Use the [bug report template](../../issues/new?template=bug_report.md). Include:
+- Which component is affected (backend, admin, public form)
+- Steps to reproduce
+- Expected vs. actual behavior
+- Browser/device info for frontend issues
+
+## Requesting Features
+
+Use the [feature request template](../../issues/new?template=feature_request.md). Describe the problem you're trying to solve, not just the solution you have in mind.
+
+## Security Vulnerabilities
+
+**Do not open a public issue for security vulnerabilities.** See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it. Report unacceptable behavior to pim@hubble.cafe.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,39 @@
 # Security Policy
 
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | No |
+
+We only address security issues in the latest release. Please update before reporting.
+
 ## Reporting a Vulnerability
 
-If you want to report a vulnerability you can do so by reaching out to pim@hubble.cafe or by creating an issue. 
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report vulnerabilities privately by emailing **pim@hubble.cafe**. Include:
+
+- A description of the vulnerability
+- Steps to reproduce or a proof of concept
+- The affected component (backend, admin portal, public form)
+- Any potential impact you've identified
+
+### What to Expect
+
+- **Acknowledgement** within 3 business days
+- **Status update** within 10 business days
+- We will work with you to understand and resolve the issue before any public disclosure
+
+### Scope
+
+This policy covers the application code in this repository. For infrastructure or hosting issues related to Hubble or Meteor cafes, please contact pim@hubble.cafe directly.
+
+## Security Best Practices for Contributors
+
+- Never commit secrets, API keys, or credentials
+- Never commit `.env` files
+- Validate all user input at system boundaries
+- Use parameterized queries (JPA handles this by default)
+- Follow the principle of least privilege for API endpoints

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you want to report a vulnerability you can do so by reaching out to pim@hubble.cafe or by creating an issue. 

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.53.1",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Adds community guidelines and improves existing GitHub templates
   to make the project more contributor-friendly.

  ### Created
  - **CONTRIBUTING.md** Development workflow, project structure, commit conventions, PR process

  ### Improved
  - **SECURITY.md** Replaced 3-line stub with proper responsible disclosure policy (response times, scope, contributor best practices). Removed guidance to create public issues for vulnerabilities.
  - **Bug report template** Added component checklist (backend/admin/public/calendar), cleaned up environment section
  - **Feature request template** Added component checklist

  ### New
  - **`.github/ISSUE_TEMPLATE/config.yml`** Disables blank issues, adds contact links for security reports (email) and general questions (Discussions)

  ## Type of change
  - [x] Documentation
  - [x] Other: GitHub community health files

  ## Checklist
  - [x] No secrets or credentials are committed
  - [x] README / docs updated (if needed)
