### PR TITLE
feat: audit log

### DIFF
--- a/docs/migration-audit-log.md
+++ b/docs/migration-audit-log.md
@@ -1,0 +1,54 @@
+# Audit Log Migration Guide
+
+## Overview
+
+This migration introduces a persistent **audit log** that records who changed what (and when) across admin-managed entities — starting with reservations. Each entry captures the actor (from their Microsoft login), the action, and field-level diffs (old → new), and stays readable even after the underlying record is deleted.
+
+The change is **additive and backwards compatible**: it creates one new table (`audit_log`) and adds new read-only endpoints. No existing tables or API contracts change.
+
+## Step 1: Run SQL Migration
+
+The production backend runs with `ddl-auto=validate`, so the table must exist **before** deploying the new backend. Execute the following on the production MariaDB database:
+
+```sql
+CREATE TABLE audit_log (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  entity_type VARCHAR(40) NOT NULL,
+  entity_id BIGINT,
+  entity_label VARCHAR(255),
+  action VARCHAR(30) NOT NULL,
+  actor_oid VARCHAR(255),
+  actor_email VARCHAR(255),
+  actor_name VARCHAR(255),
+  changes TEXT,
+  summary VARCHAR(500),
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_audit_entity (entity_type, entity_id),
+  INDEX idx_audit_created_at (created_at)
+);
+```
+
+Dev and test environments create the table automatically (`ddl-auto=update` / H2), so no manual step is needed there.
+
+## Step 2: Deploy
+
+Deploy the new backend (and, in later phases, the admin frontend). Deployment order does not matter — the SQL migration creates the table before the backend validates the schema, and existing endpoints are unaffected.
+
+## Step 3: Verify
+
+1. Edit a reservation (e.g. change the number of guests and confirm it) → a row appears in `audit_log` with `entity_type = 'RESERVATION'`, your email/name, and a `changes` JSON array.
+2. `GET /api/admin/audit` as an ADMIN returns the entry; as an EDITOR/VIEWER it returns `403`.
+3. `GET /api/admin/audit/reservation/{id}` returns that reservation's history for any authenticated user.
+4. Delete a reservation → a `DELETE` entry remains, with the human-readable `entity_label` preserved.
+
+## Rollback
+
+1. Deploy the previous backend version.
+2. The `audit_log` table can remain (the old backend ignores it).
+3. To fully clean up: `DROP TABLE audit_log;`
+
+## Notes
+
+- Audit writes are best-effort: a failure to record an entry is logged but never breaks the underlying operation.
+- Internal-note content is intentionally **not** stored in the audit log (only the fact that notes were updated), since notes may be long or sensitive.
+- No retention/auto-purge is applied to audit rows in this release.

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/App.tsx
+++ b/the-harry-list-admin/src/App.tsx
@@ -10,6 +10,7 @@ import { EmailTemplatesPage } from './pages/EmailTemplatesPage';
 import { SettingsPage } from './pages/FormSettingsPage';
 import { CalendarAppointmentsPage } from './pages/CalendarAppointmentsPage';
 import { WeekOverviewPage } from './pages/WeekOverviewPage';
+import { AuditLogPage } from './pages/AuditLogPage';
 import { Layout } from './components/Layout';
 import { useGroupAuthorization } from './lib/useGroupAuthorization';
 import { ThemeProvider } from './lib/ThemeContext';
