### PR TITLE
280 feature catering export

### DIFF
--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -169,7 +169,10 @@ export const exportGuide: GuideSection[] = [
 1. **Select a date** — choose the day you want the report for
 2. **Select a location** — choose either Hubble or Meteor
 3. **Confirmed only** — toggle this on to exclude pending, rejected, or cancelled reservations (recommended for daily prep sheets)
-4. Click **"Export PDF"**
+4. **Catering only** — toggle this on to include only reservations that have catering (eat a la carte, eat catering, or Catering Corona Room) — handy for the kitchen's prep list
+5. Click **"Export PDF"**
+
+You can combine the two toggles, e.g. **Confirmed only + Catering only** for a confirmed catering prep sheet.
 
 The PDF will automatically download to your device.
 

--- a/the-harry-list-admin/src/pages/ExportPage.tsx
+++ b/the-harry-list-admin/src/pages/ExportPage.tsx
@@ -10,6 +10,7 @@ export function ExportPage() {
   );
   const [selectedLocation, setSelectedLocation] = useState<'HUBBLE' | 'METEOR'>('HUBBLE');
   const [confirmedOnly, setConfirmedOnly] = useState(true);
+  const [cateringOnly, setCateringOnly] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,7 +20,7 @@ export function ExportPage() {
 
     try {
       const response = await fetchWithAuth(
-        `/api/admin/export/daily-report?date=${selectedDate}&location=${selectedLocation}&confirmedOnly=${confirmedOnly}`
+        `/api/admin/export/daily-report?date=${selectedDate}&location=${selectedLocation}&confirmedOnly=${confirmedOnly}&cateringOnly=${cateringOnly}`
       );
 
       if (!response.ok) {
@@ -146,18 +147,33 @@ export function ExportPage() {
               <Filter className="w-4 h-4" />
               Filter
             </label>
-            <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
-              <input
-                type="checkbox"
-                checked={confirmedOnly}
-                onChange={(e) => setConfirmedOnly(e.target.checked)}
-                className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
-              />
-              <div>
-                <span className="text-sm font-medium text-white">Confirmed reservations only</span>
-                <p className="text-xs text-dark-400">Exclude pending, rejected, and cancelled reservations</p>
-              </div>
-            </label>
+            <div className="space-y-3">
+              <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={confirmedOnly}
+                  onChange={(e) => setConfirmedOnly(e.target.checked)}
+                  className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
+                />
+                <div>
+                  <span className="text-sm font-medium text-white">Confirmed reservations only</span>
+                  <p className="text-xs text-dark-400">Exclude pending, rejected, and cancelled reservations</p>
+                </div>
+              </label>
+
+              <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={cateringOnly}
+                  onChange={(e) => setCateringOnly(e.target.checked)}
+                  className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
+                />
+                <div>
+                  <span className="text-sm font-medium text-white">Catering reservations only</span>
+                  <p className="text-xs text-dark-400">Only include reservations with catering (eat a la carte, eat catering, or Catering Corona Room)</p>
+                </div>
+              </label>
+            </div>
           </div>
 
           {/* Error Message */}

--- a/the-harry-list-admin/src/test/ExportPage.test.tsx
+++ b/the-harry-list-admin/src/test/ExportPage.test.tsx
@@ -39,5 +39,19 @@ describe('ExportPage', () => {
     renderWithRouter(<ExportPage />);
     expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
   });
+
+  it('displays catering only filter', () => {
+    renderWithRouter(<ExportPage />);
+    expect(screen.getByText(/catering reservations only/i)).toBeInTheDocument();
+  });
+
+  it('catering filter is unchecked by default', () => {
+    renderWithRouter(<ExportPage />);
+    const cateringCheckbox = screen
+      .getByText(/catering reservations only/i)
+      .closest('label')!
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(cateringCheckbox).not.toBeChecked();
+  });
 });
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportController.java
@@ -34,7 +34,8 @@ public class AdminExportController {
     public ResponseEntity<byte[]> generateDailyReport(
             @RequestParam String date,
             @RequestParam String location,
-            @RequestParam(required = false, defaultValue = "true") boolean confirmedOnly) {
+            @RequestParam(required = false, defaultValue = "true") boolean confirmedOnly,
+            @RequestParam(required = false, defaultValue = "false") boolean cateringOnly) {
 
         // Parse date
         LocalDate reportDate;
@@ -53,7 +54,7 @@ public class AdminExportController {
         }
 
         try {
-            byte[] pdfBytes = pdfExportService.generateDailyReport(reportDate, reportLocation, confirmedOnly);
+            byte[] pdfBytes = pdfExportService.generateDailyReport(reportDate, reportLocation, confirmedOnly, cateringOnly);
 
             String filename = String.format("reservations-%s-%s.pdf",
                     reportLocation.name().toLowerCase(),

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
@@ -38,11 +38,12 @@ public class PdfExportService {
         this.reservationRepository = reservationRepository;
     }
 
-    public byte[] generateDailyReport(LocalDate date, BarLocation location, boolean confirmedOnly) throws DocumentException {
+    public byte[] generateDailyReport(LocalDate date, BarLocation location, boolean confirmedOnly, boolean cateringOnly) throws DocumentException {
         List<Reservation> reservations = reservationRepository.findAll().stream()
                 .filter(r -> r.getEventDate() != null && r.getEventDate().equals(date))
                 .filter(r -> r.getLocation() != null && r.getLocation().equals(location))
                 .filter(r -> !confirmedOnly || r.getStatus() == ReservationStatus.CONFIRMED)
+                .filter(r -> !cateringOnly || hasCateringActivity(r))
                 .sorted(Comparator.comparing(r -> r.getStartTime() != null ? r.getStartTime() : java.time.LocalTime.MAX))
                 .toList();
 
@@ -227,9 +228,7 @@ public class PdfExportService {
         contentCell.addElement(content);
 
         // Add catering info if present
-        boolean hasCateringActivity = res.getSpecialActivities() != null && res.getSpecialActivities().stream()
-                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE || a == SpecialActivity.EAT_CATERING || a == SpecialActivity.CATERING_CORONA_ROOM);
-        if (hasCateringActivity) {
+        if (hasCateringActivity(res)) {
             Paragraph cateringStatusPara = new Paragraph();
             cateringStatusPara.setSpacingBefore(10);
             cateringStatusPara.add(new Chunk("Catering Arranged: ", labelFont));
@@ -468,6 +467,18 @@ public class PdfExportService {
         cell.setHorizontalAlignment(alignment);
         cell.setPaddingTop(5);
         table.addCell(cell);
+    }
+
+    /**
+     * Whether a reservation includes catering, i.e. has one of the catering-related
+     * special activities. Used both to filter the report (cateringOnly) and to decide
+     * whether to render the catering info block on a reservation card.
+     */
+    private boolean hasCateringActivity(Reservation res) {
+        return res.getSpecialActivities() != null && res.getSpecialActivities().stream()
+                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE
+                        || a == SpecialActivity.EAT_CATERING
+                        || a == SpecialActivity.CATERING_CORONA_ROOM);
     }
 
     private void addField(Paragraph para, String label, String value, Font labelFont, Font valueFont) {

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportControllerTest.java
@@ -39,7 +39,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldReturnPdf() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -55,7 +55,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldAcceptConfirmedOnlyParameter() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), eq(false)))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), eq(false), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -63,6 +63,38 @@ class AdminExportControllerTest {
                 .param("date", "2026-02-15")
                 .param("location", "HUBBLE")
                 .param("confirmedOnly", "false"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void generateDailyReport_shouldAcceptCateringOnlyParameter() throws Exception {
+        // Given
+        byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), eq(true)))
+            .thenReturn(mockPdf);
+
+        // When/Then
+        mockMvc.perform(get("/api/admin/export/daily-report")
+                .param("date", "2026-02-15")
+                .param("location", "HUBBLE")
+                .param("cateringOnly", "true"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_PDF));
+    }
+
+    @Test
+    @WithMockUser
+    void generateDailyReport_shouldDefaultCateringOnlyToFalse() throws Exception {
+        // Given - no cateringOnly param supplied, service should be called with false
+        byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), eq(false)))
+            .thenReturn(mockPdf);
+
+        // When/Then
+        mockMvc.perform(get("/api/admin/export/daily-report")
+                .param("date", "2026-02-15")
+                .param("location", "HUBBLE"))
             .andExpect(status().isOk());
     }
 
@@ -91,7 +123,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldAcceptMeteorLocation() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.METEOR), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.METEOR), anyBoolean(), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -107,7 +139,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldAcceptLowercaseLocation() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -121,7 +153,7 @@ class AdminExportControllerTest {
     @WithMockUser
     void generateDailyReport_shouldReturnInternalServerErrorOnException() throws Exception {
         // Given
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), any(BarLocation.class), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), any(BarLocation.class), anyBoolean(), anyBoolean()))
             .thenThrow(new DocumentException("PDF generation failed"));
 
         // When/Then

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportServiceTest.java
@@ -1,0 +1,166 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import org.openpdf.text.DocumentException;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.parser.PdfTextExtractor;
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+import com.pimvanleeuwen.the_harry_list_backend.model.SpecialActivity;
+import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for PdfExportService, focusing on the reservation filtering logic
+ * (confirmed-only and catering-only) applied before rendering the daily report.
+ */
+@ExtendWith(MockitoExtension.class)
+class PdfExportServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @InjectMocks
+    private PdfExportService pdfExportService;
+
+    private static final LocalDate REPORT_DATE = LocalDate.of(2026, 2, 15);
+
+    @Test
+    void generateDailyReport_cateringOnly_includesOnlyCateringReservations() throws Exception {
+        // Given: one catering reservation and one non-catering reservation on the same day/location
+        Reservation catering = reservation("Catering Dinner", LocalTime.of(18, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_CATERING));
+        Reservation nonCatering = reservation("Plain Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(catering, nonCatering));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, true);
+
+        // Then: only the catering reservation appears
+        String text = extractText(pdf);
+        assertTrue(text.contains("Catering Dinner"), "Catering reservation should be included");
+        assertFalse(text.contains("Plain Drinks"), "Non-catering reservation should be excluded");
+    }
+
+    @Test
+    void generateDailyReport_cateringOnlyFalse_includesAllReservations() throws Exception {
+        // Given
+        Reservation catering = reservation("Catering Dinner", LocalTime.of(18, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_A_LA_CARTE));
+        Reservation nonCatering = reservation("Plain Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(catering, nonCatering));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        // Then: both reservations appear
+        String text = extractText(pdf);
+        assertTrue(text.contains("Catering Dinner"));
+        assertTrue(text.contains("Plain Drinks"));
+    }
+
+    @Test
+    void generateDailyReport_cateringOnly_recognisesAllCateringActivities() throws Exception {
+        // Given: each of the three catering activities should qualify
+        Reservation alaCarte = reservation("A La Carte Lunch", LocalTime.of(12, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_A_LA_CARTE));
+        Reservation cateringEvent = reservation("Full Catering", LocalTime.of(15, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_CATERING));
+        Reservation coronaRoom = reservation("Corona Room Catering", LocalTime.of(17, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.CATERING_CORONA_ROOM));
+        Reservation graduation = reservation("Graduation Only", LocalTime.of(19, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.GRADUATION));
+        when(reservationRepository.findAll())
+                .thenReturn(List.of(alaCarte, cateringEvent, coronaRoom, graduation));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, true);
+
+        // Then
+        String text = extractText(pdf);
+        assertTrue(text.contains("A La Carte Lunch"));
+        assertTrue(text.contains("Full Catering"));
+        assertTrue(text.contains("Corona Room Catering"));
+        assertFalse(text.contains("Graduation Only"), "Non-catering activity should be excluded");
+    }
+
+    @Test
+    void generateDailyReport_cateringOnly_combinesWithConfirmedOnly() throws Exception {
+        // Given: a confirmed catering reservation and a pending catering reservation
+        Reservation confirmedCatering = reservation("Confirmed Catering", LocalTime.of(18, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_CATERING));
+        Reservation pendingCatering = reservation("Pending Catering", LocalTime.of(20, 0),
+                ReservationStatus.PENDING, Set.of(SpecialActivity.EAT_CATERING));
+        when(reservationRepository.findAll()).thenReturn(List.of(confirmedCatering, pendingCatering));
+
+        // When: both filters active
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, true, true);
+
+        // Then: only the confirmed catering reservation remains
+        String text = extractText(pdf);
+        assertTrue(text.contains("Confirmed Catering"));
+        assertFalse(text.contains("Pending Catering"));
+    }
+
+    @Test
+    void generateDailyReport_cateringOnly_withNoMatches_producesEmptyReport() throws Exception {
+        // Given: only non-catering reservations
+        Reservation nonCatering = reservation("Plain Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(nonCatering));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, true);
+
+        // Then: a valid PDF is still produced with the "no reservations" message
+        assertNotNull(pdf);
+        assertTrue(pdf.length > 0);
+        String text = extractText(pdf);
+        assertTrue(text.contains("No reservations for this date."));
+        assertFalse(text.contains("Plain Drinks"));
+    }
+
+    // --- helpers ---
+
+    private Reservation reservation(String title, LocalTime start, ReservationStatus status,
+                                    Set<SpecialActivity> activities) {
+        Reservation r = new Reservation();
+        r.setEventTitle(title);
+        r.setContactName("Test Contact");
+        r.setEmail("test@example.com");
+        r.setEventDate(REPORT_DATE);
+        r.setStartTime(start);
+        r.setEndTime(start.plusHours(2));
+        r.setLocation(BarLocation.HUBBLE);
+        r.setExpectedGuests(10);
+        r.setStatus(status);
+        r.setSpecialActivities(activities);
+        return r;
+    }
+
+    private String extractText(byte[] pdf) throws IOException {
+        PdfReader reader = new PdfReader(pdf);
+        PdfTextExtractor extractor = new PdfTextExtractor(reader);
+        StringBuilder sb = new StringBuilder();
+        for (int page = 1; page <= reader.getNumberOfPages(); page++) {
+            sb.append(extractor.getTextFromPage(page)).append('\n');
+        }
+        reader.close();
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Catering-only export filter

Adds a **"Catering reservations only"** toggle to the daily-report export, mirroring the existing "Confirmed only" toggle but filtering for reservations that include catering. A reservation counts as catering when its special activities include *Eat a la carte*, *Eat catering*, or *Catering Corona Room* the same definition already used to render the catering block on each reservation card.

### Backend

- `PdfExportService.generateDailyReport` takes a new `boolean cateringOnly` and applies `!cateringOnly || hasCateringActivity(r)` to the reservation stream. The catering check was extracted from the inline card-rendering logic into a private `hasCateringActivity` helper, so the filter and the card display now share a single source of truth.
- `AdminExportController` exposes a new `cateringOnly` query param on `GET /api/admin/export/daily-report`, `required = false` with `defaultValue = "false"` so existing callers are unaffected.

### Frontend

- The export page has a second checkbox ("Catering reservations only", off by default) that passes `cateringOnly` through to the endpoint. It combines with the confirmed-only toggle, e.g. confirmed + catering for a kitchen prep sheet.

### Docs

- The in-app export help guide (`guideContent.ts`) documents the new toggle and the fact that the two filters can be combined.

### Tests

- New `PdfExportServiceTest` (the file was previously empty) extracts the generated PDF text and asserts the filter includes only catering reservations, recognises all three catering activities, combines correctly with `confirmedOnly`, and still produces a valid empty report when nothing matches.
- `AdminExportControllerTest` updated for the new signature, plus cases that `cateringOnly=true` is accepted and that it defaults to `false` when omitted.
- `ExportPage.test.tsx` covers the toggle rendering and its default-off state.

All backend export tests (15) and ExportPage tests (7) pass; `tsc --noEmit` and ESLint are clean. No audit-log changes — exports are read-only and aren't audited today.