### PR TITLE
feat: Role-Based Access Control (RBAC) - v1.2.0

### DIFF
--- a/docs/migration-rbac.md
+++ b/docs/migration-rbac.md
@@ -1,0 +1,75 @@
+# RBAC Migration Guide
+
+## Overview
+
+This migration introduces Role-Based Access Control (RBAC) to the admin panel. Three roles are supported:
+
+| Role | Access |
+|------|--------|
+| **ADMIN** | Full access including user management, email templates, and form settings |
+| **EDITOR** | Can manage reservations, blocked periods, appointments, and attachments |
+| **VIEWER** | Read-only access to all pages, can export data |
+
+## Prerequisites
+
+- MariaDB access to the production database
+- The Azure Object IDs (OIDs) for existing admin users
+
+## Step 1: Run SQL Migration
+
+Execute the following SQL on the production MariaDB database **before** deploying the new backend. The production backend uses `ddl-auto=validate`, so the table must exist before the application starts.
+
+```sql
+-- Create the admin_user table
+CREATE TABLE admin_user (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  azure_oid VARCHAR(255) NOT NULL UNIQUE,
+  email VARCHAR(255) NOT NULL,
+  display_name VARCHAR(255),
+  role VARCHAR(20) NOT NULL DEFAULT 'VIEWER',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Pre-seed existing users so they experience no disruption
+INSERT INTO admin_user (azure_oid, email, display_name, role) VALUES
+  ('test_oid', 'test-mail', 'test-name', 'ADMIN')
+```
+
+## Step 2: Set Environment Variable
+
+Set the `INITIAL_ADMIN_OID` environment variable on the backend service. This ensures that if the seeded data is ever lost, the first user to log in with this OID gets ADMIN role automatically.
+
+```
+INITIAL_ADMIN_OID=
+```
+
+## Step 3: Deploy
+
+Deploy the new backend and admin frontend. The deployment order doesn't matter since:
+- The SQL migration creates the table before the backend validates it
+- The frontend gracefully handles the `/api/admin/users/me` endpoint (loading state while fetching role)
+
+## Step 4: Verify
+
+1. **ADMIN** logs in → sees Users page in nav, full admin access
+2. **EDITOR** logs in → can manage reservations, blocked periods, appointments, attachments; cannot see Users, Email Templates (edit), or Form Settings (edit)
+3. Test a viewer by logging in a new user role to VIEWER via the Users page → this should see all pages but all edit/create/delete buttons are hidden, and direct API calls to mutating endpoints return 403
+
+## Step 5: Cleanup (Optional)
+
+The `INITIAL_ADMIN_OID` env var can be removed after deployment. It only applies when a user with that OID logs in for the very first time and no record exists yet.
+
+## Rollback
+
+To roll back RBAC:
+
+1. Deploy the previous backend version
+2. The `admin_user` table can remain (it won't be used by the old backend)
+3. To fully clean up: `DROP TABLE admin_user;`
+
+## Notes
+
+- The existing Azure AD group check (`ALLOWED_GROUP_ID`) still works as the first gate — RBAC is a second layer on top
+- New users who log in after deployment are auto-created with VIEWER role
+- Roles are hierarchical: ADMIN inherits all EDITOR permissions, EDITOR inherits all VIEWER permissions

--- a/the-harry-list-admin/Dockerfile
+++ b/the-harry-list-admin/Dockerfile
@@ -9,8 +9,9 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (--include=optional ensures platform-specific native binaries
+# like rolldown are installed for the container's architecture, not the host's)
+RUN npm ci --include=optional
 
 # Copy source files
 COPY . .

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/App.tsx
+++ b/the-harry-list-admin/src/App.tsx
@@ -7,10 +7,9 @@ import { ReservationDetailPage } from './pages/ReservationDetailPage';
 import { CalendarPage } from './pages/CalendarPage';
 import { ExportPage } from './pages/ExportPage';
 import { EmailTemplatesPage } from './pages/EmailTemplatesPage';
-import { FormSettingsPage } from './pages/FormSettingsPage';
+import { SettingsPage } from './pages/FormSettingsPage';
 import { CalendarAppointmentsPage } from './pages/CalendarAppointmentsPage';
 import { WeekOverviewPage } from './pages/WeekOverviewPage';
-import { UsersPage } from './pages/UsersPage';
 import { Layout } from './components/Layout';
 import { useGroupAuthorization } from './lib/useGroupAuthorization';
 import { ThemeProvider } from './lib/ThemeContext';
@@ -92,9 +91,9 @@ function App() {
           <Route path="export" element={<ExportPage />} />
           <Route path="calendar" element={<CalendarPage />} />
           <Route path="email-templates" element={<EmailTemplatesPage />} />
-          <Route path="form-settings" element={<FormSettingsPage />} />
+          <Route path="settings" element={<SettingsPage />} />
+          <Route path="form-settings" element={<SettingsPage />} />
           <Route path="calendar-appointments" element={<CalendarAppointmentsPage />} />
-          <Route path="users" element={<UsersPage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/the-harry-list-admin/src/App.tsx
+++ b/the-harry-list-admin/src/App.tsx
@@ -10,6 +10,7 @@ import { EmailTemplatesPage } from './pages/EmailTemplatesPage';
 import { FormSettingsPage } from './pages/FormSettingsPage';
 import { CalendarAppointmentsPage } from './pages/CalendarAppointmentsPage';
 import { WeekOverviewPage } from './pages/WeekOverviewPage';
+import { UsersPage } from './pages/UsersPage';
 import { Layout } from './components/Layout';
 import { useGroupAuthorization } from './lib/useGroupAuthorization';
 import { ThemeProvider } from './lib/ThemeContext';
@@ -93,6 +94,7 @@ function App() {
           <Route path="email-templates" element={<EmailTemplatesPage />} />
           <Route path="form-settings" element={<FormSettingsPage />} />
           <Route path="calendar-appointments" element={<CalendarAppointmentsPage />} />
+          <Route path="users" element={<UsersPage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/the-harry-list-admin/src/App.tsx
+++ b/the-harry-list-admin/src/App.tsx
@@ -13,6 +13,7 @@ import { WeekOverviewPage } from './pages/WeekOverviewPage';
 import { Layout } from './components/Layout';
 import { useGroupAuthorization } from './lib/useGroupAuthorization';
 import { ThemeProvider } from './lib/ThemeContext';
+import { RoleProvider } from './lib/RoleContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Loader2, ShieldX } from 'lucide-react';
 
@@ -72,6 +73,7 @@ function App() {
   return (
     <ErrorBoundary>
     <ThemeProvider>
+    <RoleProvider>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route
@@ -94,6 +96,7 @@ function App() {
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+    </RoleProvider>
     </ThemeProvider>
     </ErrorBoundary>
   );

--- a/the-harry-list-admin/src/components/ConfirmDialog.tsx
+++ b/the-harry-list-admin/src/components/ConfirmDialog.tsx
@@ -1,0 +1,64 @@
+import { AlertTriangle, Loader2, X } from 'lucide-react';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+      <div className="bg-dark-900 border border-dark-700 rounded-xl w-full max-w-sm">
+        <div className="p-6 space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="p-2 rounded-lg bg-red-500/10 shrink-0">
+              <AlertTriangle className="w-5 h-5 text-red-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-white font-semibold">{title}</h3>
+              <p className="text-sm text-dark-400 mt-1">{message}</p>
+            </div>
+            <button onClick={onCancel} className="text-dark-400 hover:text-white shrink-0" disabled={loading}>
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              onClick={onCancel}
+              disabled={loading}
+              className="px-4 py-2 text-sm text-dark-400 hover:text-white transition-colors"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              onClick={onConfirm}
+              disabled={loading}
+              className="px-4 py-2 text-sm bg-red-500/20 text-red-400 hover:bg-red-500/30 border border-red-500/30 rounded-lg transition-colors flex items-center gap-2"
+            >
+              {loading && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+              {confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { useMsal } from '@azure/msal-react';
 import {
   LayoutDashboard, Calendar, CalendarDays, LogOut,
-  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings, Users
+  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings
 } from 'lucide-react';
 import { useState } from 'react';
 import { clearAuth} from '../lib/api';
@@ -15,7 +15,7 @@ export function Layout() {
   const { instance, accounts } = useMsal();
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { canEditEmailTemplates, canEditFormSettings, canManageUsers } = usePermissions();
+  const { canEditEmailTemplates, canEditFormSettings } = usePermissions();
   const { role } = useRole();
 
   const user = accounts[0];
@@ -38,8 +38,7 @@ export function Layout() {
     { to: '/calendar', icon: CalendarSync, label: 'Calendar Feeds' },
     { to: '/calendar-appointments', icon: CalendarPlus, label: 'Appointments' },
     ...(canEditEmailTemplates ? [{ to: '/email-templates', icon: Mail, label: 'Email Templates' }] : []),
-    ...(canEditFormSettings ? [{ to: '/form-settings', icon: Settings, label: 'Form Settings' }] : []),
-    ...(canManageUsers ? [{ to: '/users', icon: Users, label: 'Users' }] : []),
+    ...(canEditFormSettings ? [{ to: '/settings', icon: Settings, label: 'Settings' }] : []),
   ];
 
   return (

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -2,10 +2,12 @@ import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { useMsal } from '@azure/msal-react';
 import {
   LayoutDashboard, Calendar, CalendarDays, LogOut,
-  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings
+  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings, Users
 } from 'lucide-react';
 import { useState } from 'react';
 import { clearAuth} from '../lib/api';
+import { usePermissions } from '../lib/usePermissions';
+import { useRole } from '../lib/RoleContext';
 import { ThemeToggle } from './ThemeToggle';
 import { version } from '../../package.json';
 
@@ -13,6 +15,8 @@ export function Layout() {
   const { instance, accounts } = useMsal();
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { canEditEmailTemplates, canEditFormSettings, canManageUsers } = usePermissions();
+  const { role } = useRole();
 
   const user = accounts[0];
 
@@ -33,8 +37,9 @@ export function Layout() {
     { to: '/export', icon: FileDown, label: 'Export' },
     { to: '/calendar', icon: CalendarSync, label: 'Calendar Feeds' },
     { to: '/calendar-appointments', icon: CalendarPlus, label: 'Appointments' },
-    { to: '/email-templates', icon: Mail, label: 'Email Templates' },
-    { to: '/form-settings', icon: Settings, label: 'Form Settings' },
+    ...(canEditEmailTemplates ? [{ to: '/email-templates', icon: Mail, label: 'Email Templates' }] : []),
+    ...(canEditFormSettings ? [{ to: '/form-settings', icon: Settings, label: 'Form Settings' }] : []),
+    ...(canManageUsers ? [{ to: '/users', icon: Users, label: 'Users' }] : []),
   ];
 
   return (
@@ -107,8 +112,15 @@ export function Layout() {
                 <div className="text-sm font-medium text-white truncate">
                   {user?.name || 'Staff'}
                 </div>
-                <div className="text-xs text-dark-400 truncate">
+                <div className="text-xs text-dark-400 truncate flex items-center gap-1.5">
                   {user?.username || 'Logged in'}
+                  {role && (
+                    <span className={`text-[9px] font-semibold px-1 py-0.5 rounded ${
+                      role === 'ADMIN' ? 'bg-red-500/20 text-red-400' :
+                      role === 'EDITOR' ? 'bg-hubble-500/20 text-hubble-400' :
+                      'bg-dark-700 text-dark-400'
+                    }`}>{role}</span>
+                  )}
                 </div>
               </div>
             </div>

--- a/the-harry-list-admin/src/lib/RoleContext.tsx
+++ b/the-harry-list-admin/src/lib/RoleContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { useIsAuthenticated } from '@azure/msal-react';
 import { fetchCurrentUser, type AdminUser } from './api';
 
@@ -20,13 +20,18 @@ const RoleContext = createContext<RoleContextValue>({
   refetch: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
+export function useRole() {
+  return useContext(RoleContext);
+}
+
 export function RoleProvider({ children }: { children: ReactNode }) {
   const isAuthenticated = useIsAuthenticated();
   const [user, setUser] = useState<AdminUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchRole = async () => {
+  const fetchRole = useCallback(async () => {
     if (!isAuthenticated) {
       setUser(null);
       setIsLoading(false);
@@ -44,15 +49,41 @@ export function RoleProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [isAuthenticated]);
 
   useEffect(() => {
-    fetchRole();
+    let cancelled = false;
+
+    const load = async () => {
+      if (!isAuthenticated) {
+        if (!cancelled) {
+          setUser(null);
+          setIsLoading(false);
+        }
+        return;
+      }
+      try {
+        if (!cancelled) setIsLoading(true);
+        if (!cancelled) setError(null);
+        const currentUser = await fetchCurrentUser();
+        if (!cancelled) setUser(currentUser);
+      } catch (e) {
+        console.error('Failed to fetch current user role:', e);
+        if (!cancelled) setError('Failed to load user role');
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
 
     // Re-fetch when MSAL account changes (login/redirect)
-    const handleAccountChanged = () => fetchRole();
+    const handleAccountChanged = () => load();
     window.addEventListener('msal:accountChanged', handleAccountChanged);
-    return () => window.removeEventListener('msal:accountChanged', handleAccountChanged);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('msal:accountChanged', handleAccountChanged);
+    };
   }, [isAuthenticated]);
 
   return (
@@ -66,8 +97,4 @@ export function RoleProvider({ children }: { children: ReactNode }) {
       {children}
     </RoleContext.Provider>
   );
-}
-
-export function useRole() {
-  return useContext(RoleContext);
 }

--- a/the-harry-list-admin/src/lib/RoleContext.tsx
+++ b/the-harry-list-admin/src/lib/RoleContext.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useIsAuthenticated } from '@azure/msal-react';
+import { fetchCurrentUser, type AdminUser } from './api';
+
+type AdminRole = 'VIEWER' | 'EDITOR' | 'ADMIN';
+
+interface RoleContextValue {
+  user: AdminUser | null;
+  role: AdminRole | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+const RoleContext = createContext<RoleContextValue>({
+  user: null,
+  role: null,
+  isLoading: true,
+  error: null,
+  refetch: () => {},
+});
+
+export function RoleProvider({ children }: { children: ReactNode }) {
+  const isAuthenticated = useIsAuthenticated();
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRole = async () => {
+    if (!isAuthenticated) {
+      setUser(null);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const currentUser = await fetchCurrentUser();
+      setUser(currentUser);
+    } catch (e) {
+      console.error('Failed to fetch current user role:', e);
+      setError('Failed to load user role');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRole();
+
+    // Re-fetch when MSAL account changes (login/redirect)
+    const handleAccountChanged = () => fetchRole();
+    window.addEventListener('msal:accountChanged', handleAccountChanged);
+    return () => window.removeEventListener('msal:accountChanged', handleAccountChanged);
+  }, [isAuthenticated]);
+
+  return (
+    <RoleContext.Provider value={{
+      user,
+      role: user?.role as AdminRole | null,
+      isLoading,
+      error,
+      refetch: fetchRole,
+    }}>
+      {children}
+    </RoleContext.Provider>
+  );
+}
+
+export function useRole() {
+  return useContext(RoleContext);
+}

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { PublicClientApplication } from '@azure/msal-browser';
+import * as Sentry from '@sentry/react';
 // Note: Window.__RUNTIME_CONFIG__ type is declared in authConfig.ts
 
 // Get API URL from runtime config or fall back to build-time env
@@ -100,7 +101,9 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}): Pro
   }
 
   if (response.status === 403) {
-    throw new ForbiddenError('You do not have permission to perform this action');
+    const err = new ForbiddenError('You do not have permission to perform this action');
+    Sentry.captureException(err, { level: 'warning', extra: { url, method: options?.method || 'GET' } });
+    throw err;
   }
 
   return response;

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -16,6 +16,13 @@ const getApiUrl = (): string => {
 
 const API_BASE_URL = getApiUrl();
 
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
 // MSAL instance for getting tokens
 let msalInstance: PublicClientApplication | null = null;
 
@@ -90,6 +97,10 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}): Pro
   if (response.status === 401) {
     clearAuth();
     throw new Error('Authentication failed');
+  }
+
+  if (response.status === 403) {
+    throw new ForbiddenError('You do not have permission to perform this action');
   }
 
   return response;
@@ -326,6 +337,32 @@ export interface RetentionSettings {
 
 export async function fetchRetentionSettings(): Promise<RetentionSettings> {
   return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/settings/retention`) as Promise<RetentionSettings>;
+}
+
+// ===== Admin Users =====
+export interface AdminUser {
+  id: number;
+  azureOid: string;
+  email: string;
+  displayName: string;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchCurrentUser(): Promise<AdminUser> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/users/me`) as Promise<AdminUser>;
+}
+
+export async function fetchAllUsers(): Promise<AdminUser[]> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/users`) as Promise<AdminUser[]>;
+}
+
+export async function updateUserRole(userId: number, role: string): Promise<AdminUser> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/users/${userId}/role`, {
+    method: 'PUT',
+    body: JSON.stringify({ role }),
+  }) as Promise<AdminUser>;
 }
 
 // Test if authentication is working

--- a/the-harry-list-admin/src/lib/usePermissions.ts
+++ b/the-harry-list-admin/src/lib/usePermissions.ts
@@ -1,0 +1,21 @@
+import { useRole } from './RoleContext';
+
+export function usePermissions() {
+  const { role } = useRole();
+
+  const isEditor = role === 'EDITOR' || role === 'ADMIN';
+  const isAdmin = role === 'ADMIN';
+
+  return {
+    // Editor-level permissions
+    canUpdateReservations: isEditor,
+    canManageBlockedPeriods: isEditor,
+    canManageAppointments: isEditor,
+    canManageAttachments: isEditor,
+
+    // Admin-level permissions
+    canEditEmailTemplates: isAdmin,
+    canEditFormSettings: isAdmin,
+    canManageUsers: isAdmin,
+  };
+}

--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '../lib/api';
 import type { CalendarAppointment, RecurrenceType } from '../types/reservation';
 import { usePermissions } from '../lib/usePermissions';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 
 const RECURRENCE_OPTIONS: { value: RecurrenceType; label: string }[] = [
   { value: 'NONE', label: 'None' },
@@ -46,6 +47,8 @@ export function CalendarAppointmentsPage() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<CalendarAppointment | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const { canManageAppointments } = usePermissions();
 
   useEffect(() => {
@@ -94,12 +97,17 @@ export function CalendarAppointmentsPage() {
     }
   };
 
-  const handleDelete = async (id: number) => {
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
     try {
-      await deleteCalendarAppointment(id);
-      setAppointments(prev => prev.filter(a => a.id !== id));
+      await deleteCalendarAppointment(deleteTarget);
+      setAppointments(prev => prev.filter(a => a.id !== deleteTarget));
+      setDeleteTarget(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete appointment');
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -217,7 +225,7 @@ export function CalendarAppointmentsPage() {
                   }
                 </button>
                 <button
-                  onClick={() => appointment.id && handleDelete(appointment.id)}
+                  onClick={() => appointment.id && setDeleteTarget(appointment.id)}
                   className="p-1.5 rounded-lg text-dark-400 hover:text-red-400 hover:bg-red-500/10"
                   title="Delete"
                 >
@@ -380,6 +388,17 @@ export function CalendarAppointmentsPage() {
           </div>
         </div>
       )}
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete appointment"
+        message="This appointment will be permanently deleted. This action cannot be undone."
+        confirmLabel="Delete"
+        loading={deleting}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -8,6 +8,7 @@ import {
   toggleCalendarAppointment, deleteCalendarAppointment,
 } from '../lib/api';
 import type { CalendarAppointment, RecurrenceType } from '../types/reservation';
+import { usePermissions } from '../lib/usePermissions';
 
 const RECURRENCE_OPTIONS: { value: RecurrenceType; label: string }[] = [
   { value: 'NONE', label: 'None' },
@@ -45,6 +46,7 @@ export function CalendarAppointmentsPage() {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<CalendarAppointment | null>(null);
   const [saving, setSaving] = useState(false);
+  const { canManageAppointments } = usePermissions();
 
   useEffect(() => {
     fetchCalendarAppointments()
@@ -117,6 +119,7 @@ export function CalendarAppointmentsPage() {
           <h1 className="text-2xl font-title font-bold text-white">Calendar Appointments</h1>
           <p className="text-dark-400 font-light">Custom calendar entries that appear in the ICS feeds alongside reservations</p>
         </div>
+        {canManageAppointments && (
         <button
           onClick={() => setEditing({ ...emptyAppointment })}
           className="btn-primary flex items-center gap-2 shrink-0"
@@ -124,6 +127,7 @@ export function CalendarAppointmentsPage() {
           <Plus className="w-4 h-4" />
           Add Appointment
         </button>
+        )}
       </div>
 
       {/* Error */}
@@ -193,6 +197,7 @@ export function CalendarAppointmentsPage() {
                   <p className="text-sm text-dark-400 truncate">{appointment.description}</p>
                 )}
               </div>
+              {canManageAppointments && (
               <div className="flex items-center gap-2 shrink-0">
                 <button
                   onClick={() => setEditing({ ...appointment })}
@@ -219,6 +224,7 @@ export function CalendarAppointmentsPage() {
                   <Trash2 className="w-4 h-4" />
                 </button>
               </div>
+              )}
             </div>
           ))}
         </div>

--- a/the-harry-list-admin/src/pages/CalendarPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Calendar, Copy, Check, ExternalLink, RefreshCw, Loader2, AlertCircle, Lock, Unlock } from 'lucide-react';
+import { Calendar, Copy, Check, ExternalLink, RefreshCw, Loader2, AlertCircle, Lock, Unlock, EyeOff, Eye, ShieldAlert } from 'lucide-react';
 import { fetchWithAuth } from '../lib/api';
 import { HelpGuide } from '../components/HelpGuide';
 import { calendarGuide } from '../lib/guideContent';
@@ -31,6 +31,7 @@ export function CalendarPage() {
   const [parameters, setParameters] = useState<ParameterInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [revealedFeeds, setRevealedFeeds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     async function loadFeeds() {
@@ -136,37 +137,59 @@ export function CalendarPage() {
         {/* Content */}
         <div className="p-4">
           {feed.hasToken && feed.url ? (
-            <div className="space-y-3">
-              {/* URL Display */}
-              <input
-                type="text"
-                readOnly
-                value={feed.url}
-                className="w-full px-3 py-2 bg-dark-800 border border-dark-700 rounded-lg text-xs text-dark-400 truncate"
-              />
+            revealedFeeds.has(feed.id) ? (
+              <div className="space-y-3">
+                {/* URL Display */}
+                <input
+                  type="text"
+                  readOnly
+                  value={feed.url}
+                  className="w-full px-3 py-2 bg-dark-800 border border-dark-700 rounded-lg text-xs text-dark-400 truncate"
+                />
 
-              {/* Quick Actions */}
-              <div className="flex gap-2">
-                <a
-                  href={feed.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-2.5 py-1.5 bg-dark-800 hover:bg-dark-700 text-dark-300 hover:text-white rounded-lg text-xs transition-colors"
-                >
-                  <ExternalLink className="w-3.5 h-3.5" />
-                  Preview
-                </a>
-                <a
-                  href={`https://calendar.google.com/calendar/r?cid=${encodeURIComponent(feed.url.replace('https://', 'webcal://').replace('http://', 'webcal://'))}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-2.5 py-1.5 bg-dark-800 hover:bg-dark-700 text-dark-300 hover:text-white rounded-lg text-xs transition-colors"
-                >
-                  <Calendar className="w-3.5 h-3.5" />
-                  Add to Google
-                </a>
+                {/* Quick Actions */}
+                <div className="flex gap-2">
+                  <a
+                    href={feed.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 bg-dark-800 hover:bg-dark-700 text-dark-300 hover:text-white rounded-lg text-xs transition-colors"
+                  >
+                    <ExternalLink className="w-3.5 h-3.5" />
+                    Preview
+                  </a>
+                  <a
+                    href={`https://calendar.google.com/calendar/r?cid=${encodeURIComponent(feed.url.replace('https://', 'webcal://').replace('http://', 'webcal://'))}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 bg-dark-800 hover:bg-dark-700 text-dark-300 hover:text-white rounded-lg text-xs transition-colors"
+                  >
+                    <Calendar className="w-3.5 h-3.5" />
+                    Add to Google
+                  </a>
+                  <button
+                    onClick={() => setRevealedFeeds(prev => { const next = new Set(prev); next.delete(feed.id); return next; })}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 bg-dark-800 hover:bg-dark-700 text-dark-300 hover:text-white rounded-lg text-xs transition-colors ml-auto"
+                  >
+                    <EyeOff className="w-3.5 h-3.5" />
+                    Hide
+                  </button>
+                </div>
               </div>
-            </div>
+            ) : (
+              <button
+                onClick={() => setRevealedFeeds(prev => new Set(prev).add(feed.id))}
+                className="w-full py-4 rounded-lg border border-dashed border-dark-700 hover:border-amber-500/40 bg-dark-800/50 hover:bg-amber-500/5 transition-all group"
+              >
+                <div className="flex flex-col items-center gap-2">
+                  <ShieldAlert className="w-5 h-5 text-amber-400/70 group-hover:text-amber-400 transition-colors" />
+                  <span className="text-xs text-dark-400 group-hover:text-dark-300 transition-colors">
+                    This URL contains a secret token — click to reveal
+                  </span>
+                  <Eye className="w-3.5 h-3.5 text-dark-500 group-hover:text-dark-400 transition-colors" />
+                </div>
+              </button>
+            )
           ) : (
             <div className="text-center py-2">
               <p className="text-xs text-dark-500">Token not configured</p>

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import {
   Plus, Trash2, Loader2, AlertCircle,
-  ToggleLeft, ToggleRight, Calendar, Shield, Pencil, X, Database, Clock
+  ToggleLeft, ToggleRight, Calendar, Shield, Pencil, X, Database, Clock, Users
 } from 'lucide-react';
 import {
   fetchFormConstraints, createFormConstraint, updateFormConstraint,
@@ -15,6 +15,8 @@ import type { RetentionSettings } from '../lib/api';
 import { HelpGuide } from '../components/HelpGuide';
 import { formSettingsGuide } from '../lib/guideContent';
 import { ConfirmDialog } from '../components/ConfirmDialog';
+import { usePermissions } from '../lib/usePermissions';
+import { UsersTab } from './UsersPage';
 
 const CONSTRAINT_TYPES = [
   { value: 'ACTIVITY_CONFLICT', label: 'Activity Conflict' },
@@ -53,8 +55,12 @@ const emptyBlockedPeriod: BlockedPeriod = {
   enabled: true,
 };
 
-export function FormSettingsPage() {
-  const [activeTab, setActiveTab] = useState<'constraints' | 'blocked'>('constraints');
+/** @deprecated Use SettingsPage instead */
+export const FormSettingsPage = SettingsPage;
+
+export function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<'constraints' | 'blocked' | 'retention' | 'users'>('constraints');
+  const { canEditFormSettings, canManageUsers } = usePermissions();
   const [constraints, setConstraints] = useState<FormConstraint[]>([]);
   const [blockedPeriods, setBlockedPeriods] = useState<BlockedPeriod[]>([]);
   const [loading, setLoading] = useState(true);
@@ -189,10 +195,10 @@ export function FormSettingsPage() {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-title font-bold text-white">Form Settings</h1>
-          <p className="text-dark-400 font-light">Manage form constraints and blocked periods</p>
+          <h1 className="text-2xl font-title font-bold text-white">Settings</h1>
+          <p className="text-dark-400 font-light">Manage constraints, blocked periods, and admin settings</p>
         </div>
-        <HelpGuide title="Form Settings Guide" sections={formSettingsGuide} />
+        <HelpGuide title="Settings Guide" sections={formSettingsGuide} />
       </div>
 
       {error && (
@@ -205,31 +211,48 @@ export function FormSettingsPage() {
         </div>
       )}
 
-      {/* Tab Switcher */}
-      <div className="flex gap-2 border-b border-dark-800 pb-0">
-        <button
-          onClick={() => setActiveTab('constraints')}
-          className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors flex items-center gap-2 ${
-            activeTab === 'constraints'
-              ? 'bg-dark-800 text-hubble-400 border-b-2 border-hubble-500'
-              : 'text-dark-400 hover:text-white'
-          }`}
-        >
-          <Shield className="w-4 h-4" />
-          Form Constraints ({constraints.length})
-        </button>
-        <button
-          onClick={() => setActiveTab('blocked')}
-          className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors flex items-center gap-2 ${
-            activeTab === 'blocked'
-              ? 'bg-dark-800 text-hubble-400 border-b-2 border-hubble-500'
-              : 'text-dark-400 hover:text-white'
-          }`}
-        >
-          <Calendar className="w-4 h-4" />
-          Blocked Periods ({blockedPeriods.length})
-        </button>
-      </div>
+      {/* Tab Switcher — dropdown on mobile, horizontal tabs on md+ */}
+      {(() => {
+        const tabs = [
+          { key: 'constraints' as const, icon: Shield, label: `Form Constraints (${constraints.length})` },
+          { key: 'blocked' as const, icon: Calendar, label: `Blocked Periods (${blockedPeriods.length})` },
+          ...(canEditFormSettings ? [{ key: 'retention' as const, icon: Database, label: 'Data Retention' }] : []),
+          ...(canManageUsers ? [{ key: 'users' as const, icon: Users, label: 'Users' }] : []),
+        ];
+        return (
+          <>
+            {/* Mobile: select dropdown */}
+            <div className="md:hidden">
+              <select
+                value={activeTab}
+                onChange={e => setActiveTab(e.target.value as typeof activeTab)}
+                className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2.5 text-white text-sm appearance-none"
+              >
+                {tabs.map(t => (
+                  <option key={t.key} value={t.key}>{t.label}</option>
+                ))}
+              </select>
+            </div>
+            {/* Desktop: horizontal tabs */}
+            <div className="hidden md:flex gap-2 border-b border-dark-800 pb-0">
+              {tabs.map(t => (
+                <button
+                  key={t.key}
+                  onClick={() => setActiveTab(t.key)}
+                  className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors flex items-center gap-2 ${
+                    activeTab === t.key
+                      ? 'bg-dark-800 text-hubble-400 border-b-2 border-hubble-500'
+                      : 'text-dark-400 hover:text-white'
+                  }`}
+                >
+                  <t.icon className="w-4 h-4" />
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </>
+        );
+      })()}
 
       {/* ===== Constraints Tab ===== */}
       {activeTab === 'constraints' && (
@@ -629,37 +652,33 @@ export function FormSettingsPage() {
         </div>
       )}
 
-      {/* Data Retention */}
-      {retention && (
-        <div className="card">
-          <h2 className="text-lg font-title font-semibold text-white mb-1 flex items-center gap-2">
-            <Database className="w-5 h-5 text-hubble-400" />
-            Data Retention
-          </h2>
-          <p className="text-xs text-dark-500 mb-4">
-            Read-only — configure via <code className="bg-dark-800 text-hubble-400 px-1 rounded font-mono">DATA_RETENTION_DAYS</code> in your Docker Compose settings
+      {/* ===== Data Retention Tab (Admin only) ===== */}
+      {activeTab === 'retention' && retention && (
+        <div className="space-y-4">
+          <p className="text-sm text-dark-400">
+            Read-only overview of the automatic data retention policy. Configure via <code className="bg-dark-800 text-hubble-400 px-1 rounded font-mono text-xs">DATA_RETENTION_DAYS</code> in your Docker Compose settings.
           </p>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-            <div className="bg-dark-800 rounded-xl p-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="bg-dark-900 border border-dark-800 rounded-xl p-4">
               <div className="text-xs text-dark-500 mb-1">Status</div>
               <div className={`text-sm font-semibold ${retention.enabled ? 'text-green-400' : 'text-dark-400'}`}>
                 {retention.enabled ? 'Enabled' : 'Disabled'}
               </div>
             </div>
-            <div className="bg-dark-800 rounded-xl p-4">
+            <div className="bg-dark-900 border border-dark-800 rounded-xl p-4">
               <div className="text-xs text-dark-500 mb-1">Retention Period</div>
               <div className="text-sm font-semibold text-white">
                 {retention.enabled ? `${retention.retentionDays} days` : '—'}
               </div>
             </div>
-            <div className="bg-dark-800 rounded-xl p-4">
+            <div className="bg-dark-900 border border-dark-800 rounded-xl p-4">
               <div className="text-xs text-dark-500 mb-1">Cutoff Date</div>
               <div className="text-sm font-semibold text-white">
                 {retention.cutoffDate ?? '—'}
               </div>
             </div>
-            <div className="bg-dark-800 rounded-xl p-4">
+            <div className="bg-dark-900 border border-dark-800 rounded-xl p-4">
               <div className="text-xs text-dark-500 mb-1">Eligible for Removal</div>
               <div className={`text-sm font-semibold ${retention.eligibleForDeletion > 0 ? 'text-amber-400' : 'text-white'}`}>
                 {retention.eligibleForDeletion} reservations
@@ -673,6 +692,9 @@ export function FormSettingsPage() {
           </div>
         </div>
       )}
+
+      {/* ===== Users Tab (Admin only) ===== */}
+      {activeTab === 'users' && <UsersTab />}
 
       {/* Delete Confirmation */}
       <ConfirmDialog

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -14,6 +14,7 @@ import type { FormConstraint, BlockedPeriod } from '../types/reservation';
 import type { RetentionSettings } from '../lib/api';
 import { HelpGuide } from '../components/HelpGuide';
 import { formSettingsGuide } from '../lib/guideContent';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 
 const CONSTRAINT_TYPES = [
   { value: 'ACTIVITY_CONFLICT', label: 'Activity Conflict' },
@@ -69,6 +70,10 @@ export function FormSettingsPage() {
   const [editingPeriod, setEditingPeriod] = useState<BlockedPeriod | null>(null);
   const [savingPeriod, setSavingPeriod] = useState(false);
 
+  // Delete confirmation state
+  const [deleteTarget, setDeleteTarget] = useState<{ type: 'constraint' | 'period'; id: number } | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
   useEffect(() => {
     Promise.all([fetchFormConstraints(), fetchBlockedPeriods(), fetchRetentionSettings()])
       .then(([c, bp, ret]) => {
@@ -90,13 +95,22 @@ export function FormSettingsPage() {
     }
   }
 
-  async function handleDeleteConstraint(id: number) {
-    if (!confirm('Delete this constraint?')) return;
+  async function handleConfirmDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
     try {
-      await deleteFormConstraint(id);
-      setConstraints(prev => prev.filter(c => c.id !== id));
+      if (deleteTarget.type === 'constraint') {
+        await deleteFormConstraint(deleteTarget.id);
+        setConstraints(prev => prev.filter(c => c.id !== deleteTarget.id));
+      } else {
+        await deleteBlockedPeriod(deleteTarget.id);
+        setBlockedPeriods(prev => prev.filter(bp => bp.id !== deleteTarget.id));
+      }
+      setDeleteTarget(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete constraint');
+      setError(err instanceof Error ? err.message : `Failed to delete ${deleteTarget.type === 'constraint' ? 'constraint' : 'blocked period'}`);
+    } finally {
+      setDeleting(false);
     }
   }
 
@@ -141,15 +155,7 @@ export function FormSettingsPage() {
     }
   }
 
-  async function handleDeletePeriod(id: number) {
-    if (!confirm('Delete this blocked period?')) return;
-    try {
-      await deleteBlockedPeriod(id);
-      setBlockedPeriods(prev => prev.filter(bp => bp.id !== id));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete blocked period');
-    }
-  }
+  // handleDeletePeriod and handleDeleteConstraint now use the shared handleConfirmDelete via ConfirmDialog
 
   async function handleSavePeriod() {
     if (!editingPeriod) return;
@@ -283,7 +289,7 @@ export function FormSettingsPage() {
                       }
                     </button>
                     <button
-                      onClick={() => c.id && handleDeleteConstraint(c.id)}
+                      onClick={() => c.id && setDeleteTarget({ type: 'constraint', id: c.id })}
                       className="p-1.5 rounded-lg text-dark-400 hover:text-red-400 hover:bg-red-500/10 transition-colors"
                       title="Delete"
                     >
@@ -363,7 +369,7 @@ export function FormSettingsPage() {
                       }
                     </button>
                     <button
-                      onClick={() => bp.id && handleDeletePeriod(bp.id)}
+                      onClick={() => bp.id && setDeleteTarget({ type: 'period', id: bp.id })}
                       className="p-1.5 rounded-lg text-dark-400 hover:text-red-400 hover:bg-red-500/10 transition-colors"
                       title="Delete"
                     >
@@ -667,6 +673,17 @@ export function FormSettingsPage() {
           </div>
         </div>
       )}
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={deleteTarget?.type === 'constraint' ? 'Delete constraint' : 'Delete blocked period'}
+        message="This will be permanently deleted. This action cannot be undone."
+        confirmLabel="Delete"
+        loading={deleting}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   updateCateringArranged, fetchEmailAttachments, fetchCateringEmailPreview, sendCateringEmail
 } from '../lib/api';
 import type { Reservation, EmailAttachment } from '../types/reservation';
+import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { reservationDetailGuide } from '../lib/guideContent';
 
@@ -47,6 +48,7 @@ export function ReservationDetailPage() {
   const [sendingCateringEmail, setSendingCateringEmail] = useState(false);
   const [cateringEmailStatus, setCateringEmailStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
+  const { canUpdateReservations } = usePermissions();
   const userName = accounts[0]?.name || 'Staff';
 
   useEffect(() => {
@@ -230,6 +232,7 @@ export function ReservationDetailPage() {
       </div>
 
       {/* Actions */}
+      {canUpdateReservations && (
       <div className="card">
         <h2 className="text-lg font-title font-semibold text-white mb-4">Actions</h2>
 
@@ -451,6 +454,7 @@ export function ReservationDetailPage() {
           </div>
         )}
       </div>
+      )}
 
       {/* Details Grid */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -540,6 +544,7 @@ export function ReservationDetailPage() {
             {reservation.specialActivities?.some(a => ['EAT_A_LA_CARTE', 'EAT_CATERING', 'CATERING_CORONA_ROOM'].includes(a)) && (
               <div className="flex items-center justify-between">
                 <span className="text-sm text-dark-400">Catering Arranged</span>
+                {canUpdateReservations ? (
                 <button
                   type="button"
                   onClick={async () => {
@@ -558,6 +563,16 @@ export function ReservationDetailPage() {
                   <UtensilsCrossed className="w-3 h-3" />
                   {reservation.cateringArranged ? 'Arranged ✓ (click to undo)' : 'Not arranged yet (click to mark done)'}
                 </button>
+                ) : (
+                <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium ${
+                    reservation.cateringArranged
+                      ? 'bg-green-500/20 text-green-400 border border-green-500/30'
+                      : 'bg-orange-500/20 text-orange-400 border border-orange-500/30'
+                  }`}>
+                  <UtensilsCrossed className="w-3 h-3" />
+                  {reservation.cateringArranged ? 'Arranged ✓' : 'Not arranged yet'}
+                </span>
+                )}
               </div>
             )}
           </div>

--- a/the-harry-list-admin/src/pages/ReservationsPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationsPage.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react';
 import { fetchReservations, updateCateringArranged } from '../lib/api';
 import type { Reservation } from '../types/reservation';
+import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { reservationsGuide } from '../lib/guideContent';
 
@@ -27,6 +28,7 @@ export function ReservationsPage() {
   const [statusFilter, setStatusFilter] = useState(searchParams.get('status') || 'ALL');
   const [locationFilter, setLocationFilter] = useState('ALL');
   const [showPast, setShowPast] = useState(false);
+  const { canUpdateReservations } = usePermissions();
 
   const todayStr = toLocalDateString(new Date());
 
@@ -206,6 +208,7 @@ export function ReservationsPage() {
                             <div className="flex items-center gap-2 flex-wrap mb-0.5">
                               <h3 className="font-medium text-white truncate">{reservation.eventTitle}</h3>
                               {hasCatering(reservation.specialActivities) && (
+                                canUpdateReservations ? (
                                 <button
                                   type="button"
                                   onClick={async (e) => {
@@ -229,6 +232,16 @@ export function ReservationsPage() {
                                   <UtensilsCrossed className="w-3 h-3" />
                                   {reservation.cateringArranged ? 'Catering arranged' : 'Catering'}
                                 </button>
+                                ) : (
+                                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${
+                                    reservation.cateringArranged
+                                      ? 'bg-green-500/20 text-green-400 border border-green-500/30'
+                                      : 'bg-orange-500/20 text-orange-400 border border-orange-500/30'
+                                  }`}>
+                                  <UtensilsCrossed className="w-3 h-3" />
+                                  {reservation.cateringArranged ? 'Catering arranged' : 'Catering'}
+                                </span>
+                                )
                               )}
                             </div>
                             <p className="text-sm text-dark-400 truncate">

--- a/the-harry-list-admin/src/pages/UsersPage.tsx
+++ b/the-harry-list-admin/src/pages/UsersPage.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from 'react';
+import { Loader2, AlertCircle, X, Users, Shield } from 'lucide-react';
+import { fetchAllUsers, updateUserRole, type AdminUser } from '../lib/api';
+import { useRole } from '../lib/RoleContext';
+
+const ROLE_OPTIONS = ['VIEWER', 'EDITOR', 'ADMIN'] as const;
+
+const ROLE_STYLES: Record<string, string> = {
+  ADMIN: 'bg-red-500/20 text-red-400',
+  EDITOR: 'bg-hubble-500/20 text-hubble-400',
+  VIEWER: 'bg-dark-700 text-dark-300',
+};
+
+const ROLE_DESCRIPTIONS: Record<string, string> = {
+  ADMIN: 'Full access including user management, email templates, and form settings',
+  EDITOR: 'Can manage reservations, blocked periods, appointments, and attachments',
+  VIEWER: 'Read-only access to all pages, can export data',
+};
+
+export function UsersPage() {
+  const { user: currentUser, refetch: refetchRole } = useRole();
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetchAllUsers()
+      .then(setUsers)
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load users'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleRoleChange = async (userId: number, newRole: string) => {
+    setSaving(userId);
+    setError(null);
+    try {
+      const updated = await updateUserRole(userId, newRole);
+      setUsers(prev => prev.map(u => u.id === userId ? updated : u));
+      refetchRole();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update role');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="w-8 h-8 text-hubble-400 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-title font-bold text-white">User Management</h1>
+        <p className="text-dark-400 font-light">Manage admin panel access and roles</p>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
+          <span className="text-red-400 text-sm">{error}</span>
+          <button onClick={() => setError(null)} className="ml-auto">
+            <X className="w-4 h-4 text-red-400" />
+          </button>
+        </div>
+      )}
+
+      {/* Role Legend */}
+      <div className="bg-dark-900 border border-dark-800 rounded-xl p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Shield className="w-4 h-4 text-dark-400" />
+          <span className="text-sm font-medium text-dark-300">Role Permissions</span>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {ROLE_OPTIONS.map(role => (
+            <div key={role} className="flex items-start gap-2">
+              <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded mt-0.5 ${ROLE_STYLES[role]}`}>
+                {role}
+              </span>
+              <span className="text-xs text-dark-500">{ROLE_DESCRIPTIONS[role]}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Users List */}
+      {users.length === 0 ? (
+        <div className="card text-center py-12">
+          <Users className="w-12 h-12 text-dark-600 mx-auto mb-3" />
+          <p className="text-dark-400">No users yet. Users are created automatically on first login.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {users.map(user => {
+            const isSelf = currentUser?.id === user.id;
+            return (
+              <div
+                key={user.id}
+                className="bg-dark-900 border border-dark-800 rounded-xl p-4 flex items-center gap-4"
+              >
+                {/* Avatar */}
+                <div className="w-10 h-10 rounded-full bg-hubble-500/20 flex items-center justify-center shrink-0">
+                  <span className="text-hubble-400 font-semibold text-sm">
+                    {(user.displayName || user.email).charAt(0).toUpperCase()}
+                  </span>
+                </div>
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-white font-medium">{user.displayName || 'Unknown'}</span>
+                    {isSelf && (
+                      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-dark-700 text-dark-400">
+                        You
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-dark-500 truncate">{user.email}</div>
+                </div>
+
+                {/* Role selector */}
+                <div className="flex items-center gap-2 shrink-0">
+                  {isSelf ? (
+                    <span className={`text-xs font-semibold px-2 py-1 rounded ${ROLE_STYLES[user.role]}`}>
+                      {user.role}
+                    </span>
+                  ) : (
+                    <div className="relative">
+                      <select
+                        value={user.role}
+                        onChange={e => handleRoleChange(user.id, e.target.value)}
+                        disabled={saving === user.id}
+                        className="bg-dark-800 border border-dark-700 rounded-lg px-3 py-1.5 text-white text-sm appearance-none pr-8 cursor-pointer disabled:opacity-50"
+                      >
+                        {ROLE_OPTIONS.map(role => (
+                          <option key={role} value={role}>{role}</option>
+                        ))}
+                      </select>
+                      {saving === user.id && (
+                        <Loader2 className="w-4 h-4 text-hubble-400 animate-spin absolute right-2 top-1/2 -translate-y-1/2" />
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/the-harry-list-admin/src/pages/UsersPage.tsx
+++ b/the-harry-list-admin/src/pages/UsersPage.tsx
@@ -17,7 +17,11 @@ const ROLE_DESCRIPTIONS: Record<string, string> = {
   VIEWER: 'Read-only access to all pages, can export data',
 };
 
-export function UsersPage() {
+/**
+ * Users tab content — used inside the Settings page.
+ * Does not render its own page header.
+ */
+export function UsersTab() {
   const { user: currentUser, refetch: refetchRole } = useRole();
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -54,13 +58,7 @@ export function UsersPage() {
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-title font-bold text-white">User Management</h1>
-        <p className="text-dark-400 font-light">Manage admin panel access and roles</p>
-      </div>
-
+    <div className="space-y-4">
       {/* Error */}
       {error && (
         <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-3">
@@ -154,6 +152,21 @@ export function UsersPage() {
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Standalone Users page — kept for backwards compatibility with /users route.
+ */
+export function UsersPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-title font-bold text-white">User Management</h1>
+        <p className="text-dark-400 font-light">Manage admin panel access and roles</p>
+      </div>
+      <UsersTab />
     </div>
   );
 }

--- a/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
+++ b/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import { fetchReservations, updateCateringArranged, fetchCalendarAppointments } from '../lib/api';
 import type { Reservation, CalendarAppointment } from '../types/reservation';
+import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { weekOverviewGuide } from '../lib/guideContent';
 
@@ -122,6 +123,7 @@ export function WeekOverviewPage() {
   const [error, setError] = useState<string | null>(null);
   const [locationFilter, setLocationFilter] = useState('ALL');
   const [statusFilter, setStatusFilter] = useState('ALL');
+  const { canUpdateReservations } = usePermissions();
 
   // Determine the Monday of the current week from URL or today
   const weekParam = searchParams.get('week');
@@ -349,6 +351,7 @@ export function WeekOverviewPage() {
                       <WeekReservationCard
                         key={reservation.id}
                         reservation={reservation}
+                        canEdit={canUpdateReservations}
                         onCateringToggle={async (id, newValue) => {
                           try {
                             const updated = await updateCateringArranged(id, newValue);
@@ -383,9 +386,11 @@ export function WeekOverviewPage() {
 
 function WeekReservationCard({
   reservation,
+  canEdit,
   onCateringToggle,
 }: {
   reservation: Reservation;
+  canEdit: boolean;
   onCateringToggle: (id: number, newValue: boolean) => Promise<void>;
 }) {
   const needsCatering = hasCatering(reservation.specialActivities);
@@ -432,7 +437,7 @@ function WeekReservationCard({
         </span>
 
         {/* Catering badge */}
-        {needsCatering && (
+        {needsCatering && (canEdit ? (
           <button
             type="button"
             onClick={(e) => {
@@ -450,7 +455,16 @@ function WeekReservationCard({
             <UtensilsCrossed className="w-3 h-3" />
             {reservation.cateringArranged ? 'OK' : '!'}
           </button>
-        )}
+        ) : (
+          <span className={`flex items-center gap-0.5 text-[10px] font-medium px-1.5 py-0.5 rounded ${
+              reservation.cateringArranged
+                ? 'bg-green-500/20 text-green-400'
+                : 'bg-orange-500/20 text-orange-400'
+            }`}>
+            <UtensilsCrossed className="w-3 h-3" />
+            {reservation.cateringArranged ? 'OK' : '!'}
+          </span>
+        ))}
       </div>
     </Link>
   );

--- a/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
+++ b/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
@@ -35,7 +35,7 @@ const viewerPermissions = {
 };
 
 vi.mock('../lib/usePermissions', () => ({
-  usePermissions: (...args: any[]) => mockUsePermissions(...args),
+  usePermissions: () => mockUsePermissions(),
 }));
 
 vi.mock('../lib/api', () => ({

--- a/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
+++ b/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
@@ -208,7 +208,7 @@ describe('CalendarAppointmentsPage', () => {
     });
   });
 
-  it('calls delete when delete button clicked', async () => {
+  it('calls delete when delete button clicked and confirmed in dialog', async () => {
     mockDelete.mockResolvedValue(undefined);
     renderPage();
     await waitFor(() => {
@@ -216,6 +216,13 @@ describe('CalendarAppointmentsPage', () => {
     });
     const deleteButtons = screen.getAllByTitle('Delete');
     fireEvent.click(deleteButtons[0]);
+
+    // Confirmation dialog should appear
+    expect(screen.getByText('Delete appointment')).toBeInTheDocument();
+    expect(screen.getByText(/permanently deleted/)).toBeInTheDocument();
+
+    // Confirm the deletion
+    fireEvent.click(screen.getByText('Delete', { selector: 'button' }));
     await waitFor(() => {
       expect(mockDelete).toHaveBeenCalledWith(1);
     });

--- a/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
+++ b/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
@@ -3,15 +3,40 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { CalendarAppointmentsPage } from '../pages/CalendarAppointmentsPage';
 
-const { mockFetch, mockCreate, mockUpdate, mockToggle, mockDelete } = vi.hoisted(() => {
+const { mockFetch, mockCreate, mockUpdate, mockToggle, mockDelete, mockUsePermissions } = vi.hoisted(() => {
   return {
     mockFetch: vi.fn(),
     mockCreate: vi.fn(),
     mockUpdate: vi.fn(),
     mockToggle: vi.fn(),
     mockDelete: vi.fn(),
+    mockUsePermissions: vi.fn(),
   };
 });
+
+const allPermissions = {
+  canUpdateReservations: true,
+  canManageBlockedPeriods: true,
+  canManageAppointments: true,
+  canManageAttachments: true,
+  canEditEmailTemplates: true,
+  canEditFormSettings: true,
+  canManageUsers: true,
+};
+
+const viewerPermissions = {
+  canUpdateReservations: false,
+  canManageBlockedPeriods: false,
+  canManageAppointments: false,
+  canManageAttachments: false,
+  canEditEmailTemplates: false,
+  canEditFormSettings: false,
+  canManageUsers: false,
+};
+
+vi.mock('../lib/usePermissions', () => ({
+  usePermissions: (...args: any[]) => mockUsePermissions(...args),
+}));
 
 vi.mock('../lib/api', () => ({
   fetchCalendarAppointments: mockFetch,
@@ -58,6 +83,7 @@ describe('CalendarAppointmentsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockResolvedValue(sampleAppointments);
+    mockUsePermissions.mockReturnValue(allPermissions);
   });
 
   it('renders page title', async () => {
@@ -192,6 +218,43 @@ describe('CalendarAppointmentsPage', () => {
     fireEvent.click(deleteButtons[0]);
     await waitFor(() => {
       expect(mockDelete).toHaveBeenCalledWith(1);
+    });
+  });
+});
+
+describe('CalendarAppointmentsPage - viewer permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue(sampleAppointments);
+    mockUsePermissions.mockReturnValue(viewerPermissions);
+  });
+
+  it('hides Add Appointment button for viewer', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Add Appointment')).not.toBeInTheDocument();
+  });
+
+  it('hides edit, toggle, and delete buttons for viewer', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+    });
+    expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Disable')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Enable')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('still shows appointment data for viewer', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Staff Meeting')).toBeInTheDocument();
+      expect(screen.getByText('Holiday Closure')).toBeInTheDocument();
+      expect(screen.getByText('HUBBLE')).toBeInTheDocument();
+      expect(screen.getByText('METEOR')).toBeInTheDocument();
     });
   });
 });

--- a/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
+++ b/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
@@ -3,6 +3,27 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { FormSettingsPage } from '../pages/FormSettingsPage';
 
+vi.mock('../lib/usePermissions', () => ({
+  usePermissions: () => ({
+    canUpdateReservations: true,
+    canManageBlockedPeriods: true,
+    canManageAppointments: true,
+    canManageAttachments: true,
+    canEditEmailTemplates: true,
+    canEditFormSettings: true,
+    canManageUsers: true,
+  }),
+}));
+
+vi.mock('../lib/RoleContext', () => ({
+  useRole: () => ({
+    role: 'ADMIN',
+    user: { id: 1, azureOid: 'test', email: 'test@test.com', displayName: 'Test', role: 'ADMIN' },
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
 // Mock the API
 vi.mock('../lib/api', () => ({
   fetchFormConstraints: vi.fn().mockResolvedValue([
@@ -64,6 +85,8 @@ vi.mock('../lib/api', () => ({
     nextRunAt: '2026-04-03T02:00:00',
     cutoffDate: '2025-04-02',
   }),
+  fetchAllUsers: vi.fn().mockResolvedValue([]),
+  updateUserRole: vi.fn(),
 }));
 
 const renderWithRouter = (component: React.ReactNode) => {
@@ -82,7 +105,7 @@ describe('FormSettingsPage', () => {
   it('renders the page title', async () => {
     renderWithRouter(<FormSettingsPage />);
     await waitFor(() => {
-      expect(screen.getByText('Form Settings')).toBeInTheDocument();
+      expect(screen.getByText('Settings')).toBeInTheDocument();
     }, { timeout: 3000 });
   });
 
@@ -95,14 +118,14 @@ describe('FormSettingsPage', () => {
   it('displays constraints tab with constraint count', async () => {
     renderWithRouter(<FormSettingsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Form Constraints \(3\)/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Form Constraints \(3\)/).length).toBeGreaterThanOrEqual(1);
     }, { timeout: 3000 });
   });
 
   it('displays blocked periods tab with count', async () => {
     renderWithRouter(<FormSettingsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Blocked Periods \(1\)/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Blocked Periods \(1\)/).length).toBeGreaterThanOrEqual(1);
     }, { timeout: 3000 });
   });
 
@@ -126,10 +149,12 @@ describe('FormSettingsPage', () => {
   it('switches to blocked periods tab', async () => {
     renderWithRouter(<FormSettingsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Blocked Periods/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
     }, { timeout: 3000 });
 
-    fireEvent.click(screen.getByText(/Blocked Periods/));
+    // Click the button tab (not the select option)
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
 
     await waitFor(() => {
       expect(screen.getByText('Spring maintenance')).toBeInTheDocument();
@@ -140,10 +165,11 @@ describe('FormSettingsPage', () => {
   it('shows blocked period date range and location', async () => {
     renderWithRouter(<FormSettingsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Blocked Periods/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
     }, { timeout: 3000 });
 
-    fireEvent.click(screen.getByText(/Blocked Periods/));
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
 
     await waitFor(() => {
       expect(screen.getByText('2026-04-01 — 2026-04-03')).toBeInTheDocument();
@@ -167,10 +193,11 @@ describe('FormSettingsPage', () => {
   it('opens new blocked period modal when Add Blocked Period is clicked', async () => {
     renderWithRouter(<FormSettingsPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Blocked Periods/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
     }, { timeout: 3000 });
 
-    fireEvent.click(screen.getByText(/Blocked Periods/));
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
 
     await waitFor(() => {
       expect(screen.getByText('Add Blocked Period')).toBeInTheDocument();

--- a/the-harry-list-admin/src/test/ReservationsPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationsPage.test.tsx
@@ -10,6 +10,18 @@ function dateOffset(monthOffset: number, dayOffset = 0): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
+vi.mock('../lib/usePermissions', () => ({
+  usePermissions: () => ({
+    canUpdateReservations: true,
+    canManageBlockedPeriods: true,
+    canManageAppointments: true,
+    canManageAttachments: true,
+    canEditEmailTemplates: true,
+    canEditFormSettings: true,
+    canManageUsers: true,
+  }),
+}));
+
 // Mock the API
 vi.mock('../lib/api', () => ({
   fetchReservations: vi.fn().mockResolvedValue([

--- a/the-harry-list-admin/src/test/UsersPage.test.tsx
+++ b/the-harry-list-admin/src/test/UsersPage.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { UsersPage } from '../pages/UsersPage';
+
+const { mockFetchAllUsers, mockUpdateUserRole } = vi.hoisted(() => ({
+  mockFetchAllUsers: vi.fn(),
+  mockUpdateUserRole: vi.fn(),
+}));
+
+vi.mock('../lib/api', () => ({
+  fetchAllUsers: mockFetchAllUsers,
+  updateUserRole: mockUpdateUserRole,
+}));
+
+const mockRefetch = vi.fn();
+
+vi.mock('../lib/RoleContext', () => ({
+  useRole: () => ({
+    user: { id: 1, azureOid: 'oid-1', email: 'pim@hubble.cafe', displayName: 'Pim', role: 'ADMIN' },
+    role: 'ADMIN',
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+}));
+
+const sampleUsers = [
+  { id: 1, azureOid: 'oid-1', email: 'pim@hubble.cafe', displayName: 'Pim', role: 'ADMIN' },
+  { id: 2, azureOid: 'oid-2', email: 'josselyn@hubble.cafe', displayName: 'Josselyn', role: 'EDITOR' },
+  { id: 3, azureOid: 'oid-3', email: 'mike@hubble.cafe', displayName: 'Mike', role: 'VIEWER' },
+];
+
+const renderPage = () =>
+  render(
+    <BrowserRouter>
+      <UsersPage />
+    </BrowserRouter>
+  );
+
+describe('UsersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAllUsers.mockResolvedValue(sampleUsers);
+  });
+
+  it('renders page title', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('User Management')).toBeInTheDocument();
+    });
+  });
+
+  it('displays all users after loading', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Pim')).toBeInTheDocument();
+      expect(screen.getByText('Josselyn')).toBeInTheDocument();
+      expect(screen.getByText('Mike')).toBeInTheDocument();
+    });
+  });
+
+  it('shows user emails', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('pim@hubble.cafe')).toBeInTheDocument();
+      expect(screen.getByText('josselyn@hubble.cafe')).toBeInTheDocument();
+      expect(screen.getByText('mike@hubble.cafe')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "You" badge next to current user', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('You')).toBeInTheDocument();
+    });
+  });
+
+  it('shows role badge (not dropdown) for current user', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Pim')).toBeInTheDocument();
+    });
+    // Current user should see a badge, not a select
+    // There should be 2 dropdowns (Josselyn + Mike), not 3
+    const selects = screen.getAllByRole('combobox');
+    expect(selects).toHaveLength(2);
+  });
+
+  it('shows role legend with descriptions', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Role Permissions')).toBeInTheDocument();
+    });
+  });
+
+  it('calls updateUserRole when role is changed', async () => {
+    const updatedUser = { ...sampleUsers[2], role: 'EDITOR' };
+    mockUpdateUserRole.mockResolvedValue(updatedUser);
+
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Mike')).toBeInTheDocument();
+    });
+
+    const selects = screen.getAllByRole('combobox');
+    // Find the one for Mike (VIEWER)
+    const mikeSelect = selects.find(s => (s as HTMLSelectElement).value === 'VIEWER');
+    expect(mikeSelect).toBeTruthy();
+
+    fireEvent.change(mikeSelect!, { target: { value: 'EDITOR' } });
+
+    await waitFor(() => {
+      expect(mockUpdateUserRole).toHaveBeenCalledWith(3, 'EDITOR');
+    });
+  });
+
+  it('shows empty state when no users', async () => {
+    mockFetchAllUsers.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No users yet/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when API fails', async () => {
+    mockFetchAllUsers.mockRejectedValue(new Error('Network error'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+});

--- a/the-harry-list-admin/src/test/WeekOverviewPage.test.tsx
+++ b/the-harry-list-admin/src/test/WeekOverviewPage.test.tsx
@@ -118,7 +118,7 @@ const viewerPermissions = {
 };
 
 vi.mock('../lib/usePermissions', () => ({
-  usePermissions: (...args: any[]) => mockUsePermissions(...args),
+  usePermissions: () => mockUsePermissions(),
 }));
 
 vi.mock('../lib/api', () => ({

--- a/the-harry-list-admin/src/test/WeekOverviewPage.test.tsx
+++ b/the-harry-list-admin/src/test/WeekOverviewPage.test.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { WeekOverviewPage } from '../pages/WeekOverviewPage';
 
 // Hoist mock data so vi.mock factory can access it
-const { mockFetchReservations, mockUpdateCateringArranged, mockFetchCalendarAppointments, testData } = vi.hoisted(() => {
+const { mockFetchReservations, mockUpdateCateringArranged, mockFetchCalendarAppointments, mockUsePermissions, testData } = vi.hoisted(() => {
   // Compute dates inside hoisted scope
   function _getMonday(): Date {
     const d = new Date();
@@ -92,9 +92,34 @@ const { mockFetchReservations, mockUpdateCateringArranged, mockFetchCalendarAppo
     mockFetchReservations: vi.fn().mockResolvedValue(reservations),
     mockUpdateCateringArranged: vi.fn().mockResolvedValue({ cateringArranged: true }),
     mockFetchCalendarAppointments: vi.fn().mockResolvedValue([]),
+    mockUsePermissions: vi.fn(),
     testData: { reservations },
   };
 });
+
+const allPermissions = {
+  canUpdateReservations: true,
+  canManageBlockedPeriods: true,
+  canManageAppointments: true,
+  canManageAttachments: true,
+  canEditEmailTemplates: true,
+  canEditFormSettings: true,
+  canManageUsers: true,
+};
+
+const viewerPermissions = {
+  canUpdateReservations: false,
+  canManageBlockedPeriods: false,
+  canManageAppointments: false,
+  canManageAttachments: false,
+  canEditEmailTemplates: false,
+  canEditFormSettings: false,
+  canManageUsers: false,
+};
+
+vi.mock('../lib/usePermissions', () => ({
+  usePermissions: (...args: any[]) => mockUsePermissions(...args),
+}));
 
 vi.mock('../lib/api', () => ({
   fetchReservations: mockFetchReservations,
@@ -115,6 +140,7 @@ describe('WeekOverviewPage', () => {
     vi.clearAllMocks();
     mockFetchReservations.mockResolvedValue(testData.reservations);
     mockUpdateCateringArranged.mockResolvedValue({ cateringArranged: true });
+    mockUsePermissions.mockReturnValue(allPermissions);
   });
 
   it('renders the page title after loading', async () => {
@@ -314,6 +340,35 @@ describe('WeekOverviewPage', () => {
     renderPage();
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('WeekOverviewPage - viewer permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchReservations.mockResolvedValue(testData.reservations);
+    mockUpdateCateringArranged.mockResolvedValue({ cateringArranged: true });
+    mockUsePermissions.mockReturnValue(viewerPermissions);
+  });
+
+  it('shows catering status as read-only for viewer', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Hubble Birthday')).toBeInTheDocument();
+    });
+
+    // Catering indicators should be spans, not buttons
+    const cateringButtons = screen.queryAllByTitle(/[Cc]atering/);
+    expect(cateringButtons).toHaveLength(0);
+  });
+
+  it('still shows all reservation data for viewer', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Hubble Birthday')).toBeInTheDocument();
+      expect(screen.getByText('Meteor Meeting')).toBeInTheDocument();
+      expect(screen.getByText('Wednesday Workshop')).toBeInTheDocument();
     });
   });
 });

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.1.2</version>
+	<version>1.2.0</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SecurityConfig.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SecurityConfig.java
@@ -1,10 +1,12 @@
 package com.pimvanleeuwen.the_harry_list_backend.config;
 
+import com.pimvanleeuwen.the_harry_list_backend.filter.RoleAuthorizationFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -15,6 +17,7 @@ import org.springframework.security.oauth2.jwt.JwtClaimValidator;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -25,6 +28,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     @Value("${azure.tenant-id:}")
@@ -35,6 +39,12 @@ public class SecurityConfig {
 
     @Value("${cors.allowed-origins:}")
     private String corsAllowedOrigins;
+
+    private final RoleAuthorizationFilter roleAuthorizationFilter;
+
+    public SecurityConfig(RoleAuthorizationFilter roleAuthorizationFilter) {
+        this.roleAuthorizationFilter = roleAuthorizationFilter;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -65,6 +75,9 @@ public class SecurityConfig {
 
         // Only allow OAuth2 JWT (Microsoft login)
         http.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        // Enrich authenticated admin requests with role-based authorities
+        http.addFilterAfter(roleAuthorizationFilter, BearerTokenAuthenticationFilter.class);
 
         return http.build();
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
@@ -5,6 +5,7 @@ import com.pimvanleeuwen.the_harry_list_backend.repository.BlockedPeriodReposito
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,6 +37,7 @@ public class AdminBlockedPeriodController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Create a new blocked period")
     public ResponseEntity<BlockedPeriod> create(@RequestBody BlockedPeriod period) {
         BlockedPeriod saved = repository.save(period);
@@ -43,6 +45,7 @@ public class AdminBlockedPeriodController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Update a blocked period")
     public ResponseEntity<BlockedPeriod> update(@PathVariable Long id, @RequestBody BlockedPeriod period) {
         return repository.findById(id)
@@ -61,6 +64,7 @@ public class AdminBlockedPeriodController {
     }
 
     @PatchMapping("/{id}/toggle")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Toggle a blocked period's enabled state")
     public ResponseEntity<BlockedPeriod> toggle(@PathVariable Long id) {
         return repository.findById(id)
@@ -72,6 +76,7 @@ public class AdminBlockedPeriodController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Delete a blocked period")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
         if (!repository.existsById(id)) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -38,6 +39,7 @@ public class AdminCalendarAppointmentController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Create a new calendar appointment")
     public ResponseEntity<CalendarAppointment> create(@RequestBody CalendarAppointment appointment) {
         CalendarAppointment saved = repository.save(appointment);
@@ -45,6 +47,7 @@ public class AdminCalendarAppointmentController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Update a calendar appointment")
     public ResponseEntity<CalendarAppointment> update(@PathVariable Long id, @RequestBody CalendarAppointment appointment) {
         return repository.findById(id)
@@ -65,6 +68,7 @@ public class AdminCalendarAppointmentController {
     }
 
     @PatchMapping("/{id}/toggle")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Toggle a calendar appointment's enabled state")
     public ResponseEntity<CalendarAppointment> toggle(@PathVariable Long id) {
         return repository.findById(id)
@@ -76,6 +80,7 @@ public class AdminCalendarAppointmentController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Delete a calendar appointment")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
         if (!repository.existsById(id)) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,6 +42,7 @@ public class AdminEmailAttachmentController {
     }
 
     @PostMapping(consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Upload a PDF attachment", description = "Upload a PDF file to use as email attachment")
     public ResponseEntity<?> uploadAttachment(
             @RequestParam("file") MultipartFile file,
@@ -78,6 +80,7 @@ public class AdminEmailAttachmentController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Delete an attachment", description = "Permanently delete an email attachment")
     public ResponseEntity<Void> deleteAttachment(@PathVariable Long id) {
         if (!repository.existsById(id)) {
@@ -89,6 +92,7 @@ public class AdminEmailAttachmentController {
     }
 
     @PatchMapping("/{id}/active")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Toggle attachment active status", description = "Enable or disable an attachment")
     public ResponseEntity<?> toggleActive(@PathVariable Long id, @RequestParam boolean active) {
         return repository.findById(id)

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -46,6 +47,7 @@ public class AdminEmailTemplateController {
     }
 
     @PutMapping("/{type}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Save a custom email template", description = "Saves a custom subject and body for the given template type. Use {{variable}} placeholders.")
     public ResponseEntity<EmailTemplateDto> update(
             @PathVariable EmailTemplateType type,
@@ -55,6 +57,7 @@ public class AdminEmailTemplateController {
     }
 
     @DeleteMapping("/{type}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Reset template to default", description = "Removes any custom template, reverting to the built-in default.")
     public ResponseEntity<Void> reset(@PathVariable EmailTemplateType type) {
         emailTemplateService.reset(type);
@@ -62,6 +65,7 @@ public class AdminEmailTemplateController {
     }
 
     @PostMapping("/{type}/test")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(
         summary = "Send a test email",
         description = "Renders the template with sample data and sends it to the provided address. " +

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintController.java
@@ -5,6 +5,7 @@ import com.pimvanleeuwen.the_harry_list_backend.repository.FormConstraintReposit
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,6 +37,7 @@ public class AdminFormConstraintController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create a new form constraint")
     public ResponseEntity<FormConstraint> create(@RequestBody FormConstraint constraint) {
         FormConstraint saved = repository.save(constraint);
@@ -43,6 +45,7 @@ public class AdminFormConstraintController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update a form constraint")
     public ResponseEntity<FormConstraint> update(@PathVariable Long id, @RequestBody FormConstraint constraint) {
         return repository.findById(id)
@@ -60,6 +63,7 @@ public class AdminFormConstraintController {
     }
 
     @PatchMapping("/{id}/toggle")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Toggle a constraint's enabled state")
     public ResponseEntity<FormConstraint> toggle(@PathVariable Long id) {
         return repository.findById(id)
@@ -71,6 +75,7 @@ public class AdminFormConstraintController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete a form constraint")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
         if (!repository.existsById(id)) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -66,6 +67,7 @@ public class AdminReservationController {
     }
 
     @PatchMapping("/{id}/status")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Update reservation status", description = "Update the status of a reservation (confirm, reject, cancel)")
     public ResponseEntity<?> updateStatus(
             @PathVariable Long id,
@@ -110,6 +112,7 @@ public class AdminReservationController {
     }
 
     @PatchMapping("/{id}/catering-arranged")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Toggle catering arranged", description = "Mark catering as arranged (or undo) for a reservation")
     public ResponseEntity<Reservation> updateCateringArranged(
             @PathVariable Long id,
@@ -129,6 +132,7 @@ public class AdminReservationController {
     }
 
     @PatchMapping("/{id}/notes")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Update internal notes", description = "Add or update internal notes for a reservation")
     public ResponseEntity<Reservation> updateInternalNotes(
             @PathVariable Long id,
@@ -148,6 +152,7 @@ public class AdminReservationController {
     }
 
     @PostMapping("/{id}/email")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Send custom email", description = "Send a custom email to the reservation contact")
     public ResponseEntity<Map<String, String>> sendCustomEmail(
             @PathVariable Long id,
@@ -192,6 +197,7 @@ public class AdminReservationController {
     }
 
     @PostMapping("/{id}/catering-email")
+    @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Send catering options email", description = "Send catering email with PDF attachments to reservation contact")
     public ResponseEntity<Map<String, String>> sendCateringEmail(
             @PathVariable Long id,

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminUserController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminUserController.java
@@ -1,0 +1,80 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@Tag(name = "Admin - Users", description = "Manage admin users and roles")
+@SecurityRequirement(name = "basicAuth")
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    public AdminUserController(AdminUserService adminUserService) {
+        this.adminUserService = adminUserService;
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "Get current user", description = "Returns the authenticated user's profile and role")
+    public ResponseEntity<AdminUser> getCurrentUser(Authentication auth) {
+        String oid = extractOid(auth);
+        AdminUser user = adminUserService.getCurrentUser(oid);
+        if (user == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(user);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List all users", description = "Returns all admin users (admin only)")
+    public ResponseEntity<List<AdminUser>> getAllUsers() {
+        return ResponseEntity.ok(adminUserService.getAllUsers());
+    }
+
+    @PutMapping("/{id}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Update user role", description = "Change a user's role (admin only, cannot change own role)")
+    public ResponseEntity<?> updateRole(
+            @PathVariable Long id,
+            @RequestBody Map<String, String> body,
+            Authentication auth) {
+
+        String roleStr = body.get("role");
+        if (roleStr == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "role is required"));
+        }
+
+        AdminRole newRole;
+        try {
+            newRole = AdminRole.valueOf(roleStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid role: " + roleStr));
+        }
+
+        String oid = extractOid(auth);
+        AdminUser updated = adminUserService.updateRole(id, newRole, oid);
+        return ResponseEntity.ok(updated);
+    }
+
+    private String extractOid(Authentication auth) {
+        if (auth instanceof JwtAuthenticationToken jwtAuth) {
+            String oid = jwtAuth.getToken().getClaimAsString("oid");
+            return oid != null ? oid : jwtAuth.getToken().getSubject();
+        }
+        return auth.getName();
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/GlobalExceptionHandler.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -44,6 +45,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<Map<String, String>> handleNoResource() {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "Not found"));
+    }
+
+    /** Insufficient role (403) — expected, not sent to Sentry */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", "You do not have permission to perform this action"));
     }
 
     /** Anything unexpected — 500, captured by Sentry */

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/GlobalExceptionHandler.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/GlobalExceptionHandler.java
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
 
     /** Insufficient role (403) — expected, not sent to Sentry */
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
+    public ResponseEntity<Map<String, String>> handleAccessDenied() {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(Map.of("error", "You do not have permission to perform this action"));
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/filter/RoleAuthorizationFilter.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/filter/RoleAuthorizationFilter.java
@@ -1,0 +1,103 @@
+package com.pimvanleeuwen.the_harry_list_backend.filter;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Enriches the SecurityContext with role-based authorities for admin endpoints.
+ * Runs after JWT authentication, looks up the user in the database (auto-creating
+ * on first login), and adds hierarchical ROLE_ authorities.
+ */
+@Component
+public class RoleAuthorizationFilter extends OncePerRequestFilter {
+
+    private final AdminUserService adminUserService;
+
+    public RoleAuthorizationFilter(AdminUserService adminUserService) {
+        this.adminUserService = adminUserService;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/api/admin");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth instanceof JwtAuthenticationToken jwtAuth) {
+            Jwt jwt = jwtAuth.getToken();
+
+            String oid = extractOid(jwt);
+            String email = extractEmail(jwt);
+            String name = extractName(jwt);
+
+            if (oid != null) {
+                AdminUser user = adminUserService.getOrCreateUser(oid, email, name);
+                List<GrantedAuthority> authorities = buildAuthorities(user.getRole());
+
+                // Wrap existing authentication with role-based authorities
+                AbstractAuthenticationToken enriched = new JwtAuthenticationToken(jwt, authorities, jwtAuth.getName());
+                enriched.setDetails(jwtAuth.getDetails());
+                SecurityContextHolder.getContext().setAuthentication(enriched);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Build hierarchical authorities: ADMIN gets all three, EDITOR gets EDITOR + VIEWER, etc.
+     */
+    List<GrantedAuthority> buildAuthorities(AdminRole role) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_VIEWER"));
+        if (role == AdminRole.EDITOR || role == AdminRole.ADMIN) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_EDITOR"));
+        }
+        if (role == AdminRole.ADMIN) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        }
+        return authorities;
+    }
+
+    private String extractOid(Jwt jwt) {
+        // Azure AD v2.0 tokens use "oid" claim, v1.0 uses "sub"
+        String oid = jwt.getClaimAsString("oid");
+        return oid != null ? oid : jwt.getSubject();
+    }
+
+    private String extractEmail(Jwt jwt) {
+        // Azure AD tokens may use "preferred_username", "email", or "upn"
+        String email = jwt.getClaimAsString("preferred_username");
+        if (email == null) email = jwt.getClaimAsString("email");
+        if (email == null) email = jwt.getClaimAsString("upn");
+        return email != null ? email : "unknown";
+    }
+
+    private String extractName(Jwt jwt) {
+        return jwt.getClaimAsString("name");
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminRole.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminRole.java
@@ -1,0 +1,17 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+public enum AdminRole {
+    VIEWER("Viewer"),
+    EDITOR("Editor"),
+    ADMIN("Admin");
+
+    private final String displayName;
+
+    AdminRole(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminUser.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminUser.java
@@ -1,0 +1,54 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "admin_user")
+public class AdminUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @NotBlank
+    @Column(name = "azure_oid", nullable = false, unique = true)
+    private String azureOid;
+
+    @NotBlank
+    @Email
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "display_name")
+    private String displayName;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private AdminRole role = AdminRole.VIEWER;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/repository/AdminUserRepository.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/repository/AdminUserRepository.java
@@ -1,0 +1,13 @@
+package com.pimvanleeuwen.the_harry_list_backend.repository;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminUserRepository extends JpaRepository<AdminUser, Long> {
+
+    Optional<AdminUser> findByAzureOid(String azureOid);
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserService.java
@@ -1,0 +1,98 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AdminUserService {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminUserService.class);
+
+    private final AdminUserRepository adminUserRepository;
+    private final String initialAdminOid;
+
+    public AdminUserService(
+            AdminUserRepository adminUserRepository,
+            @Value("${app.initial-admin-oid:}") String initialAdminOid) {
+        this.adminUserRepository = adminUserRepository;
+        this.initialAdminOid = initialAdminOid;
+    }
+
+    /**
+     * Find existing user by Azure OID or create a new one.
+     * New users get VIEWER role, except if their OID matches INITIAL_ADMIN_OID.
+     */
+    public AdminUser getOrCreateUser(String azureOid, String email, String displayName) {
+        return adminUserRepository.findByAzureOid(azureOid)
+                .map(existing -> {
+                    updateIfChanged(existing, email, displayName);
+                    return existing;
+                })
+                .orElseGet(() -> createUser(azureOid, email, displayName));
+    }
+
+    public AdminUser getCurrentUser(String azureOid) {
+        return adminUserRepository.findByAzureOid(azureOid).orElse(null);
+    }
+
+    public List<AdminUser> getAllUsers() {
+        return adminUserRepository.findAll();
+    }
+
+    /**
+     * Update a user's role. Prevents an admin from demoting themselves.
+     */
+    public AdminUser updateRole(Long userId, AdminRole newRole, String requestingUserOid) {
+        AdminUser target = adminUserRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        if (target.getAzureOid().equals(requestingUserOid)) {
+            throw new IllegalArgumentException("Cannot change your own role");
+        }
+
+        log.info("AUDIT user.role_changed userId={} oldRole={} newRole={} changedBy='{}'",
+                userId, target.getRole(), newRole, requestingUserOid);
+
+        target.setRole(newRole);
+        return adminUserRepository.save(target);
+    }
+
+    private AdminUser createUser(String azureOid, String email, String displayName) {
+        AdminUser user = new AdminUser();
+        user.setAzureOid(azureOid);
+        user.setEmail(email);
+        user.setDisplayName(displayName);
+
+        if (initialAdminOid != null && !initialAdminOid.isBlank() && initialAdminOid.equals(azureOid)) {
+            user.setRole(AdminRole.ADMIN);
+            log.info("AUDIT user.created email='{}' role=ADMIN (initial admin)", email);
+        } else {
+            user.setRole(AdminRole.VIEWER);
+            log.info("AUDIT user.created email='{}' role=VIEWER", email);
+        }
+
+        return adminUserRepository.save(user);
+    }
+
+    private void updateIfChanged(AdminUser user, String email, String displayName) {
+        boolean changed = false;
+        if (email != null && !email.equals(user.getEmail())) {
+            user.setEmail(email);
+            changed = true;
+        }
+        if (displayName != null && !displayName.equals(user.getDisplayName())) {
+            user.setDisplayName(displayName);
+            changed = true;
+        }
+        if (changed) {
+            adminUserRepository.save(user);
+        }
+    }
+}

--- a/the-harry-list-backend/src/main/resources/application-prod.properties
+++ b/the-harry-list-backend/src/main/resources/application-prod.properties
@@ -56,6 +56,9 @@ app.mail.graph.tenant-id=${azure.tenant-id}
 app.mail.graph.client-id=${azure.client-id}
 app.mail.graph.client-secret=${azure.client-secret}
 
+# RBAC - Azure OID of the initial admin user (only used on first-ever login)
+app.initial-admin-oid=${INITIAL_ADMIN_OID:}
+
 # Sentry error monitoring
 sentry.dsn=${SENTRY_DSN:}
 sentry.environment=production

--- a/the-harry-list-backend/src/main/resources/application.properties
+++ b/the-harry-list-backend/src/main/resources/application.properties
@@ -39,6 +39,9 @@ cors.allowed-origins=${CORS_ALLOWED_ORIGINS:}
 recaptcha.enabled=${RECAPTCHA_ENABLED:false}
 recaptcha.secret-key=${RECAPTCHA_SECRET_KEY:}
 
+# RBAC - Azure OID of the initial admin user (only used on first-ever login)
+app.initial-admin-oid=${INITIAL_ADMIN_OID:}
+
 # Sentry error monitoring (disabled in dev)
 sentry.dsn=
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
@@ -97,7 +97,7 @@ class AdminBlockedPeriodControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void create_shouldReturn201() throws Exception {
         BlockedPeriod period = samplePeriod();
         when(repository.save(any())).thenReturn(period);
@@ -111,7 +111,7 @@ class AdminBlockedPeriodControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void toggle_shouldFlipEnabledState() throws Exception {
         BlockedPeriod period = samplePeriod();
         period.setEnabled(true);
@@ -128,7 +128,7 @@ class AdminBlockedPeriodControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void delete_shouldReturn200() throws Exception {
         when(repository.existsById(1L)).thenReturn(true);
         doNothing().when(repository).deleteById(1L);
@@ -139,7 +139,7 @@ class AdminBlockedPeriodControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void delete_shouldReturn404ForMissing() throws Exception {
         when(repository.existsById(99L)).thenReturn(false);
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
 import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.model.BlockedPeriod;
 import com.pimvanleeuwen.the_harry_list_backend.repository.BlockedPeriodRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,9 @@ class AdminBlockedPeriodControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private BlockedPeriodRepository repository;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
 import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
 import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
 import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
@@ -34,6 +35,9 @@ class AdminCalendarAppointmentControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private CalendarAppointmentRepository repository;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
@@ -118,7 +118,7 @@ class AdminCalendarAppointmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void create_shouldReturn201() throws Exception {
         CalendarAppointment appointment = sampleAppointment();
         when(repository.save(any())).thenReturn(appointment);
@@ -132,7 +132,7 @@ class AdminCalendarAppointmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void create_allDay_shouldReturn201() throws Exception {
         CalendarAppointment appointment = sampleAllDayAppointment();
         when(repository.save(any())).thenReturn(appointment);
@@ -147,7 +147,7 @@ class AdminCalendarAppointmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void toggle_shouldFlipEnabledState() throws Exception {
         CalendarAppointment appointment = sampleAppointment();
         appointment.setEnabled(true);
@@ -164,7 +164,7 @@ class AdminCalendarAppointmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void delete_shouldReturn200() throws Exception {
         when(repository.existsById(1L)).thenReturn(true);
         doNothing().when(repository).deleteById(1L);
@@ -175,7 +175,7 @@ class AdminCalendarAppointmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void delete_shouldReturn404ForMissing() throws Exception {
         when(repository.existsById(99L)).thenReturn(false);
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarControllerTest.java
@@ -1,10 +1,12 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.*;
@@ -23,6 +25,9 @@ class AdminCalendarControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @Test
     @WithMockUser

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentControllerTest.java
@@ -70,7 +70,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void uploadAttachment_shouldAcceptPdf() throws Exception {
         MockMultipartFile file = new MockMultipartFile(
                 "file", "menu.pdf", "application/pdf", new byte[]{1, 2, 3});
@@ -88,7 +88,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void uploadAttachment_shouldRejectNonPdf() throws Exception {
         MockMultipartFile file = new MockMultipartFile(
                 "file", "doc.txt", "text/plain", new byte[]{1, 2, 3});
@@ -104,7 +104,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void uploadAttachment_shouldRejectEmptyFile() throws Exception {
         MockMultipartFile file = new MockMultipartFile(
                 "file", "empty.pdf", "application/pdf", new byte[0]);
@@ -119,7 +119,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void uploadAttachment_shouldRejectOversizedFile() throws Exception {
         byte[] bigData = new byte[4 * 1024 * 1024]; // 4MB, exceeds 3MB limit
         MockMultipartFile file = new MockMultipartFile(
@@ -136,7 +136,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void deleteAttachment_shouldDeleteExisting() throws Exception {
         when(repository.existsById(1L)).thenReturn(true);
 
@@ -147,7 +147,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void deleteAttachment_shouldReturn404WhenNotFound() throws Exception {
         when(repository.existsById(999L)).thenReturn(false);
 
@@ -158,7 +158,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void toggleActive_shouldToggleToInactive() throws Exception {
         EmailAttachment attachment = sampleAttachment();
         when(repository.findById(1L)).thenReturn(Optional.of(attachment));
@@ -177,7 +177,7 @@ class AdminEmailAttachmentControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void toggleActive_shouldReturn404WhenNotFound() throws Exception {
         when(repository.findById(999L)).thenReturn(Optional.empty());
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentControllerTest.java
@@ -2,6 +2,7 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailAttachment;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.repository.EmailAttachmentRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,9 @@ class AdminEmailAttachmentControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private EmailAttachmentRepository repository;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateControllerTest.java
@@ -3,6 +3,7 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
 import com.pimvanleeuwen.the_harry_list_backend.dto.EmailTemplateDto;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailTemplateType;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailTemplateService;
@@ -33,6 +34,9 @@ class AdminEmailTemplateControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private EmailTemplateService emailTemplateService;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateControllerTest.java
@@ -109,7 +109,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void update_shouldSaveAndReturnTemplate() throws Exception {
         EmailTemplateDto updated = sampleDto(EmailTemplateType.SUBMITTED, true);
         when(emailTemplateService.update(eq(EmailTemplateType.SUBMITTED), any(), any())).thenReturn(updated);
@@ -132,7 +132,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void update_shouldRejectBlankSubject() throws Exception {
         Map<String, String> request = Map.of(
                 "subject", "",
@@ -146,7 +146,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void update_shouldRejectBlankBody() throws Exception {
         Map<String, String> request = Map.of(
                 "subject", "Valid subject",
@@ -160,7 +160,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void reset_shouldReturn204() throws Exception {
         doNothing().when(emailTemplateService).reset(EmailTemplateType.UPDATED);
 
@@ -177,7 +177,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void sendTestEmail_shouldSendAndReturnSentStatus() throws Exception {
         when(emailTemplateService.buildSampleVariables(EmailTemplateType.SUBMITTED)).thenReturn(Map.of("eventTitle", "Test"));
         when(emailTemplateService.renderForTest(any(), any())).thenReturn("Rendered subject", "Rendered body");
@@ -199,7 +199,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void sendTestEmail_shouldRejectInvalidEmail() throws Exception {
         Map<String, String> request = Map.of("toEmail", "not-an-email");
 
@@ -211,7 +211,7 @@ class AdminEmailTemplateControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void sendTestEmail_shouldRejectMissingEmail() throws Exception {
         mockMvc.perform(post("/api/admin/email-templates/SUBMITTED/test")
                         .with(csrf())

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportControllerTest.java
@@ -2,6 +2,7 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 
 import org.openpdf.text.DocumentException;
 import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.service.PdfExportService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +27,9 @@ class AdminExportControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private PdfExportService pdfExportService;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintControllerTest.java
@@ -3,6 +3,7 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
 import com.pimvanleeuwen.the_harry_list_backend.model.FormConstraint;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.model.FormConstraintType;
 import com.pimvanleeuwen.the_harry_list_backend.repository.FormConstraintRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,9 @@ class AdminFormConstraintControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private FormConstraintRepository repository;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintControllerTest.java
@@ -94,7 +94,7 @@ class AdminFormConstraintControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void create_shouldReturn201() throws Exception {
         FormConstraint constraint = sampleConstraint();
         when(repository.save(any())).thenReturn(constraint);
@@ -108,7 +108,7 @@ class AdminFormConstraintControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void update_shouldUpdateExisting() throws Exception {
         FormConstraint existing = sampleConstraint();
         FormConstraint updated = sampleConstraint();
@@ -126,7 +126,7 @@ class AdminFormConstraintControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void update_shouldReturn404ForMissing() throws Exception {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
@@ -138,7 +138,7 @@ class AdminFormConstraintControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void toggle_shouldFlipEnabledState() throws Exception {
         FormConstraint constraint = sampleConstraint();
         constraint.setEnabled(true);
@@ -155,7 +155,7 @@ class AdminFormConstraintControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void delete_shouldReturn200() throws Exception {
         when(repository.existsById(1L)).thenReturn(true);
         doNothing().when(repository).deleteById(1L);
@@ -166,7 +166,7 @@ class AdminFormConstraintControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "ADMIN")
     void delete_shouldReturn404ForMissing() throws Exception {
         when(repository.existsById(99L)).thenReturn(false);
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -70,7 +70,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldConfirmReservation() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
@@ -92,7 +92,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldRejectReservation() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
@@ -111,7 +111,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldCancelReservation() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
@@ -130,7 +130,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldCompleteReservation() throws Exception {
         // Given
         sampleReservation.setStatus(ReservationStatus.CONFIRMED);
@@ -150,7 +150,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldReturnNotFoundWhenReservationDoesNotExist() throws Exception {
         // Given
         when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
@@ -163,7 +163,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldSendEmailWhenEnabled() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
@@ -182,7 +182,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldNotSendEmailWhenDisabled() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
@@ -201,7 +201,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateInternalNotes_shouldUpdateNotes() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
@@ -219,7 +219,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void updateInternalNotes_shouldReturnNotFoundWhenReservationDoesNotExist() throws Exception {
         // Given
         when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
@@ -266,7 +266,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void sendCateringEmail_shouldSendWithAttachments() throws Exception {
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
         when(emailTemplateService.getRenderedSubject(eq(EmailTemplateType.CATERING_OPTIONS), any()))
@@ -294,7 +294,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void sendCateringEmail_shouldUseCustomSubjectAndBody() throws Exception {
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
         when(emailAttachmentRepository.findAllById(any())).thenReturn(List.of());
@@ -318,7 +318,7 @@ class AdminReservationControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "EDITOR")
     void sendCateringEmail_shouldReturn404WhenNotFound() throws Exception {
         when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pimvanleeuwen.the_harry_list_backend.dto.CateringEmailRequest;
 import com.pimvanleeuwen.the_harry_list_backend.model.*;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.repository.EmailAttachmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
@@ -37,6 +38,9 @@ class AdminReservationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private ReservationRepository reservationRepository;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminSettingsControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminSettingsControllerTest.java
@@ -1,6 +1,7 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.service.DataRetentionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ class AdminSettingsControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private DataRetentionService dataRetentionService;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminUserControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminUserControllerTest.java
@@ -1,0 +1,114 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminUserController.class)
+@Import(SecurityConfig.class)
+class AdminUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    private AdminUser sampleUser(Long id, String email, String name, AdminRole role) {
+        AdminUser user = new AdminUser();
+        user.setId(id);
+        user.setAzureOid("oid-" + id);
+        user.setEmail(email);
+        user.setDisplayName(name);
+        user.setRole(role);
+        return user;
+    }
+
+    @Test
+    void listUsers_shouldRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void listUsers_shouldReturnAllUsersForAdmin() throws Exception {
+        List<AdminUser> users = List.of(
+                sampleUser(1L, "admin@example.com", "Admin", AdminRole.ADMIN),
+                sampleUser(2L, "editor@example.com", "Editor", AdminRole.EDITOR)
+        );
+        when(adminUserService.getAllUsers()).thenReturn(users);
+
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].email").value("admin@example.com"))
+                .andExpect(jsonPath("$[1].role").value("EDITOR"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void listUsers_shouldBeForbiddenForEditor() throws Exception {
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "VIEWER")
+    void listUsers_shouldBeForbiddenForViewer() throws Exception {
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void updateRole_shouldUpdateForAdmin() throws Exception {
+        AdminUser updated = sampleUser(2L, "editor@example.com", "Editor", AdminRole.ADMIN);
+        when(adminUserService.updateRole(eq(2L), eq(AdminRole.ADMIN), any())).thenReturn(updated);
+
+        mockMvc.perform(put("/api/admin/users/2/role")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("role", "ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("ADMIN"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateRole_shouldBeForbiddenForEditor() throws Exception {
+        mockMvc.perform(put("/api/admin/users/2/role")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("role", "ADMIN"))))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/PublicReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/PublicReservationControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
 import com.pimvanleeuwen.the_harry_list_backend.dto.PublicReservationRequest;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.dto.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.*;
 import com.pimvanleeuwen.the_harry_list_backend.service.CreateReservationService;
@@ -38,6 +39,9 @@ class PublicReservationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private CreateReservationService createReservationService;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/ReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/ReservationControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pimvanleeuwen.the_harry_list_backend.dto.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.*;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.service.CreateReservationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.DeleteReservationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.GetReservationService;
@@ -39,6 +40,9 @@ class ReservationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
 
     @MockitoBean
     private GetReservationService getReservationService;

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/filter/RoleAuthorizationFilterTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/filter/RoleAuthorizationFilterTest.java
@@ -1,0 +1,136 @@
+package com.pimvanleeuwen.the_harry_list_backend.filter;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RoleAuthorizationFilterTest {
+
+    @Mock
+    private AdminUserService adminUserService;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private RoleAuthorizationFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    private static final String OID = "d7795f0e-32fd-4618-b5da-bf2c0079dd4a";
+
+    @BeforeEach
+    void setUp() {
+        filter = new RoleAuthorizationFilter(adminUserService);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldSkipNonAdminPaths() throws Exception {
+        request.setRequestURI("/api/public/reservations");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(adminUserService, never()).getOrCreateUser(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void shouldEnrichAdminRequestWithViewerAuthorities() throws Exception {
+        request.setRequestURI("/api/admin/reservations");
+        setupJwtAuth(AdminRole.VIEWER);
+
+        filter.doFilter(request, response, filterChain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertTrue(hasAuthority(auth.getAuthorities(), "ROLE_VIEWER"));
+        assertFalse(hasAuthority(auth.getAuthorities(), "ROLE_EDITOR"));
+        assertFalse(hasAuthority(auth.getAuthorities(), "ROLE_ADMIN"));
+    }
+
+    @Test
+    void shouldEnrichAdminRequestWithEditorAuthorities() throws Exception {
+        request.setRequestURI("/api/admin/reservations");
+        setupJwtAuth(AdminRole.EDITOR);
+
+        filter.doFilter(request, response, filterChain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertTrue(hasAuthority(auth.getAuthorities(), "ROLE_VIEWER"));
+        assertTrue(hasAuthority(auth.getAuthorities(), "ROLE_EDITOR"));
+        assertFalse(hasAuthority(auth.getAuthorities(), "ROLE_ADMIN"));
+    }
+
+    @Test
+    void shouldEnrichAdminRequestWithAllAuthoritiesForAdmin() throws Exception {
+        request.setRequestURI("/api/admin/reservations");
+        setupJwtAuth(AdminRole.ADMIN);
+
+        filter.doFilter(request, response, filterChain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertTrue(hasAuthority(auth.getAuthorities(), "ROLE_VIEWER"));
+        assertTrue(hasAuthority(auth.getAuthorities(), "ROLE_EDITOR"));
+        assertTrue(hasAuthority(auth.getAuthorities(), "ROLE_ADMIN"));
+    }
+
+    @Test
+    void shouldContinueFilterChainEvenWithoutJwtAuth() throws Exception {
+        request.setRequestURI("/api/admin/reservations");
+        // No authentication set in SecurityContext
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(adminUserService, never()).getOrCreateUser(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void buildAuthorities_shouldBeHierarchical() {
+        assertEquals(1, filter.buildAuthorities(AdminRole.VIEWER).size());
+        assertEquals(2, filter.buildAuthorities(AdminRole.EDITOR).size());
+        assertEquals(3, filter.buildAuthorities(AdminRole.ADMIN).size());
+    }
+
+    private void setupJwtAuth(AdminRole role) {
+        Jwt jwt = new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600),
+                Map.of("alg", "RS256"),
+                Map.of("oid", OID, "preferred_username", "pim@hubble.cafe", "name", "Pim", "sub", OID));
+
+        JwtAuthenticationToken jwtAuth = new JwtAuthenticationToken(jwt);
+        SecurityContextHolder.getContext().setAuthentication(jwtAuth);
+
+        AdminUser user = new AdminUser();
+        user.setAzureOid(OID);
+        user.setEmail("pim@hubble.cafe");
+        user.setDisplayName("Pim");
+        user.setRole(role);
+        when(adminUserService.getOrCreateUser(OID, "pim@hubble.cafe", "Pim")).thenReturn(user);
+    }
+
+    private boolean hasAuthority(java.util.Collection<? extends GrantedAuthority> authorities, String authority) {
+        return authorities.stream().anyMatch(a -> a.getAuthority().equals(authority));
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminRoleTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminRoleTest.java
@@ -1,0 +1,21 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdminRoleTest {
+
+    @Test
+    void shouldHaveCorrectDisplayNames() {
+        assertEquals("Viewer", AdminRole.VIEWER.getDisplayName());
+        assertEquals("Editor", AdminRole.EDITOR.getDisplayName());
+        assertEquals("Admin", AdminRole.ADMIN.getDisplayName());
+    }
+
+    @Test
+    void shouldHaveAllExpectedValues() {
+        AdminRole[] values = AdminRole.values();
+        assertEquals(3, values.length);
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminUserTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/AdminUserTest.java
@@ -1,0 +1,57 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdminUserTest {
+
+    private AdminUser user;
+
+    @BeforeEach
+    void setUp() {
+        user = new AdminUser();
+    }
+
+    @Test
+    void onCreate_shouldSetTimestamps() {
+        user.onCreate();
+
+        assertNotNull(user.getCreatedAt());
+        assertNotNull(user.getUpdatedAt());
+    }
+
+    @Test
+    void onUpdate_shouldUpdateTimestamp() {
+        user.onCreate();
+        var original = user.getUpdatedAt();
+
+        try { Thread.sleep(10); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        user.onUpdate();
+
+        assertNotNull(user.getUpdatedAt());
+        assertTrue(user.getUpdatedAt().isAfter(original) || user.getUpdatedAt().equals(original));
+    }
+
+    @Test
+    void defaultRole_shouldBeViewer() {
+        assertEquals(AdminRole.VIEWER, user.getRole());
+    }
+
+    @Test
+    void settersAndGetters_shouldWorkCorrectly() {
+        user.setId(1L);
+        user.setAzureOid("d7795f0e-32fd-4618-b5da-bf2c0079dd4a");
+        user.setEmail("pim@hubble.cafe");
+        user.setDisplayName("Pim");
+        user.setRole(AdminRole.ADMIN);
+
+        assertEquals(1L, user.getId());
+        assertEquals("d7795f0e-32fd-4618-b5da-bf2c0079dd4a", user.getAzureOid());
+        assertEquals("pim@hubble.cafe", user.getEmail());
+        assertEquals("Pim", user.getDisplayName());
+        assertEquals(AdminRole.ADMIN, user.getRole());
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserServiceTest.java
@@ -1,0 +1,148 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock
+    private AdminUserRepository adminUserRepository;
+
+    private AdminUserService service;
+
+    private static final String ADMIN_OID = "d7795f0e-32fd-4618-b5da-bf2c0079dd4a";
+    private static final String OTHER_OID = "2afebecd-9543-4525-8ee5-c12ec15d7a2b";
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminUserService(adminUserRepository, ADMIN_OID);
+    }
+
+    @Test
+    void getOrCreateUser_shouldReturnExistingUser() {
+        AdminUser existing = createUser(1L, OTHER_OID, "josselyn@hubble.cafe", "Josselyn", AdminRole.EDITOR);
+        when(adminUserRepository.findByAzureOid(OTHER_OID)).thenReturn(Optional.of(existing));
+
+        AdminUser result = service.getOrCreateUser(OTHER_OID, "josselyn@hubble.cafe", "Josselyn");
+
+        assertEquals(existing, result);
+        verify(adminUserRepository, never()).save(any());
+    }
+
+    @Test
+    void getOrCreateUser_shouldCreateViewerForNewUser() {
+        when(adminUserRepository.findByAzureOid(OTHER_OID)).thenReturn(Optional.empty());
+        when(adminUserRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        AdminUser result = service.getOrCreateUser(OTHER_OID, "josselyn@hubble.cafe", "Josselyn");
+
+        assertEquals(AdminRole.VIEWER, result.getRole());
+        assertEquals("josselyn@hubble.cafe", result.getEmail());
+        assertEquals("Josselyn", result.getDisplayName());
+    }
+
+    @Test
+    void getOrCreateUser_shouldCreateAdminForInitialAdminOid() {
+        when(adminUserRepository.findByAzureOid(ADMIN_OID)).thenReturn(Optional.empty());
+        when(adminUserRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        AdminUser result = service.getOrCreateUser(ADMIN_OID, "pim@hubble.cafe", "Pim");
+
+        assertEquals(AdminRole.ADMIN, result.getRole());
+    }
+
+    @Test
+    void getOrCreateUser_shouldUpdateEmailIfChanged() {
+        AdminUser existing = createUser(1L, OTHER_OID, "old@hubble.cafe", "Josselyn", AdminRole.EDITOR);
+        when(adminUserRepository.findByAzureOid(OTHER_OID)).thenReturn(Optional.of(existing));
+        when(adminUserRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.getOrCreateUser(OTHER_OID, "new@hubble.cafe", "Josselyn");
+
+        assertEquals("new@hubble.cafe", existing.getEmail());
+        verify(adminUserRepository).save(existing);
+    }
+
+    @Test
+    void getCurrentUser_shouldReturnNullWhenNotFound() {
+        when(adminUserRepository.findByAzureOid("unknown")).thenReturn(Optional.empty());
+
+        assertNull(service.getCurrentUser("unknown"));
+    }
+
+    @Test
+    void getAllUsers_shouldReturnAll() {
+        AdminUser user1 = createUser(1L, ADMIN_OID, "pim@hubble.cafe", "Pim", AdminRole.ADMIN);
+        AdminUser user2 = createUser(2L, OTHER_OID, "josselyn@hubble.cafe", "Josselyn", AdminRole.EDITOR);
+        when(adminUserRepository.findAll()).thenReturn(List.of(user1, user2));
+
+        List<AdminUser> result = service.getAllUsers();
+
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void updateRole_shouldUpdateTargetRole() {
+        AdminUser target = createUser(2L, OTHER_OID, "josselyn@hubble.cafe", "Josselyn", AdminRole.VIEWER);
+        when(adminUserRepository.findById(2L)).thenReturn(Optional.of(target));
+        when(adminUserRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        AdminUser result = service.updateRole(2L, AdminRole.EDITOR, ADMIN_OID);
+
+        assertEquals(AdminRole.EDITOR, result.getRole());
+        verify(adminUserRepository).save(target);
+    }
+
+    @Test
+    void updateRole_shouldThrowWhenChangingOwnRole() {
+        AdminUser self = createUser(1L, ADMIN_OID, "pim@hubble.cafe", "Pim", AdminRole.ADMIN);
+        when(adminUserRepository.findById(1L)).thenReturn(Optional.of(self));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                service.updateRole(1L, AdminRole.VIEWER, ADMIN_OID));
+    }
+
+    @Test
+    void updateRole_shouldThrowWhenUserNotFound() {
+        when(adminUserRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                service.updateRole(999L, AdminRole.EDITOR, ADMIN_OID));
+    }
+
+    @Test
+    void getOrCreateUser_shouldCreateViewerWhenInitialAdminOidIsEmpty() {
+        service = new AdminUserService(adminUserRepository, "");
+        when(adminUserRepository.findByAzureOid(ADMIN_OID)).thenReturn(Optional.empty());
+        when(adminUserRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        AdminUser result = service.getOrCreateUser(ADMIN_OID, "pim@hubble.cafe", "Pim");
+
+        assertEquals(AdminRole.VIEWER, result.getRole());
+    }
+
+    private AdminUser createUser(Long id, String oid, String email, String name, AdminRole role) {
+        AdminUser user = new AdminUser();
+        user.setId(id);
+        user.setAzureOid(oid);
+        user.setEmail(email);
+        user.setDisplayName(name);
+        user.setRole(role);
+        return user;
+    }
+}

--- a/the-harry-list-public/Dockerfile
+++ b/the-harry-list-public/Dockerfile
@@ -9,8 +9,9 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (--include=optional ensures platform-specific native binaries
+# like rolldown are installed for the container's architecture, not the host's)
+RUN npm ci --include=optional
 
 # Copy source files
 COPY . .

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.53.1",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION

## Summary

- **RBAC system**: Introduces three roles: `ADMIN`, `EDITOR`, and `VIEWER` enforced at both backend (Spring Security `@PreAuthorize`, `RoleAuthorizationFilter`) and frontend (permissions hook + role context).
- **User management page**: Admins can assign and manage roles for all users that have logged in via Azure AD.
- **Mutating UI actions gated by role**: Create/edit/delete buttons are hidden for Viewers; direct API calls to mutating endpoints return 403.
- **Auto-user creation**: New users are auto-provisioned as `VIEWER` on first login; an `INITIAL_ADMIN_OID` env var seeds the first admin.
- **Calendar appointments**: Custom calendar appointments with admin UI; calendar URLs shown to Viewers only after a spoiler warning.
- **Confirmation dialogs**: Replaced native `window.confirm` calls with a styled `ConfirmDialog` component across destructive actions.
- **Settings reorganisation**: Data retention and user management moved to an admin-only tab.
- **Sentry**: 403 errors now captured to surface unresolved frontend permission issues.

## Migration required before deploy

**⚠️ Run the SQL migration against the production database BEFORE deploying the backend.**
See `docs/migration-rbac.md` for the full steps, including `INSERT` statements for pre-seeding existing users as `ADMIN`.