### PR TITLE
279 feature custom message in emails

### DIFF
--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -156,7 +156,12 @@ export async function fetchReservation(id: number): Promise<Reservation | null> 
   return fetchJsonWithAuth(`${API_BASE_URL}/api/reservations/${id}`) as Promise<Reservation | null>;
 }
 
-export async function updateReservation(id: number, data: Record<string, unknown>, sendEmail: boolean = true): Promise<Reservation> {
+export async function updateReservation(
+  id: number,
+  data: Record<string, unknown>,
+  sendEmail: boolean = true,
+  customMessage?: string
+): Promise<Reservation> {
   // Clean up empty strings to null for enum fields that the backend expects
   const cleanedData: Record<string, unknown> = { ...data };
   const enumFields = ['seatingArea', 'location', 'paymentOption', 'invoiceType'];
@@ -166,7 +171,11 @@ export async function updateReservation(id: number, data: Record<string, unknown
     }
   });
 
-  return fetchJsonWithAuth(`${API_BASE_URL}/api/reservations/${id}?sendEmail=${sendEmail}`, {
+  let url = `${API_BASE_URL}/api/reservations/${id}?sendEmail=${sendEmail}`;
+  if (customMessage && customMessage.trim()) {
+    url += `&customMessage=${encodeURIComponent(customMessage)}`;
+  }
+  return fetchJsonWithAuth(url, {
     method: 'PUT',
     body: JSON.stringify(cleanedData),
   }) as Promise<Reservation>;
@@ -182,11 +191,15 @@ export async function updateReservationStatus(
   id: number,
   status: string,
   confirmedBy?: string,
-  sendEmail: boolean = true
+  sendEmail: boolean = true,
+  customMessage?: string
 ): Promise<Reservation> {
   let url = `${API_BASE_URL}/api/admin/reservations/${id}/status?status=${status}&sendEmail=${sendEmail}`;
   if (confirmedBy) {
     url += `&confirmedBy=${encodeURIComponent(confirmedBy)}`;
+  }
+  if (customMessage && customMessage.trim()) {
+    url += `&customMessage=${encodeURIComponent(customMessage)}`;
   }
   return fetchJsonWithAuth(url, { method: 'PATCH' }) as Promise<Reservation>;
 }

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -259,6 +259,10 @@ Templates support **variables** that get replaced with actual reservation data w
 - \`{{location}}\` — Hubble or Meteor
 - \`{{confirmationNumber}}\` — the unique booking reference
 
+The **Reservation Confirmed/Rejected** and **Reservation Updated** templates also support:
+
+- \`{{customMessage}}\` — the optional message a staff member types when confirming, rejecting, cancelling, completing, or editing a reservation. It renders as a highlighted note, or nothing at all when no message is entered. Keep this placeholder in the template if you want those one-off messages to appear.
+
 ### Actions
 
 - **Save** — save your changes
@@ -408,7 +412,7 @@ The available actions depend on the current status:
 
 ### Pending Reservations
 - **Confirm** — approve the reservation. Optionally sends a confirmation email
-- **Reject** — decline with an optional reason (included in the rejection email)
+- **Reject** — decline the reservation. The rejection email is pre-filled with a default reason you can edit or replace
 
 ### Confirmed Reservations
 - **Complete** — mark as completed after the event has taken place
@@ -419,7 +423,10 @@ The available actions depend on the current status:
 - **Delete** — permanently remove (with confirmation dialog)
 
 ### Email Notifications
-Each status change dialog has a **"Send email notification"** checkbox. Keep this checked to automatically notify the customer. Uncheck it only if you've already communicated with them directly.`,
+Each status change dialog (and the edit form) has a **"Send email notification"** checkbox. Keep this checked to automatically notify the customer. Uncheck it only if you've already communicated with them directly.
+
+### Adding a Message to the Email
+When the email notification is on, every status dialog and the edit form shows an optional **"Add a message to the email"** box. Anything you type here appears as a highlighted note in that email — use it to clarify things the standard template doesn't cover, e.g. *"We read your special request and will keep a shaded spot for you."* For **Reject**, this box is pre-filled with a default reason that you can edit, replace, or clear before sending.`,
   },
   {
     title: 'Catering Email',

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -18,6 +18,39 @@ import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { reservationDetailGuide } from '../lib/guideContent';
 
+// Pre-filled (editable) default shown when rejecting a reservation. Staff can edit or clear it.
+const DEFAULT_REJECTION_MESSAGE =
+  'Unfortunately we cannot host you since we do not have any places left at this time';
+
+/**
+ * Optional free-text message added to the notification email for a reservation action.
+ * Only rendered when an email will actually be sent.
+ */
+function EmailMessageField({
+  value,
+  onChange,
+  show,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  show: boolean;
+}) {
+  if (!show) return null;
+  return (
+    <div className="mt-3">
+      <label className="block text-sm text-dark-300 mb-1">
+        Add a message to the email <span className="text-dark-500">(optional)</span>
+      </label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="input-field min-h-[80px] w-full"
+        placeholder="e.g. We read your special request and will keep a shaded spot for you."
+      />
+    </div>
+  );
+}
+
 export function ReservationDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -35,11 +68,15 @@ export function ReservationDetailPage() {
   const [showCompleteDialog, setShowCompleteDialog] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [sendEmail, setSendEmail] = useState(true);
+  // Optional free-text message added to the status-change email (pre-filled for rejections).
+  const [actionMessage, setActionMessage] = useState('');
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [editData, setEditData] = useState<Partial<Reservation>>({});
   const [sendEditEmail, setSendEditEmail] = useState(true);
+  // Optional free-text message added to the "reservation updated" email.
+  const [editMessage, setEditMessage] = useState('');
 
   // Catering email state
   const [showCateringEmail, setShowCateringEmail] = useState(false);
@@ -84,7 +121,8 @@ export function ReservationDetailPage() {
 
     setIsUpdating(true);
     try {
-      await updateReservationStatus(reservation.id, newStatus, userName, sendEmail);
+      await updateReservationStatus(
+        reservation.id, newStatus, userName, sendEmail, sendEmail ? actionMessage : undefined);
       setReservation({ ...reservation, status: newStatus });
       loadAuditLog();
     } catch (err) {
@@ -140,6 +178,7 @@ export function ReservationDetailPage() {
       comments: reservation.comments || '',
       internalNotes: reservation.internalNotes || '',
     });
+    setEditMessage('');
     setIsEditing(true);
   };
 
@@ -148,7 +187,8 @@ export function ReservationDetailPage() {
 
     setIsUpdating(true);
     try {
-      const updatedReservation = await updateReservation(reservation.id, editData, sendEditEmail);
+      const updatedReservation = await updateReservation(
+        reservation.id, editData, sendEditEmail, sendEditEmail ? editMessage : undefined);
       setReservation(updatedReservation);
       setIsEditing(false);
       setEditData({});
@@ -298,7 +338,7 @@ export function ReservationDetailPage() {
           {reservation.status === 'PENDING' && (
             <>
               <button
-                onClick={() => setShowConfirmDialog(true)}
+                onClick={() => { setActionMessage(''); setShowConfirmDialog(true); }}
                 disabled={isUpdating}
                 className="btn-primary flex items-center gap-2"
               >
@@ -306,7 +346,7 @@ export function ReservationDetailPage() {
                 Confirm
               </button>
               <button
-                onClick={() => setShowRejectDialog(true)}
+                onClick={() => { setActionMessage(DEFAULT_REJECTION_MESSAGE); setShowRejectDialog(true); }}
                 disabled={isUpdating}
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
               >
@@ -318,7 +358,7 @@ export function ReservationDetailPage() {
 
           {reservation.status === 'CONFIRMED' && (
             <button
-              onClick={() => setShowCompleteDialog(true)}
+              onClick={() => { setActionMessage(''); setShowCompleteDialog(true); }}
               disabled={isUpdating}
               className="btn-secondary flex items-center gap-2"
             >
@@ -329,7 +369,7 @@ export function ReservationDetailPage() {
 
           {reservation.status === 'CONFIRMED' && (
             <button
-              onClick={() => setShowCancelDialog(true)}
+              onClick={() => { setActionMessage(''); setShowCancelDialog(true); }}
               disabled={isUpdating}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors ml-auto"
             >
@@ -376,7 +416,8 @@ export function ReservationDetailPage() {
         {showConfirmDialog && (
           <div className="mt-4 p-4 rounded-xl bg-green-500/10 border border-green-500/50">
             <p className="text-green-400 mb-3">Are you sure you want to confirm this reservation? {sendEmail && 'A confirmation email will be sent to the customer.'}</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('CONFIRMED');
@@ -402,7 +443,8 @@ export function ReservationDetailPage() {
         {showRejectDialog && (
           <div className="mt-4 p-4 rounded-xl bg-red-500/10 border border-red-500/50">
             <p className="text-red-400 mb-3">Are you sure you want to reject this reservation? {sendEmail && 'A rejection email will be sent to the customer.'}</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('REJECTED');
@@ -428,7 +470,8 @@ export function ReservationDetailPage() {
         {showCompleteDialog && (
           <div className="mt-4 p-4 rounded-xl bg-blue-500/10 border border-blue-500/50">
             <p className="text-blue-400 mb-3">Are you sure you want to mark this reservation as completed?</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('COMPLETED');
@@ -454,7 +497,8 @@ export function ReservationDetailPage() {
         {showCancelDialog && (
           <div className="mt-4 p-4 rounded-xl bg-amber-500/10 border border-amber-500/50">
             <p className="text-amber-400 mb-3">Are you sure you want to cancel this reservation? {sendEmail && 'A cancellation email will be sent to the customer.'}</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('CANCELLED');
@@ -828,6 +872,8 @@ export function ReservationDetailPage() {
                   Send email notification about changes to customer
                 </span>
               </label>
+
+              <EmailMessageField value={editMessage} onChange={setEditMessage} show={sendEditEmail} />
 
               {/* Contact Information */}
               <div>

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { ReservationDetailPage } from '../pages/ReservationDetailPage';
 
@@ -57,7 +57,10 @@ vi.mock('../lib/api', () => ({
   sendCateringEmail: vi.fn(),
 }));
 
-import { fetchReservationAuditLog } from '../lib/api';
+import { fetchReservationAuditLog, fetchReservation, updateReservationStatus } from '../lib/api';
+
+const DEFAULT_REJECTION_MESSAGE =
+  'Unfortunately we cannot host you since we do not have any places left at this time';
 
 const renderPage = () =>
   render(
@@ -100,5 +103,62 @@ describe('ReservationDetailPage — change history', () => {
 
     // The rest of the page still renders.
     expect(screen.getByText('Birthday Party')).toBeInTheDocument();
+  });
+});
+
+describe('ReservationDetailPage — custom email message', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills the editable default rejection message and sends it', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+    vi.mocked(updateReservationStatus).mockResolvedValueOnce({ ...sampleReservation, status: 'REJECTED' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }));
+
+    const textarea = await screen.findByPlaceholderText(/shaded spot/i);
+    expect(textarea).toHaveValue(DEFAULT_REJECTION_MESSAGE);
+
+    fireEvent.click(screen.getByRole('button', { name: /Yes, Reject Reservation/ }));
+
+    await waitFor(() =>
+      expect(updateReservationStatus).toHaveBeenCalledWith(
+        1, 'REJECTED', 'Staff Member', true, DEFAULT_REJECTION_MESSAGE));
+  });
+
+  it('sends a typed message when confirming', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+    vi.mocked(updateReservationStatus).mockResolvedValueOnce({ ...sampleReservation, status: 'CONFIRMED' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }));
+
+    const textarea = await screen.findByPlaceholderText(/shaded spot/i);
+    expect(textarea).toHaveValue(''); // no default for confirmations
+    fireEvent.change(textarea, { target: { value: 'We saved you a spot in the shade!' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Yes, Confirm Reservation/ }));
+
+    await waitFor(() =>
+      expect(updateReservationStatus).toHaveBeenCalledWith(
+        1, 'CONFIRMED', 'Staff Member', true, 'We saved you a spot in the shade!'));
+  });
+
+  it('hides the message field when email notification is turned off', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('checkbox')); // turn off "send email notification"
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }));
+
+    expect(screen.queryByPlaceholderText(/shaded spot/i)).not.toBeInTheDocument();
   });
 });

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
@@ -92,14 +92,15 @@ public class AdminEmailTemplateController {
         }
 
         Map<String, String> sampleVars = emailTemplateService.buildSampleVariables(type);
+        Map<String, String> sampleRawHtml = emailTemplateService.buildSampleRawHtmlVariables(type);
 
         String subject = (request.getSubject() != null && !request.getSubject().isBlank())
                 ? emailTemplateService.renderForTest(request.getSubject(), sampleVars)
                 : emailTemplateService.getRenderedSubject(type, sampleVars);
 
         String body = (request.getBodyTemplate() != null && !request.getBodyTemplate().isBlank())
-                ? emailTemplateService.renderForTest(request.getBodyTemplate(), sampleVars)
-                : emailTemplateService.getRenderedBody(type, sampleVars);
+                ? emailTemplateService.renderForTest(request.getBodyTemplate(), sampleVars, sampleRawHtml)
+                : emailTemplateService.getRenderedBody(type, sampleVars, sampleRawHtml);
 
         try {
             emailNotificationService.get().sendRawEmail(request.getToEmail(), subject, body);

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -85,6 +85,7 @@ public class AdminReservationController {
             @RequestParam ReservationStatus status,
             @RequestParam(required = false) String confirmedBy,
             @RequestParam(required = false, defaultValue = "true") boolean sendEmail,
+            @RequestParam(required = false) String customMessage,
             Principal principal) {
 
         return reservationRepository.findById(id)
@@ -108,15 +109,20 @@ public class AdminReservationController {
                             oldStatus, status, principal != null ? principal.getName() : "unknown",
                             confirmedBy != null ? " confirmedBy='" + confirmedBy + "'" : "");
 
+                    // The message content itself is not stored in the audit log (may be long); we only
+                    // record that a custom message accompanied the status change.
+                    boolean hasCustomMessage = customMessage != null && !customMessage.isBlank();
                     auditService.recordAction(AuditEntityType.RESERVATION, id, label(saved),
                             AuditAction.STATUS_CHANGE,
                             List.of(new FieldChange("status", String.valueOf(oldStatus), String.valueOf(status))),
-                            "Status changed" + (confirmedBy != null ? " (confirmed by " + confirmedBy + ")" : ""));
+                            "Status changed"
+                                    + (confirmedBy != null ? " (confirmed by " + confirmedBy + ")" : "")
+                                    + (hasCustomMessage ? " (with message)" : ""));
 
                     // Send email notification if enabled
                     if (sendEmail && emailService != null) {
                         try {
-                            emailService.sendStatusChangeEmail(saved, oldStatus, confirmedBy);
+                            emailService.sendStatusChangeEmail(saved, oldStatus, confirmedBy, customMessage);
                         } catch (Exception e) {
                             log.error("Failed to send status change email, but status was updated successfully", e);
                         }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/open/ReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/open/ReservationController.java
@@ -59,13 +59,14 @@ public class ReservationController {
     }
 
     @PutMapping("/{id}")
-    @Operation(summary = "Update a reservation", description = "Update an existing reservation (staff only). Set sendEmail=false to skip email notification.")
+    @Operation(summary = "Update a reservation", description = "Update an existing reservation (staff only). Set sendEmail=false to skip email notification. Optionally pass customMessage to add a note to the update email.")
     public ResponseEntity<Reservation> updateReservation(
             @PathVariable Long id,
             @Valid @RequestBody Reservation reservation,
-            @RequestParam(required = false, defaultValue = "true") boolean sendEmail) {
+            @RequestParam(required = false, defaultValue = "true") boolean sendEmail,
+            @RequestParam(required = false) String customMessage) {
         reservation.setId(id);
-        return updateReservationService.executeWithEmail(reservation, sendEmail);
+        return updateReservationService.executeWithEmail(reservation, sendEmail, customMessage);
     }
 
     @DeleteMapping("/{id}")

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailNotificationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailNotificationService.java
@@ -19,13 +19,20 @@ public interface EmailNotificationService {
 
     /**
      * Send email when reservation status changes.
+     *
+     * @param customMessage optional free-text note from staff, added to the email as a highlighted
+     *                      block; may be {@code null} or blank to omit it.
      */
-    void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy);
+    void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy,
+                               String customMessage);
 
     /**
      * Send email when reservation is updated.
+     *
+     * @param customMessage optional free-text note from staff, added to the email as a highlighted
+     *                      block; may be {@code null} or blank to omit it.
      */
-    void sendReservationUpdatedEmail(Reservation reservation);
+    void sendReservationUpdatedEmail(Reservation reservation, String customMessage);
 
     /**
      * Send email when reservation is deleted/cancelled.

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateService.java
@@ -39,11 +39,11 @@ public class EmailTemplateService {
         AVAILABLE_VARIABLES.put(EmailTemplateType.STATUS_CHANGED, List.of(
                 "contactName", "confirmationNumber", "eventTitle", "eventDate",
                 "startTime", "endTime", "location", "expectedGuests",
-                "status", "statusMessage", "statusColor", "barName", "staffEmail"));
+                "status", "statusMessage", "statusColor", "barName", "staffEmail", "customMessage"));
 
         AVAILABLE_VARIABLES.put(EmailTemplateType.UPDATED, List.of(
                 "contactName", "confirmationNumber", "eventTitle", "eventDate",
-                "startTime", "endTime", "location", "expectedGuests", "status", "barName"));
+                "startTime", "endTime", "location", "expectedGuests", "status", "barName", "customMessage"));
 
         AVAILABLE_VARIABLES.put(EmailTemplateType.CANCELLED, List.of(
                 "contactName", "eventTitle", "confirmationNumber", "staffEmail", "barName"));
@@ -126,6 +126,7 @@ public class EmailTemplateService {
                         <div class="content">
                             <p>Dear {{contactName}},</p>
                             <p>{{statusMessage}}</p>
+                            {{customMessage}}
                             <div class="details">
                                 <p><strong>Confirmation Number:</strong> {{confirmationNumber}}</p>
                                 <p><strong>Event:</strong> {{eventTitle}}</p>
@@ -160,6 +161,7 @@ public class EmailTemplateService {
                         <div class="content">
                             <p>Dear {{contactName}},</p>
                             <p>Your reservation has been updated. Please review the details below:</p>
+                            {{customMessage}}
                             <div class="details">
                                 <p><strong>Confirmation Number:</strong> {{confirmationNumber}}</p>
                                 <p><strong>Event:</strong> {{eventTitle}}</p>
@@ -290,10 +292,26 @@ public class EmailTemplateService {
      * All variable values are HTML-escaped before substitution to prevent XSS.
      */
     public String getRenderedBody(EmailTemplateType type, Map<String, String> variables) {
+        // Types that support an optional {{customMessage}} block default to an empty block when no
+        // message is supplied, so the placeholder never renders literally.
+        Map<String, String> rawHtmlVariables =
+                (type == EmailTemplateType.STATUS_CHANGED || type == EmailTemplateType.UPDATED)
+                        ? Map.of("customMessage", "")
+                        : Map.of();
+        return getRenderedBody(type, variables, rawHtmlVariables);
+    }
+
+    /**
+     * Render a template body with both escaped variables and pre-sanitized raw-HTML variables.
+     * Raw-HTML variables (e.g. {@code customMessage}) are substituted verbatim and must already be
+     * safe HTML — see {@link EmailTemplates#buildCustomMessageBlock(String)}.
+     */
+    public String getRenderedBody(EmailTemplateType type, Map<String, String> variables,
+                                  Map<String, String> rawHtmlVariables) {
         String template = repository.findByTemplateType(type)
                 .map(EmailTemplate::getBodyTemplate)
                 .orElse(DEFAULT_BODIES.get(type));
-        return render(template, variables);
+        return render(template, variables, rawHtmlVariables);
     }
 
     /**
@@ -303,7 +321,7 @@ public class EmailTemplateService {
         String template = repository.findByTemplateType(type)
                 .map(EmailTemplate::getSubject)
                 .orElse(DEFAULT_SUBJECTS.get(type));
-        return render(template, variables);
+        return render(template, variables, Map.of());
     }
 
     public List<EmailTemplateDto> findAll() {
@@ -374,7 +392,26 @@ public class EmailTemplateService {
 
     /** Render an arbitrary template string with the given variables (used for test previews). */
     public String renderForTest(String template, Map<String, String> variables) {
-        return render(template, variables);
+        return render(template, variables, Map.of());
+    }
+
+    /** Render an arbitrary template string with escaped variables plus pre-sanitized raw-HTML variables. */
+    public String renderForTest(String template, Map<String, String> variables,
+                                Map<String, String> rawHtmlVariables) {
+        return render(template, variables, rawHtmlVariables);
+    }
+
+    /**
+     * Returns sample raw-HTML variables (e.g. a {@code customMessage} block) for test/preview
+     * rendering, so admins can see how the optional message appears. Empty for types that do not
+     * support a custom message.
+     */
+    public Map<String, String> buildSampleRawHtmlVariables(EmailTemplateType type) {
+        if (type == EmailTemplateType.STATUS_CHANGED || type == EmailTemplateType.UPDATED) {
+            return Map.of("customMessage", EmailTemplates.buildCustomMessageBlock(
+                    "We read your special request and will make sure you have a spot in the shade."));
+        }
+        return Map.of();
     }
 
     public String getDefaultBody(EmailTemplateType type) {
@@ -399,11 +436,17 @@ public class EmailTemplateService {
                 .build();
     }
 
-    private String render(String template, Map<String, String> variables) {
+    private String render(String template, Map<String, String> variables,
+                          Map<String, String> rawHtmlVariables) {
         if (template == null) return "";
         String result = template;
         for (Map.Entry<String, String> entry : variables.entrySet()) {
             result = result.replace("{{" + entry.getKey() + "}}", escapeHtml(entry.getValue()));
+        }
+        // Raw-HTML variables are pre-sanitized and substituted verbatim (no escaping).
+        for (Map.Entry<String, String> entry : rawHtmlVariables.entrySet()) {
+            String value = entry.getValue() != null ? entry.getValue() : "";
+            result = result.replace("{{" + entry.getKey() + "}}", value);
         }
         return result;
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplates.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplates.java
@@ -430,4 +430,21 @@ public class EmailTemplates {
             escapeHtml(barName)
         );
     }
+
+    /**
+     * Builds the optional "custom message" block injected into status-change and update emails.
+     * Returns an empty string when no message is provided, so the surrounding template renders
+     * nothing. The message text is HTML-escaped (newlines become &lt;br&gt;) so the block is safe
+     * to substitute as raw HTML into a template.
+     */
+    public static String buildCustomMessageBlock(String message) {
+        if (message == null || message.isBlank()) {
+            return "";
+        }
+        String htmlMessage = escapeHtml(message).replace("\n", "<br>");
+        return String.format("""
+            <div style="background-color: #ffffff; padding: 15px; margin: 15px 0; border-left: 4px solid #6b46c1;">
+                <p style="margin: 0;">%s</p>
+            </div>""", htmlMessage);
+    }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/MicrosoftGraphEmailService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/MicrosoftGraphEmailService.java
@@ -90,11 +90,14 @@ public class MicrosoftGraphEmailService implements EmailNotificationService {
     }
 
     @Override
-    public void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy) {
+    public void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy,
+                                      String customMessage) {
         try {
             Map<String, String> vars = buildStatusChangeVars(reservation);
+            Map<String, String> rawHtmlVars = Map.of(
+                    "customMessage", EmailTemplates.buildCustomMessageBlock(customMessage));
             String subject = emailTemplateService.getRenderedSubject(EmailTemplateType.STATUS_CHANGED, vars);
-            String body = emailTemplateService.getRenderedBody(EmailTemplateType.STATUS_CHANGED, vars);
+            String body = emailTemplateService.getRenderedBody(EmailTemplateType.STATUS_CHANGED, vars, rawHtmlVars);
             sendEmail(reservation.getEmail(), subject, body);
             log.info("LOGGING email.status_change_sent confirmation='{}' to='{}' status={}",
                     reservation.getConfirmationNumber(), reservation.getEmail(), reservation.getStatus());
@@ -104,12 +107,14 @@ public class MicrosoftGraphEmailService implements EmailNotificationService {
     }
 
     @Override
-    public void sendReservationUpdatedEmail(Reservation reservation) {
+    public void sendReservationUpdatedEmail(Reservation reservation, String customMessage) {
         try {
             Map<String, String> vars = buildBaseVars(reservation);
             vars.put("status", reservation.getStatus().getDisplayName());
+            Map<String, String> rawHtmlVars = Map.of(
+                    "customMessage", EmailTemplates.buildCustomMessageBlock(customMessage));
             String subject = emailTemplateService.getRenderedSubject(EmailTemplateType.UPDATED, vars);
-            String body = emailTemplateService.getRenderedBody(EmailTemplateType.UPDATED, vars);
+            String body = emailTemplateService.getRenderedBody(EmailTemplateType.UPDATED, vars, rawHtmlVars);
             sendEmail(reservation.getEmail(), subject, body);
             log.info("LOGGING email.updated_sent confirmation='{}' to='{}'",
                     reservation.getConfirmationNumber(), reservation.getEmail());

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
@@ -39,13 +39,19 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         return executeWithEmail(input, true);
     }
 
-    /**
-     * Update a reservation with optional email notification.
-     * @param input The reservation DTO
-     * @param sendEmail Whether to send email notification
-     */
     public ResponseEntity<com.pimvanleeuwen.the_harry_list_backend.dto.Reservation> executeWithEmail(
             com.pimvanleeuwen.the_harry_list_backend.dto.Reservation input, boolean sendEmail) {
+        return executeWithEmail(input, sendEmail, null);
+    }
+
+    /**
+     * Update a reservation with optional email notification and an optional custom message.
+     * @param input The reservation DTO
+     * @param sendEmail Whether to send email notification
+     * @param customMessage Optional free-text note added to the update email; may be null/blank to omit.
+     */
+    public ResponseEntity<com.pimvanleeuwen.the_harry_list_backend.dto.Reservation> executeWithEmail(
+            com.pimvanleeuwen.the_harry_list_backend.dto.Reservation input, boolean sendEmail, String customMessage) {
         if (input.getId() == null) {
             log.error("Cannot update reservation without ID");
             return ResponseEntity.badRequest().build();
@@ -96,7 +102,7 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         // Send email notification if enabled
         if (sendEmail && emailService != null) {
             try {
-                emailService.sendReservationUpdatedEmail(savedEntity);
+                emailService.sendReservationUpdatedEmail(savedEntity, customMessage);
             } catch (Exception e) {
                 log.error("Failed to send update email, but reservation was updated successfully", e);
             }

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -221,7 +221,7 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any());
+        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any(), any());
     }
 
     @Test
@@ -240,7 +240,47 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any(), any());
+        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldForwardCustomMessageToEmail() throws Exception {
+        // Given
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        // When
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "REJECTED")
+                .param("customMessage", "Sorry, we are fully booked that day."))
+            .andExpect(status().isOk());
+
+        // Then
+        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any(),
+                eq("Sorry, we are fully booked that day."));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldNoteCustomMessageInAuditWhenProvided() throws Exception {
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "REJECTED")
+                .param("customMessage", "No space available."))
+            .andExpect(status().isOk());
+
+        verify(auditService).recordAction(
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.RESERVATION),
+            eq(1L), any(),
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.STATUS_CHANGE),
+            any(), contains("(with message)"));
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/ReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/ReservationControllerTest.java
@@ -129,7 +129,7 @@ class ReservationControllerTest {
         // Given
         sampleReservation.setId(1L);
         sampleReservation.setContactName("Updated Name");
-        when(updateReservationService.executeWithEmail(any(Reservation.class), anyBoolean()))
+        when(updateReservationService.executeWithEmail(any(Reservation.class), anyBoolean(), any()))
                 .thenReturn(ResponseEntity.ok(sampleReservation));
 
         // When & Then

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateServiceTest.java
@@ -186,6 +186,114 @@ class EmailTemplateServiceTest {
         assertTrue(subject.contains("Team Lunch"));
     }
 
+    // --- Custom message block ---
+
+    private Map<String, String> statusChangeVars() {
+        Map<String, String> vars = new java.util.HashMap<>();
+        vars.put("statusColor", "#f44336");
+        vars.put("status", "Rejected");
+        vars.put("statusMessage", "Unfortunately, we're unable to accommodate your request.");
+        vars.put("contactName", "Alice");
+        vars.put("confirmationNumber", "X");
+        vars.put("eventTitle", "Borrel");
+        vars.put("eventDate", "Monday");
+        vars.put("startTime", "18:00");
+        vars.put("endTime", "22:00");
+        vars.put("location", "Hubble");
+        vars.put("expectedGuests", "20");
+        vars.put("barName", "Hubble Cafe");
+        vars.put("staffEmail", "staff@hubble.cafe");
+        vars.put("statusSubject", "Reservation Request Update");
+        return vars;
+    }
+
+    @Test
+    void statusChanged_shouldInjectCustomMessageBlockWhenProvided() {
+        String block = EmailTemplates.buildCustomMessageBlock("We will keep a shaded spot for you.");
+        String body = service.getRenderedBody(EmailTemplateType.STATUS_CHANGED,
+                statusChangeVars(), Map.of("customMessage", block));
+
+        assertTrue(body.contains("We will keep a shaded spot for you."));
+        // The block HTML must survive verbatim (not double-escaped).
+        assertTrue(body.contains("border-left: 4px solid #6b46c1"));
+        assertFalse(body.contains("{{customMessage}}"));
+    }
+
+    @Test
+    void statusChanged_shouldOmitCustomMessageWhenNoneProvided() {
+        // The 2-arg overload defaults the block to empty for status-change emails.
+        String body = service.getRenderedBody(EmailTemplateType.STATUS_CHANGED, statusChangeVars());
+
+        assertFalse(body.contains("{{customMessage}}"), "Placeholder must not render literally");
+        assertFalse(body.contains("border-left: 4px solid #6b46c1"), "No block when no message");
+    }
+
+    @Test
+    void updated_shouldInjectCustomMessageBlockWhenProvided() {
+        Map<String, String> vars = new java.util.HashMap<>();
+        vars.put("contactName", "Bob");
+        vars.put("confirmationNumber", "U1");
+        vars.put("eventTitle", "Workshop");
+        vars.put("eventDate", "Tuesday");
+        vars.put("startTime", "10:00");
+        vars.put("endTime", "12:00");
+        vars.put("location", "Meteor");
+        vars.put("expectedGuests", "12");
+        vars.put("status", "Confirmed");
+        vars.put("barName", "Meteor Cafe");
+
+        String block = EmailTemplates.buildCustomMessageBlock("We moved you to the larger room.");
+        String body = service.getRenderedBody(EmailTemplateType.UPDATED, vars,
+                Map.of("customMessage", block));
+
+        assertTrue(body.contains("We moved you to the larger room."));
+        assertFalse(body.contains("{{customMessage}}"));
+    }
+
+    @Test
+    void customMessageBlock_shouldEscapeHtmlButRenderVerbatim() {
+        String block = EmailTemplates.buildCustomMessageBlock("<script>alert('x')</script>");
+        String body = service.getRenderedBody(EmailTemplateType.STATUS_CHANGED,
+                statusChangeVars(), Map.of("customMessage", block));
+
+        assertFalse(body.contains("<script>"), "Message text must be escaped");
+        assertTrue(body.contains("&lt;script&gt;"));
+        // The wrapping div is intentional HTML and must remain.
+        assertTrue(body.contains("<div"));
+    }
+
+    @Test
+    void buildCustomMessageBlock_shouldReturnEmptyForBlankOrNull() {
+        assertEquals("", EmailTemplates.buildCustomMessageBlock(null));
+        assertEquals("", EmailTemplates.buildCustomMessageBlock(""));
+        assertEquals("", EmailTemplates.buildCustomMessageBlock("   "));
+    }
+
+    @Test
+    void buildCustomMessageBlock_shouldConvertNewlinesToBreaks() {
+        String block = EmailTemplates.buildCustomMessageBlock("line one\nline two");
+        assertTrue(block.contains("line one<br>line two"));
+    }
+
+    @Test
+    void availableVariables_shouldIncludeCustomMessageForStatusAndUpdatedOnly() {
+        assertTrue(service.getAvailableVariables(EmailTemplateType.STATUS_CHANGED).contains("customMessage"));
+        assertTrue(service.getAvailableVariables(EmailTemplateType.UPDATED).contains("customMessage"));
+        assertFalse(service.getAvailableVariables(EmailTemplateType.SUBMITTED).contains("customMessage"));
+        assertFalse(service.getAvailableVariables(EmailTemplateType.CANCELLED).contains("customMessage"));
+    }
+
+    @Test
+    void buildSampleRawHtmlVariables_shouldProvideBlockForStatusAndUpdatedOnly() {
+        assertTrue(service.buildSampleRawHtmlVariables(EmailTemplateType.STATUS_CHANGED)
+                .containsKey("customMessage"));
+        assertFalse(service.buildSampleRawHtmlVariables(EmailTemplateType.STATUS_CHANGED)
+                .get("customMessage").isBlank());
+        assertTrue(service.buildSampleRawHtmlVariables(EmailTemplateType.UPDATED)
+                .containsKey("customMessage"));
+        assertTrue(service.buildSampleRawHtmlVariables(EmailTemplateType.SUBMITTED).isEmpty());
+    }
+
     // --- Default content ---
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,6 +39,9 @@ class UpdateReservationServiceTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private EmailNotificationService emailService;
+
     @InjectMocks
     private UpdateReservationService updateReservationService;
 
@@ -48,6 +52,9 @@ class UpdateReservationServiceTest {
     void setUp() {
         sampleDto = createSampleDto();
         existingEntity = createExistingEntity();
+        // emailService is an optional (@Autowired(required=false)) field, not a constructor arg, so
+        // @InjectMocks (constructor injection) doesn't set it — wire the mock in explicitly.
+        ReflectionTestUtils.setField(updateReservationService, "emailService", emailService);
     }
 
     @Test
@@ -95,6 +102,44 @@ class UpdateReservationServiceTest {
                 c.field().equals("contactName")
                         && "Original Name".equals(c.oldValue())
                         && "Updated Name".equals(c.newValue())));
+    }
+
+    @Test
+    void executeWithEmail_shouldForwardCustomMessageToEmail() {
+        // Given
+        sampleDto.setId(1L);
+        com.pimvanleeuwen.the_harry_list_backend.model.Reservation incoming = createExistingEntity();
+        incoming.setContactName("Updated Name");
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(reservationMapper.toEntity(sampleDto)).thenReturn(incoming);
+        when(reservationRepository.save(any())).thenReturn(incoming);
+        when(reservationMapper.toDto(incoming)).thenReturn(sampleDto);
+
+        // When
+        updateReservationService.executeWithEmail(sampleDto, true, "We moved your booking to the terrace.");
+
+        // Then
+        verify(emailService).sendReservationUpdatedEmail(any(), eq("We moved your booking to the terrace."));
+    }
+
+    @Test
+    void executeWithEmail_shouldNotSendEmailWhenDisabled() {
+        // Given
+        sampleDto.setId(1L);
+        com.pimvanleeuwen.the_harry_list_backend.model.Reservation incoming = createExistingEntity();
+        incoming.setContactName("Updated Name");
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(reservationMapper.toEntity(sampleDto)).thenReturn(incoming);
+        when(reservationRepository.save(any())).thenReturn(incoming);
+        when(reservationMapper.toDto(incoming)).thenReturn(sampleDto);
+
+        // When
+        updateReservationService.executeWithEmail(sampleDto, false, "ignored message");
+
+        // Then
+        verify(emailService, never()).sendReservationUpdatedEmail(any(), any());
     }
 
     @Test


### PR DESCRIPTION
Closes #279

### What & why

Staff couldn't add a one-off clarification to the automated emails sent when a reservation changes state, e.g. "we read your special request and will keep a shaded spot for you". This PR adds an optional free-text message to those emails, plus an editable default reason for rejections.

### Scope

An optional message box now appears for every customer-facing reservation action: **Confirm, Reject, Cancel, Complete** (status changes) and **Edit** (update). The box only shows when the "Send email notification" checkbox is on. When rejecting, it's pre-filled with an editable default *"Unfortunately we cannot host you since we do not have any places left at this time"* which staff can edit, replace, or clear before sending.

### How it works

- The message is delivered via a new `{{customMessage}}` placeholder in the **Reservation Confirmed/Rejected** (`STATUS_CHANGED`) and **Reservation Updated** (`UPDATED`) templates. The email service injects a pre-built, styled HTML block, or nothing when no message is entered.
- This composes cleanly with the editable email-template feature: `{{customMessage}}` is listed in the template variables, admins can reposition/remove it, and the test-send preview renders a sample block. A new raw-HTML render path substitutes the block without re-escaping, while the message text itself is HTML-escaped (XSS-safe) and newlines become `<br>`.
- The audit log records that a message accompanied a status change ("(with message)") without storing its content, consistent with the existing internal-notes convention.

### API changes (backward-compatible)

- `PATCH /api/admin/reservations/{id}/status` — new optional `customMessage` query param.
- `PUT /api/reservations/{id}` — new optional `customMessage` query param.
- `EmailNotificationService.sendStatusChangeEmail(...)` and `sendReservationUpdatedEmail(...)` gain a `customMessage` argument; `UpdateReservationService` adds an `executeWithEmail(..., customMessage)` overload, with the old signatures preserved.

### Tests

- Backend: 287 passed. New coverage for block injection, empty-when-blank, HTML-escaping, newline handling, and template variables (`EmailTemplateServiceTest`); message forwarding + audit note (`AdminReservationControllerTest`); message forwarding + disabled-email (`UpdateReservationServiceTest`). Existing mock arities updated.
- Admin frontend: 94 passed. New coverage for the pre-filled rejection default, a typed confirmation message, and the field hiding when email is off.
- Both production builds succeed.

### Docs

In-app help (`guideContent.ts`) updated: the Status Actions guide describes the optional message box and editable rejection default; the Email Templates guide documents the `{{customMessage}}` variable. README needs no change, as it covers deployment/config rather than template variables.

### Compatibility

No breaking changes. Existing emails render identically when no message is supplied, and the audit-log and email-template features are unaffected.