@@ -94,6 +95,7 @@ function App() {
           <Route path="settings" element={<SettingsPage />} />
           <Route path="form-settings" element={<SettingsPage />} />
           <Route path="calendar-appointments" element={<CalendarAppointmentsPage />} />
+          <Route path="audit" element={<AuditLogPage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -38,8 +38,8 @@ export function Layout() {
     { to: '/calendar', icon: CalendarSync, label: 'Calendar Feeds' },
     { to: '/calendar-appointments', icon: CalendarPlus, label: 'Appointments' },
     ...(canEditEmailTemplates ? [{ to: '/email-templates', icon: Mail, label: 'Email Templates' }] : []),
-    ...(canEditFormSettings ? [{ to: '/settings', icon: Settings, label: 'Settings' }] : []),
     ...(canViewAuditLog ? [{ to: '/audit', icon: History, label: 'Audit Log' }] : []),
+    ...(canEditFormSettings ? [{ to: '/settings', icon: Settings, label: 'Settings' }] : []),
   ];
 
   return (

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { useMsal } from '@azure/msal-react';
 import {
   LayoutDashboard, Calendar, CalendarDays, LogOut,
-  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings
+  User, Menu, CalendarSync, CalendarPlus, FileDown, Mail, Settings, History
 } from 'lucide-react';
 import { useState } from 'react';
 import { clearAuth} from '../lib/api';
@@ -15,7 +15,7 @@ export function Layout() {
   const { instance, accounts } = useMsal();
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { canEditEmailTemplates, canEditFormSettings } = usePermissions();
+  const { canEditEmailTemplates, canEditFormSettings, canViewAuditLog } = usePermissions();
   const { role } = useRole();
 
   const user = accounts[0];
@@ -39,6 +39,7 @@ export function Layout() {
     { to: '/calendar-appointments', icon: CalendarPlus, label: 'Appointments' },
     ...(canEditEmailTemplates ? [{ to: '/email-templates', icon: Mail, label: 'Email Templates' }] : []),
     ...(canEditFormSettings ? [{ to: '/settings', icon: Settings, label: 'Settings' }] : []),
+    ...(canViewAuditLog ? [{ to: '/audit', icon: History, label: 'Audit Log' }] : []),
   ];
 
   return (

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -145,6 +145,7 @@ async function fetchJsonWithAuth(url: string, options: RequestInit = {}): Promis
 
 // Import types for proper typing
 import type { Reservation, FormConstraint, BlockedPeriod, EmailAttachment, CateringEmailRequest, CalendarAppointment } from '../types/reservation';
+import type { AuditLogEntry, AuditLogPageResponse, AuditLogFilters } from '../types/audit';
 
 // API Functions
 export async function fetchReservations(): Promise<Reservation[]> {
@@ -366,6 +367,25 @@ export async function updateUserRole(userId: number, role: string): Promise<Admi
     method: 'PUT',
     body: JSON.stringify({ role }),
   }) as Promise<AdminUser>;
+}
+
+// ===== Audit Log =====
+export async function fetchReservationAuditLog(reservationId: number): Promise<AuditLogEntry[]> {
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/audit/reservation/${reservationId}`) as Promise<AuditLogEntry[]>;
+}
+
+export async function fetchAuditLog(filters: AuditLogFilters = {}): Promise<AuditLogPageResponse> {
+  const params = new URLSearchParams();
+  if (filters.entityType) params.set('entityType', filters.entityType);
+  if (filters.entityId != null) params.set('entityId', String(filters.entityId));
+  if (filters.actorEmail) params.set('actorEmail', filters.actorEmail);
+  if (filters.action) params.set('action', filters.action);
+  if (filters.from) params.set('from', filters.from);
+  if (filters.to) params.set('to', filters.to);
+  if (filters.page != null) params.set('page', String(filters.page));
+  if (filters.size != null) params.set('size', String(filters.size));
+  const qs = params.toString();
+  return fetchJsonWithAuth(`${API_BASE_URL}/api/admin/audit${qs ? `?${qs}` : ''}`) as Promise<AuditLogPageResponse>;
 }
 
 // Test if authentication is working

--- a/the-harry-list-admin/src/lib/usePermissions.ts
+++ b/the-harry-list-admin/src/lib/usePermissions.ts
@@ -17,5 +17,6 @@ export function usePermissions() {
     canEditEmailTemplates: isAdmin,
     canEditFormSettings: isAdmin,
     canManageUsers: isAdmin,
+    canViewAuditLog: isAdmin,
   };
 }

--- a/the-harry-list-admin/src/pages/AuditLogPage.tsx
+++ b/the-harry-list-admin/src/pages/AuditLogPage.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import { Loader2, AlertCircle, History, ChevronLeft, ChevronRight, Filter } from 'lucide-react';
+import { fetchAuditLog } from '../lib/api';
+import type { AuditAction, AuditEntityType, AuditLogEntry } from '../types/audit';
+
+const ENTITY_TYPES: AuditEntityType[] = [
+  'RESERVATION', 'BLOCKED_PERIOD', 'CALENDAR_APPOINTMENT',
+  'EMAIL_TEMPLATE', 'EMAIL_ATTACHMENT', 'FORM_CONSTRAINT', 'ADMIN_USER',
+];
+
+const ACTIONS: AuditAction[] = [
+  'CREATE', 'UPDATE', 'DELETE', 'STATUS_CHANGE',
+  'NOTES_UPDATED', 'CATERING_ARRANGED', 'EMAIL_SENT', 'ROLE_CHANGED', 'TOGGLE',
+];
+
+const PAGE_SIZE = 50;
+
+export function AuditLogPage() {
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+
+  // Filters
+  const [entityType, setEntityType] = useState<AuditEntityType | ''>('');
+  const [action, setAction] = useState<AuditAction | ''>('');
+  const [actorEmail, setActorEmail] = useState('');
+
+  // State is only set inside async callbacks (not synchronously in the effect body),
+  // to satisfy the react-hooks/set-state-in-effect rule. `loading` starts true.
+  useEffect(() => {
+    let cancelled = false;
+    fetchAuditLog({
+      page,
+      size: PAGE_SIZE,
+      entityType: entityType || undefined,
+      action: action || undefined,
+      actorEmail: actorEmail.trim() || undefined,
+    })
+      .then(result => {
+        if (cancelled) return;
+        setEntries(result.content);
+        setTotalPages(result.totalPages);
+        setTotalElements(result.totalElements);
+        setError(null);
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load audit log');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [page, entityType, action, actorEmail]);
+
+  // Changing a filter resets to the first page.
+  const onFilterChange = <T,>(setter: (v: T) => void) => (value: T) => {
+    setPage(0);
+    setter(value);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-title font-bold text-white flex items-center gap-2">
+          <History className="w-6 h-6 text-hubble-400" />
+          Audit Log
+        </h1>
+        <p className="text-dark-400 font-light">A record of who changed what across the admin panel</p>
+      </div>
+
+      {/* Filters */}
+      <div className="card">
+        <div className="flex items-center gap-2 mb-3 text-sm text-dark-300">
+          <Filter className="w-4 h-4" /> Filters
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="form-group">
+            <label className="label" htmlFor="audit-entity-type">Entity type</label>
+            <select
+              id="audit-entity-type"
+              value={entityType}
+              onChange={e => onFilterChange(setEntityType)(e.target.value as AuditEntityType | '')}
+              className="select-field"
+            >
+              <option value="">All</option>
+              {ENTITY_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, ' ')}</option>)}
+            </select>
+          </div>
+          <div className="form-group">
+            <label className="label" htmlFor="audit-action">Action</label>
+            <select
+              id="audit-action"
+              value={action}
+              onChange={e => onFilterChange(setAction)(e.target.value as AuditAction | '')}
+              className="select-field"
+            >
+              <option value="">All</option>
+              {ACTIONS.map(a => <option key={a} value={a}>{a.replace(/_/g, ' ')}</option>)}
+            </select>
+          </div>
+          <div className="form-group">
+            <label className="label" htmlFor="audit-actor-email">Actor email</label>
+            <input
+              id="audit-actor-email"
+              type="text"
+              value={actorEmail}
+              onChange={e => onFilterChange(setActorEmail)(e.target.value)}
+              placeholder="e.g. staff@example.com"
+              className="input-field"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
+          <span className="text-red-400 text-sm">{error}</span>
+        </div>
+      )}
+
+      {/* Entries */}
+      {loading ? (
+        <div className="flex items-center justify-center h-48">
+          <Loader2 className="w-8 h-8 text-hubble-400 animate-spin" />
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="card text-center py-12">
+          <History className="w-12 h-12 text-dark-600 mx-auto mb-3" />
+          <p className="text-dark-400">No audit entries match your filters.</p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {entries.map(entry => (
+              <div key={entry.id} className="bg-dark-900 border border-dark-800 rounded-xl p-4">
+                <div className="flex items-center justify-between flex-wrap gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <AuditActionBadge action={entry.action} />
+                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-dark-700 text-dark-300">
+                      {entry.entityType.replace(/_/g, ' ')}
+                    </span>
+                    <span className="text-white text-sm">{entry.entityLabel || `#${entry.entityId ?? '—'}`}</span>
+                  </div>
+                  <time className="text-xs text-dark-500">{new Date(entry.createdAt).toLocaleString()}</time>
+                </div>
+                <div className="text-sm text-dark-300 mt-1">
+                  <span className="text-white">{entry.actorName || entry.actorEmail || 'system'}</span>
+                  {entry.summary && <span className="text-dark-400"> — {entry.summary}</span>}
+                </div>
+                {entry.changes.length > 0 && (
+                  <ul className="mt-2 space-y-1">
+                    {entry.changes.map((change, i) => (
+                      <li key={i} className="text-xs text-dark-400">
+                        <code className="text-dark-300">{change.field}</code>:{' '}
+                        <span className="line-through text-red-400/70">{change.oldValue ?? '—'}</span>
+                        {' → '}
+                        <span className="text-green-400/80">{change.newValue ?? '—'}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-dark-500">
+              {totalElements} {totalElements === 1 ? 'entry' : 'entries'} · page {page + 1} of {Math.max(totalPages, 1)}
+            </span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPage(p => Math.max(0, p - 1))}
+                disabled={page === 0}
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <ChevronLeft className="w-4 h-4" /> Prev
+              </button>
+              <button
+                onClick={() => setPage(p => p + 1)}
+                disabled={page + 1 >= totalPages}
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Next <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function AuditActionBadge({ action }: { action: string }) {
+  const config: Record<string, { label: string; color: string; bg: string }> = {
+    CREATE: { label: 'Created', color: 'text-green-400', bg: 'bg-green-500/20' },
+    UPDATE: { label: 'Updated', color: 'text-blue-400', bg: 'bg-blue-500/20' },
+    DELETE: { label: 'Deleted', color: 'text-red-400', bg: 'bg-red-500/20' },
+    STATUS_CHANGE: { label: 'Status changed', color: 'text-amber-400', bg: 'bg-amber-500/20' },
+    NOTES_UPDATED: { label: 'Notes updated', color: 'text-hubble-400', bg: 'bg-hubble-500/20' },
+    CATERING_ARRANGED: { label: 'Catering', color: 'text-orange-400', bg: 'bg-orange-500/20' },
+    EMAIL_SENT: { label: 'Email sent', color: 'text-meteor-400', bg: 'bg-meteor-500/20' },
+    ROLE_CHANGED: { label: 'Role changed', color: 'text-red-400', bg: 'bg-red-500/20' },
+    TOGGLE: { label: 'Toggled', color: 'text-dark-300', bg: 'bg-dark-700' },
+  };
+  const { label, color, bg } = config[action] || { label: action, color: 'text-dark-300', bg: 'bg-dark-700' };
+  return <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${bg} ${color}`}>{label}</span>;
+}

--- a/the-harry-list-admin/src/pages/AuditLogPage.tsx
+++ b/the-harry-list-admin/src/pages/AuditLogPage.tsx
@@ -27,6 +27,8 @@ export function AuditLogPage() {
   const [entityType, setEntityType] = useState<AuditEntityType | ''>('');
   const [action, setAction] = useState<AuditAction | ''>('');
   const [actorEmail, setActorEmail] = useState('');
+  const [fromDate, setFromDate] = useState(''); // YYYY-MM-DD
+  const [toDate, setToDate] = useState('');     // YYYY-MM-DD
 
   // State is only set inside async callbacks (not synchronously in the effect body),
   // to satisfy the react-hooks/set-state-in-effect rule. `loading` starts true.
@@ -38,6 +40,9 @@ export function AuditLogPage() {
       entityType: entityType || undefined,
       action: action || undefined,
       actorEmail: actorEmail.trim() || undefined,
+      // Backend expects ISO date-times; widen the day bounds so the range is inclusive.
+      from: fromDate ? `${fromDate}T00:00:00` : undefined,
+      to: toDate ? `${toDate}T23:59:59` : undefined,
     })
       .then(result => {
         if (cancelled) return;
@@ -53,7 +58,7 @@ export function AuditLogPage() {
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [page, entityType, action, actorEmail]);
+  }, [page, entityType, action, actorEmail, fromDate, toDate]);
 
   // Changing a filter resets to the first page.
   const onFilterChange = <T,>(setter: (v: T) => void) => (value: T) => {
@@ -109,6 +114,28 @@ export function AuditLogPage() {
               value={actorEmail}
               onChange={e => onFilterChange(setActorEmail)(e.target.value)}
               placeholder="e.g. staff@example.com"
+              className="input-field"
+            />
+          </div>
+          <div className="form-group">
+            <label className="label" htmlFor="audit-from">From date</label>
+            <input
+              id="audit-from"
+              type="date"
+              value={fromDate}
+              max={toDate || undefined}
+              onChange={e => onFilterChange(setFromDate)(e.target.value)}
+              className="input-field"
+            />
+          </div>
+          <div className="form-group">
+            <label className="label" htmlFor="audit-to">To date</label>
+            <input
+              id="audit-to"
+              type="date"
+              value={toDate}
+              min={fromDate || undefined}
+              onChange={e => onFilterChange(setToDate)(e.target.value)}
               className="input-field"
             />
           </div>

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -1,17 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useMsal } from '@azure/msal-react';
 import {
   ArrowLeft, Calendar, Clock, MapPin, Users, Mail, Phone,
   Building2, CreditCard, UtensilsCrossed, MessageSquare,
   CheckCircle, XCircle, Loader2, AlertCircle, Trash2,
-  Send, Edit, X, FileText, Paperclip
+  Send, Edit, X, FileText, Paperclip, History
 } from 'lucide-react';
 import {
   fetchReservation, updateReservationStatus, deleteReservation, updateReservation,
-  updateCateringArranged, fetchEmailAttachments, fetchCateringEmailPreview, sendCateringEmail
+  updateCateringArranged, fetchEmailAttachments, fetchCateringEmailPreview, sendCateringEmail,
+  fetchReservationAuditLog
 } from '../lib/api';
 import type { Reservation, EmailAttachment } from '../types/reservation';
+import type { AuditLogEntry } from '../types/audit';
 import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { reservationDetailGuide } from '../lib/guideContent';
@@ -24,6 +26,8 @@ export function ReservationDetailPage() {
   const [reservation, setReservation] = useState<Reservation | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [auditLog, setAuditLog] = useState<AuditLogEntry[]>([]);
+  const [loadingAudit, setLoadingAudit] = useState(true);
   const [isUpdating, setIsUpdating] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
@@ -51,12 +55,28 @@ export function ReservationDetailPage() {
   const { canUpdateReservations } = usePermissions();
   const userName = accounts[0]?.name || 'Staff';
 
+  // Loading the audit history must never break the page — failures fall back to empty.
+  const loadAuditLog = useCallback(() => {
+    if (!id) return;
+    setLoadingAudit(true);
+    fetchReservationAuditLog(parseInt(id))
+      .then(setAuditLog)
+      .catch(() => setAuditLog([]))
+      .finally(() => setLoadingAudit(false));
+  }, [id]);
+
   useEffect(() => {
     if (!id) return;
     fetchReservation(parseInt(id))
       .then(data => setReservation(data))
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load reservation'))
       .finally(() => setIsLoading(false));
+    // Initial audit load — state is only set inside async callbacks (loadingAudit
+    // already starts true), so we don't call setState synchronously in the effect body.
+    fetchReservationAuditLog(parseInt(id))
+      .then(setAuditLog)
+      .catch(() => setAuditLog([]))
+      .finally(() => setLoadingAudit(false));
   }, [id]);
 
   const handleStatusChange = async (newStatus: string) => {
@@ -66,6 +86,7 @@ export function ReservationDetailPage() {
     try {
       await updateReservationStatus(reservation.id, newStatus, userName, sendEmail);
       setReservation({ ...reservation, status: newStatus });
+      loadAuditLog();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update status');
     } finally {
@@ -131,6 +152,7 @@ export function ReservationDetailPage() {
       setReservation(updatedReservation);
       setIsEditing(false);
       setEditData({});
+      loadAuditLog();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update reservation');
     } finally {
@@ -552,6 +574,7 @@ export function ReservationDetailPage() {
                     try {
                       const updated = await updateCateringArranged(reservation.id, newValue);
                       setReservation({ ...reservation, cateringArranged: updated.cateringArranged });
+                      loadAuditLog();
                     } catch (error) { console.error('Failed to update catering status:', error); }
                   }}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
@@ -606,6 +629,49 @@ export function ReservationDetailPage() {
           )}
         </div>
       )}
+
+      {/* Change History */}
+      <div className="card">
+        <h2 className="text-lg font-title font-semibold text-white mb-4 flex items-center gap-2">
+          <History className="w-5 h-5 text-hubble-400" />
+          Change History
+        </h2>
+        {loadingAudit ? (
+          <div className="flex items-center gap-2 text-dark-400 text-sm">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading history…
+          </div>
+        ) : auditLog.length === 0 ? (
+          <p className="text-sm text-dark-400">No changes recorded yet.</p>
+        ) : (
+          <ol className="space-y-4">
+            {auditLog.map((entry) => (
+              <li key={entry.id} className="border-l-2 border-dark-700 pl-4 relative">
+                <span className="absolute -left-[5px] top-1.5 w-2 h-2 rounded-full bg-hubble-400" />
+                <div className="flex items-center justify-between flex-wrap gap-1">
+                  <AuditActionBadge action={entry.action} />
+                  <time className="text-xs text-dark-500">{new Date(entry.createdAt).toLocaleString()}</time>
+                </div>
+                <div className="text-sm text-dark-300 mt-1">
+                  <span className="text-white">{entry.actorName || entry.actorEmail || 'system'}</span>
+                  {entry.summary && <span className="text-dark-400"> — {entry.summary}</span>}
+                </div>
+                {entry.changes.length > 0 && (
+                  <ul className="mt-2 space-y-1">
+                    {entry.changes.map((change, i) => (
+                      <li key={i} className="text-xs text-dark-400">
+                        <code className="text-dark-300">{change.field}</code>:{' '}
+                        <span className="line-through text-red-400/70">{change.oldValue ?? '—'}</span>
+                        {' → '}
+                        <span className="text-green-400/80">{change.newValue ?? '—'}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
 
       {/* Metadata */}
       <div className="text-sm text-dark-500 flex gap-6">
@@ -1096,6 +1162,20 @@ function InfoRow({ icon: Icon, label, value }: { icon?: typeof Users; label: str
       </div>
     </div>
   );
+}
+
+function AuditActionBadge({ action }: { action: string }) {
+  const config: Record<string, { label: string; color: string; bg: string }> = {
+    CREATE: { label: 'Created', color: 'text-green-400', bg: 'bg-green-500/20' },
+    UPDATE: { label: 'Updated', color: 'text-blue-400', bg: 'bg-blue-500/20' },
+    DELETE: { label: 'Deleted', color: 'text-red-400', bg: 'bg-red-500/20' },
+    STATUS_CHANGE: { label: 'Status changed', color: 'text-amber-400', bg: 'bg-amber-500/20' },
+    NOTES_UPDATED: { label: 'Notes updated', color: 'text-hubble-400', bg: 'bg-hubble-500/20' },
+    CATERING_ARRANGED: { label: 'Catering', color: 'text-orange-400', bg: 'bg-orange-500/20' },
+    EMAIL_SENT: { label: 'Email sent', color: 'text-meteor-400', bg: 'bg-meteor-500/20' },
+  };
+  const { label, color, bg } = config[action] || { label: action, color: 'text-dark-300', bg: 'bg-dark-700' };
+  return <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${bg} ${color}`}>{label}</span>;
 }
 
 function StatusBadge({ status, large }: { status: string; large?: boolean }) {

--- a/the-harry-list-admin/src/test/AuditLogPage.test.tsx
+++ b/the-harry-list-admin/src/test/AuditLogPage.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AuditLogPage } from '../pages/AuditLogPage';
+import type { AuditLogPageResponse } from '../types/audit';
+
+const { samplePage } = vi.hoisted(() => ({
+  samplePage: {
+    content: [
+      {
+        id: 10,
+        entityType: 'RESERVATION',
+        entityId: 1,
+        entityLabel: 'ABC123 - Birthday Party',
+        action: 'STATUS_CHANGE',
+        actorOid: 'oid-1',
+        actorEmail: 'staff@example.com',
+        actorName: 'Staff Member',
+        changes: [{ field: 'status', oldValue: 'PENDING', newValue: 'CONFIRMED' }],
+        summary: 'Status changed',
+        createdAt: '2026-06-01T12:00:00',
+      },
+    ],
+    page: 0,
+    size: 50,
+    totalElements: 1,
+    totalPages: 1,
+  } as AuditLogPageResponse,
+}));
+
+vi.mock('../lib/api', () => ({
+  fetchAuditLog: vi.fn().mockResolvedValue(samplePage),
+}));
+
+import { fetchAuditLog } from '../lib/api';
+
+const renderPage = () => render(<BrowserRouter><AuditLogPage /></BrowserRouter>);
+
+describe('AuditLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchAuditLog).mockResolvedValue(samplePage);
+  });
+
+  it('renders audit entries with action, entity label, actor and field diffs', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('ABC123 - Birthday Party')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    expect(screen.getByText('Status changed')).toBeInTheDocument();
+    expect(screen.getByText('Staff Member')).toBeInTheDocument();
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+    expect(screen.getByText('CONFIRMED')).toBeInTheDocument();
+  });
+
+  it('passes the selected entity type filter to the API and resets to page 0', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('ABC123 - Birthday Party')).toBeInTheDocument();
+    });
+
+    const entitySelect = screen.getByLabelText('Entity type');
+    fireEvent.change(entitySelect, { target: { value: 'ADMIN_USER' } });
+
+    await waitFor(() => {
+      expect(fetchAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'ADMIN_USER', page: 0 })
+      );
+    });
+  });
+
+  it('shows an empty state when there are no entries', async () => {
+    vi.mocked(fetchAuditLog).mockResolvedValueOnce({
+      content: [], page: 0, size: 50, totalElements: 0, totalPages: 0,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No audit entries match your filters.')).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+});

--- a/the-harry-list-admin/src/test/AuditLogPage.test.tsx
+++ b/the-harry-list-admin/src/test/AuditLogPage.test.tsx
@@ -73,6 +73,27 @@ describe('AuditLogPage', () => {
     });
   });
 
+  it('passes the selected date range to the API as inclusive ISO bounds', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('ABC123 - Birthday Party')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2026-06-01' } });
+    fireEvent.change(screen.getByLabelText('To date'), { target: { value: '2026-06-30' } });
+
+    await waitFor(() => {
+      expect(fetchAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: '2026-06-01T00:00:00',
+          to: '2026-06-30T23:59:59',
+          page: 0,
+        })
+      );
+    });
+  });
+
   it('shows an empty state when there are no entries', async () => {
     vi.mocked(fetchAuditLog).mockResolvedValueOnce({
       content: [], page: 0, size: 50, totalElements: 0, totalPages: 0,

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ReservationDetailPage } from '../pages/ReservationDetailPage';
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: () => ({ accounts: [{ name: 'Staff Member' }] }),
+}));
+
+vi.mock('../lib/usePermissions', () => ({
+  usePermissions: () => ({ canUpdateReservations: true }),
+}));
+
+const { sampleReservation, sampleAuditLog } = vi.hoisted(() => ({
+  sampleReservation: {
+    id: 1,
+    eventTitle: 'Birthday Party',
+    contactName: 'John Doe',
+    email: 'john@example.com',
+    status: 'CONFIRMED',
+    eventDate: '2026-07-01',
+    startTime: '14:00:00',
+    endTime: '17:00:00',
+    location: 'HUBBLE',
+    expectedGuests: 25,
+    confirmationNumber: 'ABC123',
+    seatingArea: 'INSIDE',
+    paymentOption: 'INDIVIDUAL',
+    specialActivities: [],
+  },
+  sampleAuditLog: [
+    {
+      id: 10,
+      entityType: 'RESERVATION',
+      entityId: 1,
+      entityLabel: 'ABC123 - Birthday Party',
+      action: 'STATUS_CHANGE',
+      actorOid: 'oid-1',
+      actorEmail: 'staff@example.com',
+      actorName: 'Staff Member',
+      changes: [{ field: 'status', oldValue: 'PENDING', newValue: 'CONFIRMED' }],
+      summary: 'Status changed',
+      createdAt: '2026-06-01T12:00:00',
+    },
+  ],
+}));
+
+vi.mock('../lib/api', () => ({
+  fetchReservation: vi.fn().mockResolvedValue(sampleReservation),
+  fetchReservationAuditLog: vi.fn().mockResolvedValue(sampleAuditLog),
+  updateReservationStatus: vi.fn(),
+  deleteReservation: vi.fn(),
+  updateReservation: vi.fn(),
+  updateCateringArranged: vi.fn(),
+  fetchEmailAttachments: vi.fn().mockResolvedValue([]),
+  fetchCateringEmailPreview: vi.fn(),
+  sendCateringEmail: vi.fn(),
+}));
+
+import { fetchReservationAuditLog } from '../lib/api';
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/reservations/1']}>
+      <Routes>
+        <Route path="/reservations/:id" element={<ReservationDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('ReservationDetailPage — change history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the change history with actor, action and field diffs', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Change History')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    expect(screen.getByText('Status changed')).toBeInTheDocument();
+    expect(screen.getByText('Staff Member')).toBeInTheDocument();
+    // Field-level diff: status PENDING -> CONFIRMED
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('PENDING')).toBeInTheDocument();
+    // CONFIRMED also appears in the status badge, so assert at least one occurrence (the diff).
+    expect(screen.getAllByText('CONFIRMED').length).toBeGreaterThan(0);
+  });
+
+  it('shows an empty state and never crashes when the audit log fails to load', async () => {
+    vi.mocked(fetchReservationAuditLog).mockRejectedValueOnce(new Error('boom'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('No changes recorded yet.')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    // The rest of the page still renders.
+    expect(screen.getByText('Birthday Party')).toBeInTheDocument();
+  });
+});

