### PR TITLE
253 bug datetime fields on mobile not loading correctly

### DIFF
--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -305,22 +305,22 @@ export function CalendarAppointmentsPage() {
               {/* Time fields (hidden when all-day) */}
               {!editing.allDay && (
                 <div className="grid grid-cols-2 gap-4">
-                  <div>
+                  <div className="min-w-0">
                     <label className="label">Start Time *</label>
                     <input
                       type="time"
                       value={editing.startTime || ''}
                       onChange={e => setEditing({ ...editing, startTime: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label className="label">End Time *</label>
                     <input
                       type="time"
                       value={editing.endTime || ''}
                       onChange={e => setEditing({ ...editing, endTime: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
                 </div>

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -591,21 +591,47 @@ export function SettingsPage() {
                 <div className="grid grid-cols-2 gap-3">
                   <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">Start Time (optional)</label>
-                    <input
-                      type="time"
-                      value={editingPeriod.startTime || ''}
-                      onChange={e => setEditingPeriod({ ...editingPeriod, startTime: e.target.value || undefined })}
-                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
-                    />
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="time"
+                        value={editingPeriod.startTime || ''}
+                        onChange={e => setEditingPeriod({ ...editingPeriod, startTime: e.target.value || undefined })}
+                        className="w-full min-w-0 flex-1 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                      {editingPeriod.startTime && (
+                        <button
+                          type="button"
+                          onClick={() => setEditingPeriod({ ...editingPeriod, startTime: undefined })}
+                          aria-label="Clear start time"
+                          title="Clear start time"
+                          className="shrink-0 p-2 text-dark-400 hover:text-white"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                   <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">End Time (optional)</label>
-                    <input
-                      type="time"
-                      value={editingPeriod.endTime || ''}
-                      onChange={e => setEditingPeriod({ ...editingPeriod, endTime: e.target.value || undefined })}
-                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
-                    />
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="time"
+                        value={editingPeriod.endTime || ''}
+                        onChange={e => setEditingPeriod({ ...editingPeriod, endTime: e.target.value || undefined })}
+                        className="w-full min-w-0 flex-1 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                      {editingPeriod.endTime && (
+                        <button
+                          type="button"
+                          onClick={() => setEditingPeriod({ ...editingPeriod, endTime: undefined })}
+                          aria-label="Clear end time"
+                          title="Clear end time"
+                          className="shrink-0 p-2 text-dark-400 hover:text-white"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
 

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -568,43 +568,43 @@ export function SettingsPage() {
                 </div>
 
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">Start Date *</label>
                     <input
                       type="date"
                       value={editingPeriod.startDate}
                       onChange={e => setEditingPeriod({ ...editingPeriod, startDate: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">End Date *</label>
                     <input
                       type="date"
                       value={editingPeriod.endDate}
                       onChange={e => setEditingPeriod({ ...editingPeriod, endDate: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">Start Time (optional)</label>
                     <input
                       type="time"
                       value={editingPeriod.startTime || ''}
                       onChange={e => setEditingPeriod({ ...editingPeriod, startTime: e.target.value || undefined })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">End Time (optional)</label>
                     <input
                       type="time"
                       value={editingPeriod.endTime || ''}
                       onChange={e => setEditingPeriod({ ...editingPeriod, endTime: e.target.value || undefined })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
                 </div>

--- a/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
+++ b/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
@@ -209,4 +209,42 @@ describe('FormSettingsPage', () => {
       expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
     });
   });
+
+  it('clears an optional blocked-period time via the clear button', async () => {
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Blocked Period')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Blocked Period'));
+
+    await waitFor(() => {
+      expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
+    });
+
+    const startTime = document.querySelector('input[type="time"]') as HTMLInputElement;
+    expect(startTime).toBeTruthy();
+
+    // No clear button while the time is empty
+    expect(screen.queryByLabelText('Clear start time')).not.toBeInTheDocument();
+
+    // Setting a value reveals the clear button
+    fireEvent.change(startTime, { target: { value: '10:30' } });
+    expect(startTime.value).toBe('10:30');
+
+    const clearBtn = await screen.findByLabelText('Clear start time');
+    fireEvent.click(clearBtn);
+
+    // Time is cleared and the clear button disappears again
+    await waitFor(() => {
+      expect((document.querySelector('input[type="time"]') as HTMLInputElement).value).toBe('');
+    });
+    expect(screen.queryByLabelText('Clear start time')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Fix datetime fields on mobile

Fixes #253.

The start/end date and time fields in the New/Edit Blocked Period form overlapped on mobile, and the optional times could not be cleared once set because iOS native time inputs offer no clear affordance.

### Changes
- Add `min-w-0` to the side by side date/time grid cells so the native inputs shrink to fit instead of overflowing their columns. Applied to the Blocked Period form (FormSettingsPage) and the Calendar Appointments form, which both use a fixed two column grid. ReservationDetailPage already stacks to one column on mobile so it was unaffected.
- Add an inline clear button next to each optional Start/End Time field in the Blocked Period modal. It appears only when a value is set and empties the field, so optional times can be removed on mobile.

### Testing
- New test covering the clear behavior (reveal on value, clear on click, hide when empty).
- Full admin suite passes (95 tests), build and lint clean.