--- a/the-harry-list-admin/src/types/audit.ts
+++ b/the-harry-list-admin/src/types/audit.ts
@@ -1,0 +1,60 @@
+// Audit log types — mirror the backend AuditLogResponse / FieldChange DTOs.
+
+export interface FieldChange {
+  field: string;
+  oldValue: string | null;
+  newValue: string | null;
+}
+
+export type AuditAction =
+  | 'CREATE'
+  | 'UPDATE'
+  | 'DELETE'
+  | 'STATUS_CHANGE'
+  | 'NOTES_UPDATED'
+  | 'CATERING_ARRANGED'
+  | 'EMAIL_SENT'
+  | 'ROLE_CHANGED'
+  | 'TOGGLE';
+
+export type AuditEntityType =
+  | 'RESERVATION'
+  | 'BLOCKED_PERIOD'
+  | 'CALENDAR_APPOINTMENT'
+  | 'EMAIL_TEMPLATE'
+  | 'EMAIL_ATTACHMENT'
+  | 'FORM_CONSTRAINT'
+  | 'ADMIN_USER';
+
+export interface AuditLogEntry {
+  id: number;
+  entityType: AuditEntityType;
+  entityId: number | null;
+  entityLabel: string | null;
+  action: AuditAction;
+  actorOid: string | null;
+  actorEmail: string | null;
+  actorName: string | null;
+  changes: FieldChange[];
+  summary: string | null;
+  createdAt: string;
+}
+
+export interface AuditLogPageResponse {
+  content: AuditLogEntry[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface AuditLogFilters {
+  entityType?: AuditEntityType;
+  entityId?: number;
+  actorEmail?: string;
+  action?: AuditAction;
+  from?: string;
+  to?: string;
+  page?: number;
+  size?: number;
+}

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.2.3</version>
+	<version>1.3.0</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
@@ -1,7 +1,12 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.BlockedPeriod;
 import com.pimvanleeuwen.the_harry_list_backend.repository.BlockedPeriodRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditDiff;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -17,9 +22,15 @@ import java.util.Map;
 public class AdminBlockedPeriodController {
 
     private final BlockedPeriodRepository repository;
+    private final AuditService auditService;
 
-    public AdminBlockedPeriodController(BlockedPeriodRepository repository) {
+    public AdminBlockedPeriodController(BlockedPeriodRepository repository, AuditService auditService) {
         this.repository = repository;
+        this.auditService = auditService;
+    }
+
+    private static String label(BlockedPeriod p) {
+        return "Blocked period: " + p.getReason();
     }
 
     @GetMapping
@@ -41,6 +52,8 @@ public class AdminBlockedPeriodController {
     @Operation(summary = "Create a new blocked period")
     public ResponseEntity<BlockedPeriod> create(@RequestBody BlockedPeriod period) {
         BlockedPeriod saved = repository.save(period);
+        auditService.recordCreate(AuditEntityType.BLOCKED_PERIOD, saved.getId(), label(saved),
+                List.of(), "Blocked period created");
         return ResponseEntity.status(201).body(saved);
     }
 
@@ -50,6 +63,8 @@ public class AdminBlockedPeriodController {
     public ResponseEntity<BlockedPeriod> update(@PathVariable Long id, @RequestBody BlockedPeriod period) {
         return repository.findById(id)
                 .map(existing -> {
+                    // Diff incoming vs current before mutating the managed instance.
+                    List<FieldChange> diffs = AuditDiff.compare(existing, period);
                     existing.setLocation(period.getLocation());
                     existing.setStartDate(period.getStartDate());
                     existing.setEndDate(period.getEndDate());
@@ -58,7 +73,10 @@ public class AdminBlockedPeriodController {
                     existing.setReason(period.getReason());
                     existing.setPublicMessage(period.getPublicMessage());
                     existing.setEnabled(period.getEnabled());
-                    return ResponseEntity.ok(repository.save(existing));
+                    BlockedPeriod saved = repository.save(existing);
+                    auditService.recordUpdate(AuditEntityType.BLOCKED_PERIOD, saved.getId(), label(saved),
+                            diffs, "Blocked period updated");
+                    return ResponseEntity.ok(saved);
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -69,8 +87,14 @@ public class AdminBlockedPeriodController {
     public ResponseEntity<BlockedPeriod> toggle(@PathVariable Long id) {
         return repository.findById(id)
                 .map(existing -> {
+                    boolean previous = Boolean.TRUE.equals(existing.getEnabled());
                     existing.setEnabled(!existing.getEnabled());
-                    return ResponseEntity.ok(repository.save(existing));
+                    BlockedPeriod saved = repository.save(existing);
+                    auditService.recordAction(AuditEntityType.BLOCKED_PERIOD, saved.getId(), label(saved),
+                            AuditAction.TOGGLE,
+                            List.of(new FieldChange("enabled", String.valueOf(previous), String.valueOf(saved.getEnabled()))),
+                            "Blocked period " + (saved.getEnabled() ? "enabled" : "disabled"));
+                    return ResponseEntity.ok(saved);
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -79,10 +103,13 @@ public class AdminBlockedPeriodController {
     @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Delete a blocked period")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
-        if (!repository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        repository.deleteById(id);
-        return ResponseEntity.ok(Map.of("status", "deleted"));
+        return repository.findById(id)
+                .map(existing -> {
+                    repository.delete(existing);
+                    auditService.recordDelete(AuditEntityType.BLOCKED_PERIOD, id, label(existing),
+                            "Blocked period deleted");
+                    return ResponseEntity.ok(Map.of("status", "deleted"));
+                })
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
@@ -1,7 +1,12 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
 import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditDiff;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,9 +24,15 @@ import java.util.Map;
 public class AdminCalendarAppointmentController {
 
     private final CalendarAppointmentRepository repository;
+    private final AuditService auditService;
 
-    public AdminCalendarAppointmentController(CalendarAppointmentRepository repository) {
+    public AdminCalendarAppointmentController(CalendarAppointmentRepository repository, AuditService auditService) {
         this.repository = repository;
+        this.auditService = auditService;
+    }
+
+    private static String label(CalendarAppointment a) {
+        return "Appointment: " + a.getTitle();
     }
 
     @GetMapping
@@ -43,6 +54,8 @@ public class AdminCalendarAppointmentController {
     @Operation(summary = "Create a new calendar appointment")
     public ResponseEntity<CalendarAppointment> create(@RequestBody CalendarAppointment appointment) {
         CalendarAppointment saved = repository.save(appointment);
+        auditService.recordCreate(AuditEntityType.CALENDAR_APPOINTMENT, saved.getId(), label(saved),
+                List.of(), "Appointment created");
         return ResponseEntity.status(201).body(saved);
     }
 
@@ -52,6 +65,7 @@ public class AdminCalendarAppointmentController {
     public ResponseEntity<CalendarAppointment> update(@PathVariable Long id, @RequestBody CalendarAppointment appointment) {
         return repository.findById(id)
                 .map(existing -> {
+                    List<FieldChange> diffs = AuditDiff.compare(existing, appointment);
                     existing.setTitle(appointment.getTitle());
                     existing.setDescription(appointment.getDescription());
                     existing.setDate(appointment.getDate());
@@ -62,7 +76,10 @@ public class AdminCalendarAppointmentController {
                     existing.setRecurrenceType(appointment.getRecurrenceType());
                     existing.setRecurrenceEndDate(appointment.getRecurrenceEndDate());
                     existing.setEnabled(appointment.getEnabled());
-                    return ResponseEntity.ok(repository.save(existing));
+                    CalendarAppointment saved = repository.save(existing);
+                    auditService.recordUpdate(AuditEntityType.CALENDAR_APPOINTMENT, saved.getId(), label(saved),
+                            diffs, "Appointment updated");
+                    return ResponseEntity.ok(saved);
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -73,8 +90,14 @@ public class AdminCalendarAppointmentController {
     public ResponseEntity<CalendarAppointment> toggle(@PathVariable Long id) {
         return repository.findById(id)
                 .map(existing -> {
+                    boolean previous = Boolean.TRUE.equals(existing.getEnabled());
                     existing.setEnabled(!existing.getEnabled());
-                    return ResponseEntity.ok(repository.save(existing));
+                    CalendarAppointment saved = repository.save(existing);
+                    auditService.recordAction(AuditEntityType.CALENDAR_APPOINTMENT, saved.getId(), label(saved),
+                            AuditAction.TOGGLE,
+                            List.of(new FieldChange("enabled", String.valueOf(previous), String.valueOf(saved.getEnabled()))),
+                            "Appointment " + (saved.getEnabled() ? "enabled" : "disabled"));
+                    return ResponseEntity.ok(saved);
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -83,10 +106,13 @@ public class AdminCalendarAppointmentController {
     @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Delete a calendar appointment")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
-        if (!repository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        repository.deleteById(id);
-        return ResponseEntity.ok(Map.of("status", "deleted"));
+        return repository.findById(id)
+                .map(existing -> {
+                    repository.delete(existing);
+                    auditService.recordDelete(AuditEntityType.CALENDAR_APPOINTMENT, id, label(existing),
+                            "Appointment deleted");
+                    return ResponseEntity.ok(Map.of("status", "deleted"));
+                })
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentController.java
@@ -1,8 +1,12 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
 import com.pimvanleeuwen.the_harry_list_backend.dto.EmailAttachmentDto;
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailAttachment;
 import com.pimvanleeuwen.the_harry_list_backend.repository.EmailAttachmentRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,9 +31,11 @@ public class AdminEmailAttachmentController {
     private static final long MAX_FILE_SIZE = 3 * 1024 * 1024; // 3MB (Graph API inline attachment limit)
 
     private final EmailAttachmentRepository repository;
+    private final AuditService auditService;
 
-    public AdminEmailAttachmentController(EmailAttachmentRepository repository) {
+    public AdminEmailAttachmentController(EmailAttachmentRepository repository, AuditService auditService) {
         this.repository = repository;
+        this.auditService = auditService;
     }
 
     @GetMapping
@@ -72,6 +78,9 @@ public class AdminEmailAttachmentController {
 
             EmailAttachment saved = repository.save(attachment);
             log.info("Uploaded email attachment: id={} name='{}' filename='{}'", saved.getId(), saved.getName(), saved.getFilename());
+            auditService.recordCreate(AuditEntityType.EMAIL_ATTACHMENT, saved.getId(),
+                    "Attachment: " + saved.getName(), List.of(),
+                    "Attachment uploaded (" + saved.getFilename() + ")");
             return ResponseEntity.ok(EmailAttachmentDto.fromEntity(saved));
         } catch (IOException e) {
             log.error("Failed to read uploaded file", e);
@@ -83,12 +92,15 @@ public class AdminEmailAttachmentController {
     @PreAuthorize("hasRole('EDITOR')")
     @Operation(summary = "Delete an attachment", description = "Permanently delete an email attachment")
     public ResponseEntity<Void> deleteAttachment(@PathVariable Long id) {
-        if (!repository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        repository.deleteById(id);
-        log.info("Deleted email attachment: id={}", id);
-        return ResponseEntity.ok().build();
+        return repository.findById(id)
+                .map(attachment -> {
+                    repository.delete(attachment);
+                    log.info("Deleted email attachment: id={}", id);
+                    auditService.recordDelete(AuditEntityType.EMAIL_ATTACHMENT, id,
+                            "Attachment: " + attachment.getName(), "Attachment deleted");
+                    return ResponseEntity.ok().<Void>build();
+                })
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @PatchMapping("/{id}/active")
@@ -97,9 +109,14 @@ public class AdminEmailAttachmentController {
     public ResponseEntity<?> toggleActive(@PathVariable Long id, @RequestParam boolean active) {
         return repository.findById(id)
                 .map(attachment -> {
+                    boolean previous = attachment.isActive();
                     attachment.setActive(active);
                     EmailAttachment saved = repository.save(attachment);
                     log.info("Toggled email attachment active: id={} active={}", id, active);
+                    auditService.recordAction(AuditEntityType.EMAIL_ATTACHMENT, id,
+                            "Attachment: " + saved.getName(), AuditAction.TOGGLE,
+                            List.of(new FieldChange("active", String.valueOf(previous), String.valueOf(active))),
+                            "Attachment " + (active ? "activated" : "deactivated"));
                     return ResponseEntity.ok(EmailAttachmentDto.fromEntity(saved));
                 })
                 .orElse(ResponseEntity.notFound().build());

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
@@ -3,7 +3,9 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 import com.pimvanleeuwen.the_harry_list_backend.dto.EmailTemplateDto;
 import com.pimvanleeuwen.the_harry_list_backend.dto.TestEmailRequest;
 import com.pimvanleeuwen.the_harry_list_backend.dto.UpdateEmailTemplateRequest;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailTemplateType;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,12 +26,15 @@ public class AdminEmailTemplateController {
 
     private final EmailTemplateService emailTemplateService;
     private final Optional<EmailNotificationService> emailNotificationService;
+    private final AuditService auditService;
 
     public AdminEmailTemplateController(
             EmailTemplateService emailTemplateService,
-            Optional<EmailNotificationService> emailNotificationService) {
+            Optional<EmailNotificationService> emailNotificationService,
+            AuditService auditService) {
         this.emailTemplateService = emailTemplateService;
         this.emailNotificationService = emailNotificationService;
+        this.auditService = auditService;
     }
 
     @GetMapping
@@ -53,6 +58,9 @@ public class AdminEmailTemplateController {
             @PathVariable EmailTemplateType type,
             @Valid @RequestBody UpdateEmailTemplateRequest request) {
         EmailTemplateDto updated = emailTemplateService.update(type, request.getSubject(), request.getBodyTemplate());
+        auditService.recordAction(AuditEntityType.EMAIL_TEMPLATE, null, "Email template: " + type,
+                com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.UPDATE,
+                List.of(), "Email template '" + type + "' saved");
         return ResponseEntity.ok(updated);
     }
 
@@ -61,6 +69,9 @@ public class AdminEmailTemplateController {
     @Operation(summary = "Reset template to default", description = "Removes any custom template, reverting to the built-in default.")
     public ResponseEntity<Void> reset(@PathVariable EmailTemplateType type) {
         emailTemplateService.reset(type);
+        auditService.recordAction(AuditEntityType.EMAIL_TEMPLATE, null, "Email template: " + type,
+                com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.UPDATE,
+                List.of(), "Email template '" + type + "' reset to default");
         return ResponseEntity.noContent().build();
     }
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintController.java
@@ -1,7 +1,12 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.FormConstraint;
 import com.pimvanleeuwen.the_harry_list_backend.repository.FormConstraintRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditDiff;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -17,9 +22,15 @@ import java.util.Map;
 public class AdminFormConstraintController {
 
     private final FormConstraintRepository repository;
+    private final AuditService auditService;
 
-    public AdminFormConstraintController(FormConstraintRepository repository) {
+    public AdminFormConstraintController(FormConstraintRepository repository, AuditService auditService) {
         this.repository = repository;
+        this.auditService = auditService;
+    }
+
+    private static String label(FormConstraint c) {
+        return "Form constraint: " + c.getConstraintType();
     }
 
     @GetMapping
@@ -41,6 +52,8 @@ public class AdminFormConstraintController {
     @Operation(summary = "Create a new form constraint")
     public ResponseEntity<FormConstraint> create(@RequestBody FormConstraint constraint) {
         FormConstraint saved = repository.save(constraint);
+        auditService.recordCreate(AuditEntityType.FORM_CONSTRAINT, saved.getId(), label(saved),
+                List.of(), "Form constraint created");
         return ResponseEntity.status(201).body(saved);
     }
 
@@ -50,6 +63,7 @@ public class AdminFormConstraintController {
     public ResponseEntity<FormConstraint> update(@PathVariable Long id, @RequestBody FormConstraint constraint) {
         return repository.findById(id)
                 .map(existing -> {
+                    List<FieldChange> diffs = AuditDiff.compare(existing, constraint);
                     existing.setConstraintType(constraint.getConstraintType());
                     existing.setTriggerActivity(constraint.getTriggerActivity());
                     existing.setTargetValue(constraint.getTargetValue());
@@ -57,7 +71,10 @@ public class AdminFormConstraintController {
                     existing.setSecondaryValue(constraint.getSecondaryValue());
                     existing.setMessage(constraint.getMessage());
                     existing.setEnabled(constraint.getEnabled());
-                    return ResponseEntity.ok(repository.save(existing));
+                    FormConstraint saved = repository.save(existing);
+                    auditService.recordUpdate(AuditEntityType.FORM_CONSTRAINT, saved.getId(), label(saved),
+                            diffs, "Form constraint updated");
+                    return ResponseEntity.ok(saved);
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -68,8 +85,14 @@ public class AdminFormConstraintController {
     public ResponseEntity<FormConstraint> toggle(@PathVariable Long id) {
         return repository.findById(id)
                 .map(existing -> {
+                    boolean previous = Boolean.TRUE.equals(existing.getEnabled());
                     existing.setEnabled(!existing.getEnabled());
-                    return ResponseEntity.ok(repository.save(existing));
+                    FormConstraint saved = repository.save(existing);
+                    auditService.recordAction(AuditEntityType.FORM_CONSTRAINT, saved.getId(), label(saved),
+                            AuditAction.TOGGLE,
+                            List.of(new FieldChange("enabled", String.valueOf(previous), String.valueOf(saved.getEnabled()))),
+                            "Form constraint " + (saved.getEnabled() ? "enabled" : "disabled"));
+                    return ResponseEntity.ok(saved);
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -78,10 +101,13 @@ public class AdminFormConstraintController {
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete a form constraint")
     public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
-        if (!repository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        repository.deleteById(id);
-        return ResponseEntity.ok(Map.of("status", "deleted"));
+        return repository.findById(id)
+                .map(existing -> {
+                    repository.delete(existing);
+                    auditService.recordDelete(AuditEntityType.FORM_CONSTRAINT, id, label(existing),
+                            "Form constraint deleted");
+                    return ResponseEntity.ok(Map.of("status", "deleted"));
+                })
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -1,13 +1,17 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
 import com.pimvanleeuwen.the_harry_list_backend.dto.CateringEmailRequest;
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
 import com.pimvanleeuwen.the_harry_list_backend.dto.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailAttachment;
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailTemplateType;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.repository.EmailAttachmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailTemplateService;
 import com.pimvanleeuwen.the_harry_list_backend.service.ReservationMapper;
@@ -46,6 +50,7 @@ public class AdminReservationController {
     private final ReservationMapper reservationMapper;
     private final EmailTemplateService emailTemplateService;
     private final EmailAttachmentRepository emailAttachmentRepository;
+    private final AuditService auditService;
     private final String barName;
     private final String staffEmail;
 
@@ -56,14 +61,20 @@ public class AdminReservationController {
                                       ReservationMapper reservationMapper,
                                       EmailTemplateService emailTemplateService,
                                       EmailAttachmentRepository emailAttachmentRepository,
+                                      AuditService auditService,
                                       @Value("${app.bar.name:Hubble and Meteor Community Cafes}") String barName,
                                       @Value("${app.mail.staff:events@hubble.cafe}") String staffEmail) {
         this.reservationRepository = reservationRepository;
         this.reservationMapper = reservationMapper;
         this.emailTemplateService = emailTemplateService;
         this.emailAttachmentRepository = emailAttachmentRepository;
+        this.auditService = auditService;
         this.barName = barName;
         this.staffEmail = staffEmail;
+    }
+
+    private static String label(com.pimvanleeuwen.the_harry_list_backend.model.Reservation r) {
+        return r.getConfirmationNumber() + " - " + r.getEventTitle();
     }
 
     @PatchMapping("/{id}/status")
@@ -97,6 +108,11 @@ public class AdminReservationController {
                             oldStatus, status, principal != null ? principal.getName() : "unknown",
                             confirmedBy != null ? " confirmedBy='" + confirmedBy + "'" : "");
 
+                    auditService.recordAction(AuditEntityType.RESERVATION, id, label(saved),
+                            AuditAction.STATUS_CHANGE,
+                            List.of(new FieldChange("status", String.valueOf(oldStatus), String.valueOf(status))),
+                            "Status changed" + (confirmedBy != null ? " (confirmed by " + confirmedBy + ")" : ""));
+
                     // Send email notification if enabled
                     if (sendEmail && emailService != null) {
                         try {
@@ -124,8 +140,15 @@ public class AdminReservationController {
 
         return reservationRepository.findById(id)
                 .map(reservation -> {
+                    boolean previous = reservation.isCateringArranged();
                     reservation.setCateringArranged(arranged);
                     com.pimvanleeuwen.the_harry_list_backend.model.Reservation saved = reservationRepository.save(reservation);
+
+                    auditService.recordAction(AuditEntityType.RESERVATION, id, label(saved),
+                            AuditAction.CATERING_ARRANGED,
+                            List.of(new FieldChange("cateringArranged", String.valueOf(previous), String.valueOf(arranged))),
+                            arranged ? "Catering marked as arranged" : "Catering arranged unset");
+
                     return ResponseEntity.ok(reservationMapper.toDto(saved));
                 })
                 .orElse(ResponseEntity.notFound().build());
@@ -146,6 +169,11 @@ public class AdminReservationController {
                 .map(reservation -> {
                     reservation.setInternalNotes(notes);
                     com.pimvanleeuwen.the_harry_list_backend.model.Reservation saved = reservationRepository.save(reservation);
+
+                    // Note content is intentionally not stored in the audit log (may be long/sensitive).
+                    auditService.recordAction(AuditEntityType.RESERVATION, id, label(saved),
+                            AuditAction.NOTES_UPDATED, List.of(), "Internal notes updated");
+
                     return ResponseEntity.ok(reservationMapper.toDto(saved));
                 })
                 .orElse(ResponseEntity.notFound().build());
@@ -170,6 +198,9 @@ public class AdminReservationController {
                     if (emailService != null) {
                         try {
                             emailService.sendCustomEmail(reservation, subject, message);
+                            auditService.recordAction(AuditEntityType.RESERVATION, id, label(reservation),
+                                    AuditAction.EMAIL_SENT, List.of(),
+                                    "Custom email sent" + (subject != null ? ": " + subject : ""));
                             return ResponseEntity.ok(Map.of("status", "sent", "message", "Email sent successfully"));
                         } catch (Exception e) {
                             log.error("Failed to send custom email", e);
@@ -235,6 +266,10 @@ public class AdminReservationController {
                         log.info("AUDIT email.catering_delivered confirmation='{}' to='{}' attachments={} user='{}'",
                                 reservation.getConfirmationNumber(), reservation.getEmail(), attachments.size(),
                                 principal != null ? principal.getName() : "unknown");
+
+                        auditService.recordAction(AuditEntityType.RESERVATION, id, label(reservation),
+                                AuditAction.EMAIL_SENT, List.of(),
+                                "Catering email sent (" + attachments.size() + " attachment(s))");
 
                         return ResponseEntity.ok(Map.of("status", "sent", "message", "Catering email sent successfully"));
                     } catch (Exception e) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminUserController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminUserController.java
@@ -3,6 +3,7 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
 import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import com.pimvanleeuwen.the_harry_list_backend.util.AuditActorResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -72,8 +73,7 @@ public class AdminUserController {
 
     private String extractOid(Authentication auth) {
         if (auth instanceof JwtAuthenticationToken jwtAuth) {
-            String oid = jwtAuth.getToken().getClaimAsString("oid");
-            return oid != null ? oid : jwtAuth.getToken().getSubject();
+            return AuditActorResolver.extractOid(jwtAuth.getToken());
         }
         return auth.getName();
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AuditLogController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AuditLogController.java
@@ -1,0 +1,123 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pimvanleeuwen.the_harry_list_backend.dto.AuditLogResponse;
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditLog;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.criteria.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read-only API over the audit log.
+ *
+ * <ul>
+ *   <li>The global, filterable log is ADMIN-only (it spans all entities and actors).</li>
+ *   <li>The per-reservation history is available to any authenticated viewer.</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/admin/audit")
+@Tag(name = "Admin - Audit Log", description = "Read-only audit trail of changes (login required)")
+@SecurityRequirement(name = "basicAuth")
+public class AuditLogController {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogController.class);
+
+    private final AuditLogRepository auditLogRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AuditLogController(AuditLogRepository auditLogRepository) {
+        this.auditLogRepository = auditLogRepository;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List audit entries", description = "Paged, filterable audit trail across all entities (admin only)")
+    public ResponseEntity<Map<String, Object>> getAuditLog(
+            @RequestParam(required = false) AuditEntityType entityType,
+            @RequestParam(required = false) Long entityId,
+            @RequestParam(required = false) String actorEmail,
+            @RequestParam(required = false) AuditAction action,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+
+        Specification<AuditLog> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (entityType != null) predicates.add(cb.equal(root.get("entityType"), entityType));
+            if (entityId != null) predicates.add(cb.equal(root.get("entityId"), entityId));
+            if (action != null) predicates.add(cb.equal(root.get("action"), action));
+            if (actorEmail != null && !actorEmail.isBlank()) {
+                predicates.add(cb.like(cb.lower(root.get("actorEmail")), "%" + actorEmail.toLowerCase() + "%"));
+            }
+            if (from != null) predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), from));
+            if (to != null) predicates.add(cb.lessThanOrEqualTo(root.get("createdAt"), to));
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        Page<AuditLog> result = auditLogRepository.findAll(spec,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+
+        List<AuditLogResponse> content = result.getContent().stream().map(this::toResponse).toList();
+
+        Map<String, Object> body = Map.of(
+                "content", content,
+                "page", result.getNumber(),
+                "size", result.getSize(),
+                "totalElements", result.getTotalElements(),
+                "totalPages", result.getTotalPages()
+        );
+        return ResponseEntity.ok(body);
+    }
+
+    @GetMapping("/reservation/{id}")
+    @PreAuthorize("hasRole('VIEWER')")
+    @Operation(summary = "Reservation history", description = "Audit entries for a single reservation, newest first")
+    public ResponseEntity<List<AuditLogResponse>> getReservationHistory(@PathVariable Long id) {
+        List<AuditLogResponse> entries = auditLogRepository
+                .findByEntityTypeAndEntityIdOrderByCreatedAtDesc(AuditEntityType.RESERVATION, id)
+                .stream().map(this::toResponse).toList();
+        return ResponseEntity.ok(entries);
+    }
+
+    private AuditLogResponse toResponse(AuditLog entry) {
+        return new AuditLogResponse(
+                entry.getId(), entry.getEntityType(), entry.getEntityId(), entry.getEntityLabel(),
+                entry.getAction(), entry.getActorOid(), entry.getActorEmail(), entry.getActorName(),
+                parseChanges(entry.getChanges()), entry.getSummary(), entry.getCreatedAt());
+    }
+
+    private List<FieldChange> parseChanges(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<FieldChange>>() {});
+        } catch (Exception e) {
+            log.warn("Failed to parse audit changes JSON: {}", json, e);
+            return List.of();
+        }
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/dto/AuditLogResponse.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/dto/AuditLogResponse.java
@@ -1,0 +1,26 @@
+package com.pimvanleeuwen.the_harry_list_backend.dto;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * API representation of an audit entry, with {@code changes} parsed from its
+ * stored JSON form into a typed list.
+ */
+public record AuditLogResponse(
+        Long id,
+        AuditEntityType entityType,
+        Long entityId,
+        String entityLabel,
+        AuditAction action,
+        String actorOid,
+        String actorEmail,
+        String actorName,
+        List<FieldChange> changes,
+        String summary,
+        LocalDateTime createdAt
+) {
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/dto/FieldChange.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/dto/FieldChange.java
@@ -1,0 +1,10 @@
+package com.pimvanleeuwen.the_harry_list_backend.dto;
+
+/**
+ * A single field-level change captured in an audit entry: the (display-friendly)
+ * field name plus its old and new values rendered as strings.
+ *
+ * <p>Serialized as a JSON array into the {@code audit_log.changes} column.
+ */
+public record FieldChange(String field, String oldValue, String newValue) {
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/filter/RoleAuthorizationFilter.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/filter/RoleAuthorizationFilter.java
@@ -3,6 +3,7 @@ package com.pimvanleeuwen.the_harry_list_backend.filter;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
 import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import com.pimvanleeuwen.the_harry_list_backend.util.AuditActorResolver;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -50,9 +51,10 @@ public class RoleAuthorizationFilter extends OncePerRequestFilter {
         if (auth instanceof JwtAuthenticationToken jwtAuth) {
             Jwt jwt = jwtAuth.getToken();
 
-            String oid = extractOid(jwt);
-            String email = extractEmail(jwt);
-            String name = extractName(jwt);
+            String oid = AuditActorResolver.extractOid(jwt);
+            String email = AuditActorResolver.extractEmail(jwt);
+            if (email == null) email = "unknown";
+            String name = AuditActorResolver.extractName(jwt);
 
             if (oid != null) {
                 AdminUser user = adminUserService.getOrCreateUser(oid, email, name);
@@ -83,21 +85,4 @@ public class RoleAuthorizationFilter extends OncePerRequestFilter {
         return authorities;
     }
 
-    private String extractOid(Jwt jwt) {
-        // Azure AD v2.0 tokens use "oid" claim, v1.0 uses "sub"
-        String oid = jwt.getClaimAsString("oid");
-        return oid != null ? oid : jwt.getSubject();
-    }
-
-    private String extractEmail(Jwt jwt) {
-        // Azure AD tokens may use "preferred_username", "email", or "upn"
-        String email = jwt.getClaimAsString("preferred_username");
-        if (email == null) email = jwt.getClaimAsString("email");
-        if (email == null) email = jwt.getClaimAsString("upn");
-        return email != null ? email : "unknown";
-    }
-
-    private String extractName(Jwt jwt) {
-        return jwt.getClaimAsString("name");
-    }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditAction.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditAction.java
@@ -1,0 +1,17 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+/**
+ * The kind of change captured by an {@link AuditLog} entry.
+ * Extensible: add new actions as more mutation points are audited.
+ */
+public enum AuditAction {
+    CREATE,
+    UPDATE,
+    DELETE,
+    STATUS_CHANGE,
+    NOTES_UPDATED,
+    CATERING_ARRANGED,
+    EMAIL_SENT,
+    ROLE_CHANGED,
+    TOGGLE
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditEntityType.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditEntityType.java
@@ -1,0 +1,14 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+/**
+ * The type of entity an {@link AuditLog} entry refers to.
+ */
+public enum AuditEntityType {
+    RESERVATION,
+    BLOCKED_PERIOD,
+    CALENDAR_APPOINTMENT,
+    EMAIL_TEMPLATE,
+    EMAIL_ATTACHMENT,
+    FORM_CONSTRAINT,
+    ADMIN_USER
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditLog.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditLog.java
@@ -1,0 +1,77 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * A persistent, queryable record of a single change made to an audited entity.
+ *
+ * <p>Each row captures <em>who</em> changed <em>what</em>, <em>when</em>, including
+ * field-level diffs (stored as a JSON array in {@link #changes}). The
+ * {@link #entityLabel} keeps the entry human-readable even after the referenced
+ * entity has been deleted.
+ */
+@Data
+@Entity
+@Table(name = "audit_log", indexes = {
+        @Index(name = "idx_audit_entity", columnList = "entity_type, entity_id"),
+        @Index(name = "idx_audit_created_at", columnList = "created_at")
+})
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    /** The type of entity that was changed (e.g. RESERVATION). */
+    @Column(name = "entity_type", nullable = false, length = 40)
+    @Enumerated(EnumType.STRING)
+    private AuditEntityType entityType;
+
+    /** The id of the changed entity (nullable: the entity may since have been deleted). */
+    @Column(name = "entity_id")
+    private Long entityId;
+
+    /** Human-friendly label so the entry stays readable after the entity is gone. */
+    @Column(name = "entity_label", length = 255)
+    private String entityLabel;
+
+    /** What kind of change this was. */
+    @Column(name = "action", nullable = false, length = 30)
+    @Enumerated(EnumType.STRING)
+    private AuditAction action;
+
+    /** Azure object id of the actor, if available. */
+    @Column(name = "actor_oid", length = 255)
+    private String actorOid;
+
+    /** Email of the actor, if available. */
+    @Column(name = "actor_email", length = 255)
+    private String actorEmail;
+
+    /** Display name of the actor (or "system"/"public submission" for non-user actions). */
+    @Column(name = "actor_name", length = 255)
+    private String actorName;
+
+    /** JSON array of {@link com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange}; null when no field diffs. */
+    @Column(name = "changes", columnDefinition = "TEXT")
+    private String changes;
+
+    /** Optional short human-readable summary of the change. */
+    @Column(name = "summary", length = 500)
+    private String summary;
+
+    /** When the change was recorded. */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/repository/AuditLogRepository.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/repository/AuditLogRepository.java
@@ -1,0 +1,14 @@
+package com.pimvanleeuwen.the_harry_list_backend.repository;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long>, JpaSpecificationExecutor<AuditLog> {
+
+    /** Entries for a single entity, newest first (used for the per-entity history timeline). */
+    List<AuditLog> findByEntityTypeAndEntityIdOrderByCreatedAtDesc(AuditEntityType entityType, Long entityId);
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserService.java
@@ -1,7 +1,10 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,12 +19,15 @@ public class AdminUserService {
     private static final Logger log = LoggerFactory.getLogger(AdminUserService.class);
 
     private final AdminUserRepository adminUserRepository;
+    private final AuditService auditService;
     private final String initialAdminOid;
 
     public AdminUserService(
             AdminUserRepository adminUserRepository,
+            AuditService auditService,
             @Value("${app.initial-admin-oid:}") String initialAdminOid) {
         this.adminUserRepository = adminUserRepository;
+        this.auditService = auditService;
         this.initialAdminOid = initialAdminOid;
     }
 
@@ -57,11 +63,19 @@ public class AdminUserService {
             throw new IllegalArgumentException("Cannot change your own role");
         }
 
+        AdminRole oldRole = target.getRole();
         log.info("AUDIT user.role_changed userId={} oldRole={} newRole={} changedBy='{}'",
-                userId, target.getRole(), newRole, requestingUserOid);
+                userId, oldRole, newRole, requestingUserOid);
 
         target.setRole(newRole);
-        return adminUserRepository.save(target);
+        AdminUser saved = adminUserRepository.save(target);
+
+        auditService.recordAction(AuditEntityType.ADMIN_USER, userId, saved.getEmail(),
+                AuditAction.ROLE_CHANGED,
+                List.of(new FieldChange("role", String.valueOf(oldRole), String.valueOf(newRole))),
+                "Role changed for " + saved.getEmail());
+
+        return saved;
     }
 
     private AdminUser createUser(String azureOid, String email, String displayName) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiff.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiff.java
@@ -56,11 +56,14 @@ public final class AuditDiff {
             }
             try {
                 field.setAccessible(true);
-                Object oldValue = field.get(before);
-                Object newValue = field.get(after);
+                // Normalize null and blank strings to the same value so that, e.g.,
+                // null -> "" (common when an edit form sends empty strings for previously
+                // unset optional fields) is not reported as a spurious change.
+                String oldValue = normalize(field.get(before));
+                String newValue = normalize(field.get(after));
                 if (!Objects.equals(oldValue, newValue)) {
                     String label = labels.getOrDefault(field.getName(), field.getName());
-                    changes.add(new FieldChange(label, stringify(oldValue), stringify(newValue)));
+                    changes.add(new FieldChange(label, oldValue, newValue));
                 }
             } catch (Exception e) {
                 // Skip fields we cannot read (e.g. IllegalAccessException, InaccessibleObjectException)
@@ -78,7 +81,15 @@ public final class AuditDiff {
         return fields;
     }
 
-    private static String stringify(Object value) {
-        return value == null ? null : String.valueOf(value);
+    /**
+     * Render a value to its string form, collapsing null and blank/whitespace-only
+     * strings to {@code null} so they compare (and display) as "no value".
+     */
+    private static String normalize(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String s = String.valueOf(value);
+        return s.isBlank() ? null : s;
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiff.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiff.java
@@ -62,8 +62,9 @@ public final class AuditDiff {
                     String label = labels.getOrDefault(field.getName(), field.getName());
                     changes.add(new FieldChange(label, stringify(oldValue), stringify(newValue)));
                 }
-            } catch (IllegalAccessException e) {
-                // Skip fields we cannot read rather than failing the whole diff.
+            } catch (Exception e) {
+                // Skip fields we cannot read (e.g. IllegalAccessException, InaccessibleObjectException)
+                // rather than failing the whole diff. Auditing must never break the caller.
             }
         }
         return changes;

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiff.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiff.java
@@ -1,0 +1,83 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Reflection-based helper that computes field-level diffs between two instances
+ * of the same entity, for use in audit logging.
+ */
+public final class AuditDiff {
+
+    private AuditDiff() {
+    }
+
+    /** Metadata fields that are never meaningful to audit. */
+    public static final Set<String> DEFAULT_IGNORE = Set.of("id", "createdAt", "updatedAt");
+
+    /**
+     * Compare two objects of the same type using {@link #DEFAULT_IGNORE} and no
+     * display-name overrides.
+     */
+    public static List<FieldChange> compare(Object before, Object after) {
+        return compare(before, after, DEFAULT_IGNORE, Collections.emptyMap());
+    }
+
+    /**
+     * Compare two objects of the same type, returning one {@link FieldChange} per
+     * differing field.
+     *
+     * @param before       the prior state (null yields an empty result)
+     * @param after        the new state (null yields an empty result)
+     * @param ignore       field names to skip (e.g. metadata)
+     * @param displayNames optional map of field name -&gt; human-friendly label
+     */
+    public static List<FieldChange> compare(Object before, Object after, Set<String> ignore,
+                                            Map<String, String> displayNames) {
+        List<FieldChange> changes = new ArrayList<>();
+        if (before == null || after == null) {
+            return changes;
+        }
+
+        Set<String> ignored = ignore != null ? ignore : Collections.emptySet();
+        Map<String, String> labels = displayNames != null ? displayNames : Collections.emptyMap();
+
+        for (Field field : collectFields(after.getClass())) {
+            if (Modifier.isStatic(field.getModifiers()) || ignored.contains(field.getName())) {
+                continue;
+            }
+            try {
+                field.setAccessible(true);
+                Object oldValue = field.get(before);
+                Object newValue = field.get(after);
+                if (!Objects.equals(oldValue, newValue)) {
+                    String label = labels.getOrDefault(field.getName(), field.getName());
+                    changes.add(new FieldChange(label, stringify(oldValue), stringify(newValue)));
+                }
+            } catch (IllegalAccessException e) {
+                // Skip fields we cannot read rather than failing the whole diff.
+            }
+        }
+        return changes;
+    }
+
+    private static List<Field> collectFields(Class<?> type) {
+        List<Field> fields = new ArrayList<>();
+        for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
+            Collections.addAll(fields, c.getDeclaredFields());
+        }
+        return fields;
+    }
+
+    private static String stringify(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditService.java
@@ -1,0 +1,99 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditLog;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
+import com.pimvanleeuwen.the_harry_list_backend.util.AuditActorResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Central API for writing persistent audit entries. The actor is resolved
+ * internally from the security context, so callers do not need to thread a
+ * {@code Principal} through their signatures.
+ *
+ * <p>All writes are wrapped defensively: a failure to record an audit entry is
+ * logged but never propagated, so it can never break the underlying business
+ * operation (same philosophy as the existing email-send paths).
+ */
+@Service
+public class AuditService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditService.class);
+
+    private final AuditLogRepository auditLogRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AuditService(AuditLogRepository auditLogRepository) {
+        this.auditLogRepository = auditLogRepository;
+    }
+
+    /** Record a creation. {@code snapshot} may carry the initial field values, or be empty. */
+    public void recordCreate(AuditEntityType entityType, Long entityId, String label,
+                             List<FieldChange> snapshot, String summary) {
+        record(entityType, entityId, label, AuditAction.CREATE, snapshot, summary);
+    }
+
+    /** Record an update. No-op when there are no field changes. */
+    public void recordUpdate(AuditEntityType entityType, Long entityId, String label,
+                             List<FieldChange> diffs, String summary) {
+        if (diffs == null || diffs.isEmpty()) {
+            return;
+        }
+        record(entityType, entityId, label, AuditAction.UPDATE, diffs, summary);
+    }
+
+    /** Record a deletion. */
+    public void recordDelete(AuditEntityType entityType, Long entityId, String label, String summary) {
+        record(entityType, entityId, label, AuditAction.DELETE, List.of(), summary);
+    }
+
+    /** Record an arbitrary action with optional field changes. */
+    public void recordAction(AuditEntityType entityType, Long entityId, String label,
+                             AuditAction action, List<FieldChange> changes, String summary) {
+        record(entityType, entityId, label, action, changes, summary);
+    }
+
+    private void record(AuditEntityType entityType, Long entityId, String label,
+                        AuditAction action, List<FieldChange> changes, String summary) {
+        try {
+            AuditActorResolver.Actor actor = AuditActorResolver.resolveCurrentActor();
+
+            AuditLog entry = new AuditLog();
+            entry.setEntityType(entityType);
+            entry.setEntityId(entityId);
+            entry.setEntityLabel(label);
+            entry.setAction(action);
+            entry.setActorOid(actor.oid());
+            entry.setActorEmail(actor.email());
+            entry.setActorName(actor.name());
+            entry.setChanges(serialize(changes));
+            entry.setSummary(summary);
+
+            auditLogRepository.save(entry);
+        } catch (Exception e) {
+            // Auditing must never break the underlying operation.
+            log.error("Failed to write audit log entry: entityType={} action={} entityId={}",
+                    entityType, action, entityId, e);
+        }
+    }
+
+    private String serialize(List<FieldChange> changes) {
+        if (changes == null || changes.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(changes);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize audit field changes", e);
+            return null;
+        }
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationService.java
@@ -1,5 +1,6 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
@@ -20,16 +21,19 @@ public class CreateReservationService implements Command<com.pimvanleeuwen.the_h
     private final ReservationRepository reservationRepository;
     private final ReservationMapper reservationMapper;
     private final ConstraintValidationService constraintValidationService;
+    private final AuditService auditService;
 
     @Autowired(required = false)
     private EmailNotificationService emailService;
 
     public CreateReservationService(ReservationRepository reservationRepository,
                                      ReservationMapper reservationMapper,
-                                     ConstraintValidationService constraintValidationService) {
+                                     ConstraintValidationService constraintValidationService,
+                                     AuditService auditService) {
         this.reservationRepository = reservationRepository;
         this.reservationMapper = reservationMapper;
         this.constraintValidationService = constraintValidationService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -74,6 +78,10 @@ public class CreateReservationService implements Command<com.pimvanleeuwen.the_h
         log.info("LOGGING reservation.created id={} confirmation='{}' event='{}' date={} location={}",
                 savedEntity.getId(), savedEntity.getConfirmationNumber(),
                 savedEntity.getEventTitle(), savedEntity.getEventDate(), savedEntity.getLocation());
+
+        auditService.recordCreate(AuditEntityType.RESERVATION, savedEntity.getId(),
+                savedEntity.getConfirmationNumber() + " - " + savedEntity.getEventTitle(),
+                List.of(), "Reservation created");
 
         // Send email notification if enabled
         if (sendEmail && emailService != null) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/DeleteReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/DeleteReservationService.java
@@ -1,5 +1,6 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import org.slf4j.Logger;
@@ -17,12 +18,14 @@ public class DeleteReservationService implements Command<Long, Void> {
     private static final Logger log = LoggerFactory.getLogger(DeleteReservationService.class);
 
     private final ReservationRepository reservationRepository;
+    private final AuditService auditService;
 
     @Autowired(required = false)
     private EmailNotificationService emailService;
 
-    public DeleteReservationService(ReservationRepository reservationRepository) {
+    public DeleteReservationService(ReservationRepository reservationRepository, AuditService auditService) {
         this.reservationRepository = reservationRepository;
+        this.auditService = auditService;
     }
 
     @Override
@@ -60,6 +63,10 @@ public class DeleteReservationService implements Command<Long, Void> {
                 r.getEventDate(), r.getContactName(), r.getEmail());
 
         reservationRepository.deleteById(id);
+
+        auditService.recordDelete(AuditEntityType.RESERVATION, id,
+                r.getConfirmationNumber() + " - " + r.getEventTitle(),
+                "Reservation deleted (contact: " + r.getContactName() + ")");
 
         return ResponseEntity.noContent().build();
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
@@ -1,5 +1,7 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import org.slf4j.Logger;
@@ -9,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -18,13 +21,17 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
 
     private final ReservationRepository reservationRepository;
     private final ReservationMapper reservationMapper;
+    private final AuditService auditService;
 
     @Autowired(required = false)
     private EmailNotificationService emailService;
 
-    public UpdateReservationService(ReservationRepository reservationRepository, ReservationMapper reservationMapper) {
+    public UpdateReservationService(ReservationRepository reservationRepository,
+                                    ReservationMapper reservationMapper,
+                                    AuditService auditService) {
         this.reservationRepository = reservationRepository;
         this.reservationMapper = reservationMapper;
+        this.auditService = auditService;
     }
 
     @Override
@@ -66,6 +73,10 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         // Internal notes can be updated by staff; fall back to existing if not provided
         entity.setInternalNotes(input.getInternalNotes() != null ? input.getInternalNotes() : existing.getInternalNotes());
 
+        // Compute the field-level diff BEFORE saving: persisting merges the new state
+        // onto the managed `existing` instance, after which they would compare equal.
+        List<FieldChange> diffs = AuditDiff.compare(existing, entity);
+
         // Save updated entity
         Reservation savedEntity = reservationRepository.save(entity);
 
@@ -73,6 +84,9 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
                 savedEntity.getId(), savedEntity.getConfirmationNumber(),
                 savedEntity.getEventTitle(), savedEntity.getEventDate(),
                 savedEntity.getLocation(), savedEntity.getExpectedGuests());
+
+        auditService.recordUpdate(AuditEntityType.RESERVATION, savedEntity.getId(),
+                label(savedEntity), diffs, "Reservation updated");
 
         // Send email notification if enabled
         if (sendEmail && emailService != null) {
@@ -84,5 +98,9 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         }
 
         return ResponseEntity.ok(reservationMapper.toDto(savedEntity));
+    }
+
+    private static String label(Reservation r) {
+        return r.getConfirmationNumber() + " - " + r.getEventTitle();
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
@@ -70,6 +70,11 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         entity.setCreatedAt(existing.getCreatedAt());
         entity.setConfirmationNumber(existing.getConfirmationNumber());
         entity.setConfirmedBy(existing.getConfirmedBy());
+        // These are not part of the edit form and must not be wiped on update:
+        // - termsAccepted is set by the customer at submission time
+        // - cateringArranged is managed via its own dedicated endpoint
+        entity.setTermsAccepted(existing.getTermsAccepted());
+        entity.setCateringArranged(existing.isCateringArranged());
         // Internal notes can be updated by staff; fall back to existing if not provided
         entity.setInternalNotes(input.getInternalNotes() != null ? input.getInternalNotes() : existing.getInternalNotes());
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/util/AuditActorResolver.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/util/AuditActorResolver.java
@@ -1,0 +1,66 @@
+package com.pimvanleeuwen.the_harry_list_backend.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Resolves the current actor (the authenticated user) for audit logging, and
+ * centralizes the Azure AD claim-extraction logic that was previously duplicated
+ * across the security filter and controllers.
+ */
+public final class AuditActorResolver {
+
+    private AuditActorResolver() {
+    }
+
+    /** Actor identity captured on an audit entry. Any field may be null. */
+    public record Actor(String oid, String email, String name) {
+    }
+
+    /** Fallback actor for changes not made by an authenticated admin user. */
+    public static final Actor SYSTEM = new Actor(null, null, "system");
+
+    /** Actor for changes originating from a public (unauthenticated) reservation submission. */
+    public static final Actor PUBLIC = new Actor(null, null, "public submission");
+
+    /**
+     * Resolve the current actor from the security context. Returns {@link #SYSTEM}
+     * when there is no recognizable authenticated principal.
+     */
+    public static Actor resolveCurrentActor() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth instanceof JwtAuthenticationToken jwtAuth) {
+            Jwt jwt = jwtAuth.getToken();
+            return new Actor(extractOid(jwt), extractEmail(jwt), extractName(jwt));
+        }
+
+        if (auth != null && auth.isAuthenticated() && auth.getName() != null
+                && !"anonymousUser".equals(auth.getName())) {
+            // e.g. tests using @WithMockUser, or other non-JWT authentication
+            return new Actor(null, null, auth.getName());
+        }
+
+        return SYSTEM;
+    }
+
+    /** Azure AD v2.0 tokens use the "oid" claim; v1.0 uses "sub". */
+    public static String extractOid(Jwt jwt) {
+        String oid = jwt.getClaimAsString("oid");
+        return oid != null ? oid : jwt.getSubject();
+    }
+
+    /** Azure AD tokens may carry the email under "preferred_username", "email", or "upn". */
+    public static String extractEmail(Jwt jwt) {
+        String email = jwt.getClaimAsString("preferred_username");
+        if (email == null) email = jwt.getClaimAsString("email");
+        if (email == null) email = jwt.getClaimAsString("upn");
+        return email;
+    }
+
+    public static String extractName(Jwt jwt) {
+        return jwt.getClaimAsString("name");
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
@@ -40,6 +40,9 @@ class AdminBlockedPeriodControllerTest {
     @MockitoBean
     private BlockedPeriodRepository repository;
 
+    @MockitoBean
+    private com.pimvanleeuwen.the_harry_list_backend.service.AuditService auditService;
+
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -108,6 +111,10 @@ class AdminBlockedPeriodControllerTest {
                         .content(objectMapper.writeValueAsString(period)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.reason").value("Spring maintenance"));
+
+        verify(auditService).recordCreate(
+                eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.BLOCKED_PERIOD),
+                any(), any(), any(), any());
     }
 
     @Test
@@ -130,12 +137,13 @@ class AdminBlockedPeriodControllerTest {
     @Test
     @WithMockUser(roles = "EDITOR")
     void delete_shouldReturn200() throws Exception {
-        when(repository.existsById(1L)).thenReturn(true);
-        doNothing().when(repository).deleteById(1L);
+        when(repository.findById(1L)).thenReturn(Optional.of(samplePeriod()));
 
         mockMvc.perform(delete("/api/admin/blocked-periods/1").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("deleted"));
+
+        verify(repository).delete(any());
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
@@ -42,6 +42,9 @@ class AdminCalendarAppointmentControllerTest {
     @MockitoBean
     private CalendarAppointmentRepository repository;
 
+    @MockitoBean
+    private com.pimvanleeuwen.the_harry_list_backend.service.AuditService auditService;
+
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -129,6 +132,10 @@ class AdminCalendarAppointmentControllerTest {
                         .content(objectMapper.writeValueAsString(appointment)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.title").value("Staff Meeting"));
+
+        verify(auditService).recordCreate(
+                eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.CALENDAR_APPOINTMENT),
+                any(), any(), any(), any());
     }
 
     @Test
@@ -166,12 +173,13 @@ class AdminCalendarAppointmentControllerTest {
     @Test
     @WithMockUser(roles = "EDITOR")
     void delete_shouldReturn200() throws Exception {
-        when(repository.existsById(1L)).thenReturn(true);
-        doNothing().when(repository).deleteById(1L);
+        when(repository.findById(1L)).thenReturn(Optional.of(sampleAppointment()));
 
         mockMvc.perform(delete("/api/admin/calendar-appointments/1").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("deleted"));
+
+        verify(repository).delete(any());
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailAttachmentControllerTest.java
@@ -35,6 +35,9 @@ class AdminEmailAttachmentControllerTest {
     @MockitoBean
     private EmailAttachmentRepository repository;
 
+    @MockitoBean
+    private com.pimvanleeuwen.the_harry_list_backend.service.AuditService auditService;
+
     private EmailAttachment sampleAttachment() {
         return EmailAttachment.builder()
                 .id(1L)
@@ -85,6 +88,9 @@ class AdminEmailAttachmentControllerTest {
             .andExpect(jsonPath("$.name").value("Catering Menu"));
 
         verify(repository).save(any());
+        verify(auditService).recordCreate(
+                eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.EMAIL_ATTACHMENT),
+                any(), any(), any(), any());
     }
 
     @Test
@@ -138,12 +144,12 @@ class AdminEmailAttachmentControllerTest {
     @Test
     @WithMockUser(roles = "EDITOR")
     void deleteAttachment_shouldDeleteExisting() throws Exception {
-        when(repository.existsById(1L)).thenReturn(true);
+        when(repository.findById(1L)).thenReturn(Optional.of(sampleAttachment()));
 
         mockMvc.perform(delete("/api/admin/email-attachments/1").with(csrf()))
             .andExpect(status().isOk());
 
-        verify(repository).deleteById(1L);
+        verify(repository).delete(any());
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateControllerTest.java
@@ -44,6 +44,9 @@ class AdminEmailTemplateControllerTest {
     @MockitoBean
     private EmailNotificationService emailNotificationService;
 
+    @MockitoBean
+    private com.pimvanleeuwen.the_harry_list_backend.service.AuditService auditService;
+
     private ObjectMapper objectMapper;
 
     @BeforeEach

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminFormConstraintControllerTest.java
@@ -38,6 +38,9 @@ class AdminFormConstraintControllerTest {
     @MockitoBean
     private FormConstraintRepository repository;
 
+    @MockitoBean
+    private com.pimvanleeuwen.the_harry_list_backend.service.AuditService auditService;
+
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -105,6 +108,10 @@ class AdminFormConstraintControllerTest {
                         .content(objectMapper.writeValueAsString(constraint)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.constraintType").value("ACTIVITY_CONFLICT"));
+
+        verify(auditService).recordCreate(
+                eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.FORM_CONSTRAINT),
+                any(), any(), any(), any());
     }
 
     @Test
@@ -157,12 +164,13 @@ class AdminFormConstraintControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void delete_shouldReturn200() throws Exception {
-        when(repository.existsById(1L)).thenReturn(true);
-        doNothing().when(repository).deleteById(1L);
+        when(repository.findById(1L)).thenReturn(Optional.of(sampleConstraint()));
 
         mockMvc.perform(delete("/api/admin/form-constraints/1").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("deleted"));
+
+        verify(repository).delete(any());
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -7,6 +7,7 @@ import com.pimvanleeuwen.the_harry_list_backend.model.*;
 import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
 import com.pimvanleeuwen.the_harry_list_backend.repository.EmailAttachmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailTemplateService;
 import com.pimvanleeuwen.the_harry_list_backend.service.ReservationMapper;
@@ -57,6 +58,9 @@ class AdminReservationControllerTest {
     @MockitoBean
     private EmailAttachmentRepository emailAttachmentRepository;
 
+    @MockitoBean
+    private AuditService auditService;
+
     private ObjectMapper objectMapper;
     private Reservation sampleReservation;
     private com.pimvanleeuwen.the_harry_list_backend.dto.Reservation sampleDto;
@@ -89,6 +93,45 @@ class AdminReservationControllerTest {
             res.getStatus() == ReservationStatus.CONFIRMED &&
             "Admin User".equals(res.getConfirmedBy())
         ));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldRecordAuditEntry() throws Exception {
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "CONFIRMED"))
+            .andExpect(status().isOk());
+
+        verify(auditService).recordAction(
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.RESERVATION),
+            eq(1L), any(),
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.STATUS_CHANGE),
+            any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateInternalNotes_shouldRecordAuditEntry() throws Exception {
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        mockMvc.perform(patch("/api/admin/reservations/1/notes")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("\"secret notes\""))
+            .andExpect(status().isOk());
+
+        verify(auditService).recordAction(
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.RESERVATION),
+            eq(1L), any(),
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.NOTES_UPDATED),
+            any(), any());
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AuditLogControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AuditLogControllerTest.java
@@ -1,0 +1,110 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.pimvanleeuwen.the_harry_list_backend.config.SecurityConfig;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditLog;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
+import com.pimvanleeuwen.the_harry_list_backend.service.AdminUserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuditLogController.class)
+@Import(SecurityConfig.class)
+class AuditLogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuditLogRepository auditLogRepository;
+
+    // Required by RoleAuthorizationFilter pulled in via SecurityConfig.
+    @MockitoBean
+    private AdminUserService adminUserService;
+
+    private AuditLog sampleEntry() {
+        AuditLog entry = new AuditLog();
+        entry.setId(10L);
+        entry.setEntityType(AuditEntityType.RESERVATION);
+        entry.setEntityId(1L);
+        entry.setEntityLabel("ABC123 - Test Event");
+        entry.setAction(AuditAction.STATUS_CHANGE);
+        entry.setActorEmail("staff@example.com");
+        entry.setActorName("Staff Member");
+        entry.setChanges("[{\"field\":\"status\",\"oldValue\":\"PENDING\",\"newValue\":\"CONFIRMED\"}]");
+        entry.setSummary("Status changed");
+        entry.setCreatedAt(LocalDateTime.of(2026, 6, 1, 12, 0));
+        return entry;
+    }
+
+    @Test
+    void getAuditLog_shouldRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/admin/audit"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void getAuditLog_shouldBeForbiddenForEditor() throws Exception {
+        mockMvc.perform(get("/api/admin/audit"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "VIEWER")
+    void getAuditLog_shouldBeForbiddenForViewer() throws Exception {
+        mockMvc.perform(get("/api/admin/audit"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getAuditLog_shouldReturnPagedEntriesForAdmin() throws Exception {
+        Page<AuditLog> page = new PageImpl<>(List.of(sampleEntry()));
+        when(auditLogRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/admin/audit"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].action").value("STATUS_CHANGE"))
+                .andExpect(jsonPath("$.content[0].entityLabel").value("ABC123 - Test Event"))
+                .andExpect(jsonPath("$.content[0].changes[0].field").value("status"))
+                .andExpect(jsonPath("$.content[0].changes[0].newValue").value("CONFIRMED"));
+    }
+
+    @Test
+    void getReservationHistory_shouldRequireAuthentication() throws Exception {
+        mockMvc.perform(get("/api/admin/audit/reservation/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "VIEWER")
+    void getReservationHistory_shouldBeAllowedForViewer() throws Exception {
+        when(auditLogRepository.findByEntityTypeAndEntityIdOrderByCreatedAtDesc(AuditEntityType.RESERVATION, 1L))
+                .thenReturn(List.of(sampleEntry()));
+
+        mockMvc.perform(get("/api/admin/audit/reservation/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].changes[0].field").value("status"));
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditLogTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/AuditLogTest.java
@@ -1,0 +1,55 @@
+package com.pimvanleeuwen.the_harry_list_backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuditLogTest {
+
+    @Test
+    void onCreate_shouldSetCreatedAtWhenNull() {
+        AuditLog entry = new AuditLog();
+        assertNull(entry.getCreatedAt());
+
+        entry.onCreate();
+
+        assertNotNull(entry.getCreatedAt());
+    }
+
+    @Test
+    void onCreate_shouldPreserveExistingCreatedAt() {
+        AuditLog entry = new AuditLog();
+        LocalDateTime fixed = LocalDateTime.of(2026, 1, 1, 12, 0);
+        entry.setCreatedAt(fixed);
+
+        entry.onCreate();
+
+        assertEquals(fixed, entry.getCreatedAt());
+    }
+
+    @Test
+    void gettersAndSetters_shouldRoundTrip() {
+        AuditLog entry = new AuditLog();
+        entry.setEntityType(AuditEntityType.RESERVATION);
+        entry.setEntityId(42L);
+        entry.setEntityLabel("ABC123 - Test Event");
+        entry.setAction(AuditAction.STATUS_CHANGE);
+        entry.setActorOid("oid-1");
+        entry.setActorEmail("staff@example.com");
+        entry.setActorName("Staff Member");
+        entry.setChanges("[]");
+        entry.setSummary("status PENDING -> CONFIRMED");
+
+        assertEquals(AuditEntityType.RESERVATION, entry.getEntityType());
+        assertEquals(42L, entry.getEntityId());
+        assertEquals("ABC123 - Test Event", entry.getEntityLabel());
+        assertEquals(AuditAction.STATUS_CHANGE, entry.getAction());
+        assertEquals("oid-1", entry.getActorOid());
+        assertEquals("staff@example.com", entry.getActorEmail());
+        assertEquals("Staff Member", entry.getActorName());
+        assertEquals("[]", entry.getChanges());
+        assertEquals("status PENDING -> CONFIRMED", entry.getSummary());
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AdminUserServiceTest.java
@@ -23,6 +23,9 @@ class AdminUserServiceTest {
     @Mock
     private AdminUserRepository adminUserRepository;
 
+    @Mock
+    private AuditService auditService;
+
     private AdminUserService service;
 
     private static final String ADMIN_OID = "d7795f0e-32fd-4618-b5da-bf2c0079dd4a";
@@ -30,7 +33,7 @@ class AdminUserServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AdminUserService(adminUserRepository, ADMIN_OID);
+        service = new AdminUserService(adminUserRepository, auditService, ADMIN_OID);
     }
 
     @Test
@@ -106,6 +109,24 @@ class AdminUserServiceTest {
 
         assertEquals(AdminRole.EDITOR, result.getRole());
         verify(adminUserRepository).save(target);
+        verify(auditService).recordAction(
+                eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.ADMIN_USER),
+                eq(2L), eq("josselyn@hubble.cafe"),
+                eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.ROLE_CHANGED),
+                any(), any());
+    }
+
+    @Test
+    void updateRole_shouldNotAuditWhenChangingOwnRole() {
+        AdminUser self = createUser(1L, ADMIN_OID, "pim@hubble.cafe", "Pim", AdminRole.ADMIN);
+        when(adminUserRepository.findById(1L)).thenReturn(Optional.of(self));
+
+        try {
+            service.updateRole(1L, AdminRole.EDITOR, ADMIN_OID);
+        } catch (IllegalArgumentException ignored) {
+            // expected
+        }
+        verifyNoInteractions(auditService);
     }
 
     @Test
@@ -127,7 +148,7 @@ class AdminUserServiceTest {
 
     @Test
     void getOrCreateUser_shouldCreateViewerWhenInitialAdminOidIsEmpty() {
-        service = new AdminUserService(adminUserRepository, "");
+        service = new AdminUserService(adminUserRepository, auditService, "");
         when(adminUserRepository.findByAzureOid(ADMIN_OID)).thenReturn(Optional.empty());
         when(adminUserRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiffTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiffTest.java
@@ -1,0 +1,98 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuditDiffTest {
+
+    @Test
+    void compare_shouldDetectChangedFields() {
+        Reservation before = base();
+        Reservation after = base();
+        after.setContactName("New Name");
+        after.setExpectedGuests(50);
+
+        List<FieldChange> changes = AuditDiff.compare(before, after);
+
+        assertEquals(2, changes.size());
+        assertTrue(changes.stream().anyMatch(c ->
+                c.field().equals("contactName") && "Old Name".equals(c.oldValue()) && "New Name".equals(c.newValue())));
+        assertTrue(changes.stream().anyMatch(c ->
+                c.field().equals("expectedGuests") && "20".equals(c.oldValue()) && "50".equals(c.newValue())));
+    }
+
+    @Test
+    void compare_shouldIgnoreMetadataFields() {
+        Reservation before = base();
+        Reservation after = base();
+        after.setId(999L);
+        after.setCreatedAt(LocalDateTime.of(2030, 1, 1, 0, 0));
+        after.setUpdatedAt(LocalDateTime.of(2030, 1, 1, 0, 0));
+
+        List<FieldChange> changes = AuditDiff.compare(before, after);
+
+        assertTrue(changes.isEmpty(), "id/createdAt/updatedAt must be ignored");
+    }
+
+    @Test
+    void compare_shouldReturnEmptyWhenUnchanged() {
+        assertTrue(AuditDiff.compare(base(), base()).isEmpty());
+    }
+
+    @Test
+    void compare_shouldReturnEmptyWhenEitherSideNull() {
+        assertTrue(AuditDiff.compare(null, base()).isEmpty());
+        assertTrue(AuditDiff.compare(base(), null).isEmpty());
+    }
+
+    @Test
+    void compare_shouldHandleNullToValueTransitions() {
+        Reservation before = base();
+        before.setLocation(null);
+        Reservation after = base();
+        after.setLocation(BarLocation.HUBBLE);
+
+        List<FieldChange> changes = AuditDiff.compare(before, after);
+
+        assertEquals(1, changes.size());
+        assertEquals("location", changes.get(0).field());
+        assertNull(changes.get(0).oldValue());
+        assertEquals("HUBBLE", changes.get(0).newValue());
+    }
+
+    @Test
+    void compare_shouldApplyDisplayNamesAndCustomIgnore() {
+        Reservation before = base();
+        Reservation after = base();
+        after.setContactName("New Name");
+        after.setExpectedGuests(50);
+
+        List<FieldChange> changes = AuditDiff.compare(before, after,
+                Set.of("id", "createdAt", "updatedAt", "expectedGuests"),
+                Map.of("contactName", "Contact name"));
+
+        assertEquals(1, changes.size());
+        assertEquals("Contact name", changes.get(0).field());
+    }
+
+    private Reservation base() {
+        Reservation r = new Reservation();
+        r.setId(1L);
+        r.setContactName("Old Name");
+        r.setExpectedGuests(20);
+        r.setLocation(BarLocation.HUBBLE);
+        r.setStatus(ReservationStatus.PENDING);
+        r.setCreatedAt(LocalDateTime.of(2026, 1, 1, 10, 0));
+        return r;
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiffTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditDiffTest.java
@@ -50,6 +50,35 @@ class AuditDiffTest {
     }
 
     @Test
+    void compare_shouldTreatNullAndBlankStringAsEqual() {
+        // Common case: an edit form sends "" for a field that was null in the DB.
+        Reservation before = base();
+        before.setComments(null);
+        before.setCostCenter(null);
+        Reservation after = base();
+        after.setComments("");
+        after.setCostCenter("   ");
+
+        assertTrue(AuditDiff.compare(before, after).isEmpty(),
+                "null vs empty/blank string must not be reported as a change");
+    }
+
+    @Test
+    void compare_shouldStillDetectBlankToRealValue() {
+        Reservation before = base();
+        before.setComments("");
+        Reservation after = base();
+        after.setComments("Details");
+
+        List<FieldChange> changes = AuditDiff.compare(before, after);
+
+        assertEquals(1, changes.size());
+        assertEquals("comments", changes.get(0).field());
+        assertNull(changes.get(0).oldValue(), "blank old value should normalize to null");
+        assertEquals("Details", changes.get(0).newValue());
+    }
+
+    @Test
     void compare_shouldReturnEmptyWhenEitherSideNull() {
         assertTrue(AuditDiff.compare(null, base()).isEmpty());
         assertTrue(AuditDiff.compare(base(), null).isEmpty());

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AuditServiceTest.java
@@ -1,0 +1,132 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditAction;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+import com.pimvanleeuwen.the_harry_list_backend.model.AuditLog;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuditServiceTest {
+
+    @Mock
+    private AuditLogRepository auditLogRepository;
+
+    private AuditService auditService;
+
+    @BeforeEach
+    void setUp() {
+        auditService = new AuditService(auditLogRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void recordUpdate_shouldPersistWithResolvedActorAndSerializedChanges() {
+        setJwtAuthentication("oid-123", "staff@example.com", "Staff Member");
+
+        auditService.recordUpdate(AuditEntityType.RESERVATION, 7L, "ABC123 - Party",
+                List.of(new FieldChange("contactName", "Old", "New")), "updated contact");
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        AuditLog saved = captor.getValue();
+
+        assertEquals(AuditEntityType.RESERVATION, saved.getEntityType());
+        assertEquals(7L, saved.getEntityId());
+        assertEquals("ABC123 - Party", saved.getEntityLabel());
+        assertEquals(AuditAction.UPDATE, saved.getAction());
+        assertEquals("oid-123", saved.getActorOid());
+        assertEquals("staff@example.com", saved.getActorEmail());
+        assertEquals("Staff Member", saved.getActorName());
+        assertEquals("updated contact", saved.getSummary());
+        assertNotNull(saved.getChanges());
+        assertTrue(saved.getChanges().contains("contactName"));
+    }
+
+    @Test
+    void recordUpdate_shouldDoNothingWhenNoChanges() {
+        setJwtAuthentication("oid-123", "staff@example.com", "Staff");
+
+        auditService.recordUpdate(AuditEntityType.RESERVATION, 7L, "label", List.of(), "noop");
+
+        verify(auditLogRepository, never()).save(any());
+    }
+
+    @Test
+    void recordDelete_shouldPersistDeleteWithoutChangesJson() {
+        setJwtAuthentication("oid-123", "staff@example.com", "Staff");
+
+        auditService.recordDelete(AuditEntityType.RESERVATION, 7L, "ABC123", "deleted");
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        assertEquals(AuditAction.DELETE, captor.getValue().getAction());
+        assertNull(captor.getValue().getChanges());
+    }
+
+    @Test
+    void record_shouldFallBackToNonJwtAuthenticationName() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("mockuser", "n/a",
+                        AuthorityUtils.createAuthorityList("ROLE_EDITOR")));
+
+        auditService.recordCreate(AuditEntityType.RESERVATION, 1L, "label", List.of(), "created");
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        assertEquals("mockuser", captor.getValue().getActorName());
+        assertNull(captor.getValue().getActorOid());
+    }
+
+    @Test
+    void record_shouldUseSystemActorWhenUnauthenticated() {
+        auditService.recordDelete(AuditEntityType.RESERVATION, 1L, "label", "deleted");
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        assertEquals("system", captor.getValue().getActorName());
+    }
+
+    @Test
+    void record_shouldSwallowRepositoryExceptions() {
+        setJwtAuthentication("oid-123", "staff@example.com", "Staff");
+        when(auditLogRepository.save(any())).thenThrow(new RuntimeException("db down"));
+
+        // Must not propagate — auditing can never break the underlying operation.
+        assertDoesNotThrow(() -> auditService.recordDelete(
+                AuditEntityType.RESERVATION, 1L, "label", "deleted"));
+    }
+
+    private void setJwtAuthentication(String oid, String email, String name) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim("oid", oid)
+                .claim("preferred_username", email)
+                .claim("name", name)
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(
+                new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_EDITOR")));
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationServiceTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -35,6 +35,9 @@ class CreateReservationServiceTest {
 
     @Mock
     private ConstraintValidationService constraintValidationService;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private CreateReservationService createReservationService;
@@ -64,6 +67,16 @@ class CreateReservationServiceTest {
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertNotNull(response.getBody());
         verify(reservationRepository, times(1)).save(any());
+        verify(auditService).recordCreate(eq(AuditEntityType.RESERVATION), eq(1L), any(), any(), any());
+    }
+
+    @Test
+    void execute_shouldNotAuditWhenConstraintViolation() {
+        when(constraintValidationService.validate(any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of("violation"));
+
+        assertThrows(IllegalArgumentException.class, () -> createReservationService.execute(sampleDto));
+        verifyNoInteractions(auditService);
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/DeleteReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/DeleteReservationServiceTest.java
@@ -27,6 +27,9 @@ class DeleteReservationServiceTest {
     @Mock
     private ReservationRepository reservationRepository;
 
+    @Mock
+    private AuditService auditService;
+
     @InjectMocks
     private DeleteReservationService deleteReservationService;
 
@@ -50,6 +53,16 @@ class DeleteReservationServiceTest {
         // Then
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
         verify(reservationRepository, times(1)).deleteById(id);
+        verify(auditService).recordDelete(eq(AuditEntityType.RESERVATION), eq(id), any(), any());
+    }
+
+    @Test
+    void execute_shouldNotAuditWhenReservationDoesNotExist() {
+        when(reservationRepository.findById(999L)).thenReturn(Optional.empty());
+
+        deleteReservationService.execute(999L);
+
+        verifyNoInteractions(auditService);
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
@@ -152,6 +152,39 @@ class UpdateReservationServiceTest {
         verify(reservationRepository, times(1)).save(any());
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void execute_shouldPreserveTermsAcceptedAndCateringArranged() {
+        // Existing reservation has terms accepted and catering arranged...
+        sampleDto.setId(1L);
+        existingEntity.setTermsAccepted(true);
+        existingEntity.setCateringArranged(true);
+
+        // ...but the incoming edit payload (mapped) carries neither (form doesn't send them).
+        com.pimvanleeuwen.the_harry_list_backend.model.Reservation incoming = createExistingEntity();
+        incoming.setTermsAccepted(null);
+        incoming.setCateringArranged(false);
+        incoming.setContactName("Updated Name"); // one real change so an audit entry is recorded
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(reservationMapper.toEntity(sampleDto)).thenReturn(incoming);
+        when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        updateReservationService.execute(sampleDto);
+
+        // The saved entity keeps the preserved values...
+        verify(reservationRepository).save(argThat(saved ->
+                Boolean.TRUE.equals(saved.getTermsAccepted()) && saved.isCateringArranged()));
+
+        // ...and neither shows up as a spurious audit change.
+        ArgumentCaptor<java.util.List<com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange>> captor =
+                ArgumentCaptor.forClass(java.util.List.class);
+        verify(auditService).recordUpdate(any(), any(), any(), captor.capture(), any());
+        assertTrue(captor.getValue().stream().noneMatch(c ->
+                c.field().equals("termsAccepted") || c.field().equals("cateringArranged")));
+    }
+
     private Reservation createSampleDto() {
         return Reservation.builder()
                 .contactName("John Doe")

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
@@ -6,6 +6,7 @@ import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,7 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -33,6 +34,9 @@ class UpdateReservationServiceTest {
 
     @Mock
     private ReservationMapper reservationMapper;
+
+    @Mock
+    private AuditService auditService;
 
     @InjectMocks
     private UpdateReservationService updateReservationService;
@@ -65,6 +69,32 @@ class UpdateReservationServiceTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         verify(reservationRepository, times(1)).save(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void execute_shouldRecordFieldLevelDiff() {
+        // Given: only the contact name changes between existing and the incoming entity
+        sampleDto.setId(1L);
+        com.pimvanleeuwen.the_harry_list_backend.model.Reservation incoming = createExistingEntity();
+        incoming.setContactName("Updated Name");
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(reservationMapper.toEntity(sampleDto)).thenReturn(incoming);
+        when(reservationRepository.save(any())).thenReturn(incoming);
+        when(reservationMapper.toDto(incoming)).thenReturn(sampleDto);
+
+        // When
+        updateReservationService.execute(sampleDto);
+
+        // Then
+        ArgumentCaptor<java.util.List<com.pimvanleeuwen.the_harry_list_backend.dto.FieldChange>> captor =
+                ArgumentCaptor.forClass(java.util.List.class);
+        verify(auditService).recordUpdate(eq(AuditEntityType.RESERVATION), eq(1L), any(), captor.capture(), any());
+        assertTrue(captor.getValue().stream().anyMatch(c ->
+                c.field().equals("contactName")
+                        && "Original Name".equals(c.oldValue())
+                        && "Updated Name".equals(c.newValue())));
     }
 
     @Test

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.55.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What & why

As more people manage reservations, we need to see **who changed what, and when**.
Until now the app only emitted ephemeral `log.info("AUDIT …")` lines (file/Sentry
only, not persistent, queryable, or visible to staff).

This PR adds a **persistent, queryable audit log** with **field-level diffs** (old → new), covering **all admin mutations**, surfaced **both** as a per-reservation
history timeline and a global, filterable audit page.

Closes #271.

## ⚠️ Deploy step (required before backend deploy)

Production runs `ddl-auto=validate`, so the new table must exist **before** the new
backend boots, or it will fail startup. Run the `CREATE TABLE audit_log …` from
[`docs/migration-audit-log.md`](docs/migration-audit-log.md) first. Deploy order is
otherwise irrelevant; dev/test auto-create the table. Rollback: the old backend
ignores the table; `DROP TABLE audit_log;` to remove it.

## How it works

**Backend (`the-harry-list-backend`)**
- New `audit_log` table + `AuditLog` entity; `AuditService` records entries with the actor resolved from the Azure JWT (`AuditActorResolver`), and `AuditDiff` computes reflection-based field diffs.
- Wired into **all** admin mutations: reservation create / update / delete / status / notes / catering / email, plus blocked periods, calendar appointments, form constraints, email templates, email attachments, and admin user role changes.
- Read API: `GET /api/admin/audit` (ADMIN-only, paged, filter by entity type / action / actor / date range) and `GET /api/admin/audit/reservation/{id}` (viewer-accessible).

**Frontend (`the-harry-list-admin`)**
- "Change History" timeline on the reservation detail page (all roles), with per-field old → new diffs.
- Global **Audit Log** page (ADMIN-only) with entity-type / action / actor / **date-range** filters and pagination. Nav item gated by a new `canViewAuditLog` permission and placed above Settings.

## Safety / backwards compatibility
- **Purely additive**: one new table, no existing schema/API/contract changes.
- **Audit never breaks the real operation**: writes are best-effort and swallowed on failure; the diff helper can't throw. Verified there's no shared `@Transactional` boundary, so a failed audit write can't roll back the business write.
- The behavior-preserving refactor (`AuditActorResolver`) is pinned by existing tests.

## Bug found & fixed along the way
The audit log immediately surfaced a real bug: editing a reservation silently wiped the customer's `termsAccepted` (and could reset `cateringArranged`), because the edit form doesn't send those fields. Now preserved on update. Also normalized `null` vs `""` in the diff so empty-form-field round-trips don't show as spurious changes.

## Testing
- Backend: `cd the-harry-list-backend && ./mvnw test` — **275 passing** (entity, diff, service incl. failure-isolation & actor resolution, controller role-enforcement & filtering, plus augmented mutation tests).
- Frontend: `cd the-harry-list-admin && npm run test:run` — **91 passing**; `npm run lint` clean; `npm run build` succeeds.