### PR TITLE
254 feature ability to use soft blocked periods

### DIFF
--- a/docs/migration-soft-blocked-periods.md
+++ b/docs/migration-soft-blocked-periods.md
@@ -1,0 +1,60 @@
+# Soft-Blocked Periods Migration Guide
+
+## Overview
+
+This migration adds a **soft block** option to blocked periods. A soft block keeps a
+period marked and shows the customer a warning, but — unlike a normal (hard) block — it
+does **not** prevent the booking. The customer must tick an acknowledgement checkbox to
+continue. This is intended for situations such as a summer closing where the bar is closed
+by default but opens on request of a reservation.
+
+The change is **additive and backwards compatible**: it adds two nullable/defaulted columns
+to the existing `blocked_periods` table. No existing tables, rows, or API contracts change —
+existing blocked periods keep behaving as hard blocks (`soft_block = false`).
+
+## Step 1: Run SQL Migration
+
+The production backend runs with `ddl-auto=validate`, so the columns must exist **before**
+deploying the new backend. Execute the following on the production MariaDB database:
+
+```sql
+ALTER TABLE blocked_periods
+  ADD COLUMN soft_block BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN acknowledgement_text VARCHAR(500) NULL;
+```
+
+- `soft_block` — `false` (hard block) for all existing rows, preserving current behaviour.
+- `acknowledgement_text` — optional checkbox label shown for a soft block; `NULL`/blank
+  falls back to a sensible default message on the public form.
+
+Dev and test environments create the columns automatically (`ddl-auto=update` / H2), so no
+manual step is needed there.
+
+## Step 2: Deploy
+
+Deploy the new backend and frontends. Deployment order does not matter — the SQL migration
+adds the columns before the backend validates the schema, and existing endpoints/payloads
+remain valid (the new fields are optional in the API).
+
+## Step 3: Verify
+
+1. In the admin **Form Settings → Blocked Periods**, add or edit a period and enable
+   **"Soft block (allow bookings with a warning)"**. Optionally set the acknowledgement text.
+   The row shows an amber **"Soft block"** badge.
+2. On the public reservation form, choose a date inside that period:
+   - The public message appears as an amber warning with an **acknowledgement checkbox**.
+   - **Continue** is blocked until the checkbox is ticked, then the booking proceeds.
+3. Confirm a regular (hard) blocked period still fully blocks the date with a red notice and
+   no checkbox.
+4. Editing a period records the `softBlock` / `acknowledgementText` changes in the **audit log**.
+
+## Rollback
+
+The columns are additive and unused by older code. To roll back, redeploy the previous
+backend; the extra columns can be left in place harmlessly, or dropped with:
+
+```sql
+ALTER TABLE blocked_periods
+  DROP COLUMN soft_block,
+  DROP COLUMN acknowledgement_text;
+```

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -361,7 +361,20 @@ Click **"Add Blocked Period"** and fill in:
 2. **Location** — optionally limit the block to just Hubble or Meteor (leave empty for both)
 3. **Reason** — internal note for staff (not shown to customers)
 4. **Public message** — the message customers see when trying to book these dates
-5. **Enabled** — toggle on/off
+5. **Soft block** — see below
+6. **Enabled** — toggle on/off
+
+### Hard vs. Soft Blocks
+
+By default a blocked period is a **hard block**: customers cannot book those dates at all.
+
+Turn on **Soft block (allow bookings with a warning)** when the venue is closed *by default* but bookings are still possible — for example a summer closing where the bar opens only on request. With a soft block:
+
+- The period is still marked and the **public message** is shown as a warning.
+- The customer must tick an **acknowledgement checkbox** before continuing, then can complete the booking.
+- Soft-blocked rows are marked with an amber **"Soft block"** badge in the list.
+
+When soft block is on you can set the **acknowledgement text** — the checkbox label the customer must tick (e.g. *"I understand the bar may be closed and my reservation is a request"*). Leave it blank to use a sensible default.
 
 ### Tip
 You can create blocked periods in advance. Use the **enabled toggle** to activate them when needed instead of creating and deleting them each time.`,

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -52,6 +52,8 @@ const emptyBlockedPeriod: BlockedPeriod = {
   endTime: '',
   reason: '',
   publicMessage: '',
+  softBlock: false,
+  acknowledgementText: '',
   enabled: true,
 };
 
@@ -353,10 +355,15 @@ export function SettingsPage() {
                   }`}
                 >
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="text-xs font-mono px-2 py-0.5 rounded bg-dark-800 text-red-400">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <span className={`text-xs font-mono px-2 py-0.5 rounded bg-dark-800 ${bp.softBlock ? 'text-amber-400' : 'text-red-400'}`}>
                         {bp.startDate} — {bp.endDate}
                       </span>
+                      {bp.softBlock && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">
+                          Soft block
+                        </span>
+                      )}
                       {bp.location && (
                         <span className="text-xs font-mono px-2 py-0.5 rounded bg-dark-800 text-amber-400">
                           {bp.location}
@@ -655,6 +662,44 @@ export function SettingsPage() {
                     placeholder="e.g. Closed for maintenance"
                     className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                   />
+                </div>
+
+                <div className="rounded-lg border border-dark-700 bg-dark-800/40 p-3 space-y-3">
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={!!editingPeriod.softBlock}
+                      onClick={() => setEditingPeriod({ ...editingPeriod, softBlock: !editingPeriod.softBlock })}
+                      className="shrink-0 mt-0.5"
+                      title="Toggle soft block"
+                    >
+                      {editingPeriod.softBlock
+                        ? <ToggleRight className="w-6 h-6 text-amber-400" />
+                        : <ToggleLeft className="w-6 h-6 text-dark-500" />}
+                    </button>
+                    <span className="text-sm text-white">
+                      Soft block (allow bookings with a warning)
+                      <span className="block text-xs text-dark-400 font-light mt-0.5">
+                        Guests can still book during this period, but must acknowledge a warning first.
+                        Use this for e.g. a summer closing where the bar opens on request.
+                      </span>
+                    </span>
+                  </label>
+
+                  {editingPeriod.softBlock && (
+                    <div>
+                      <label className="block text-sm text-dark-400 mb-1">Acknowledgement text (checkbox label)</label>
+                      <input
+                        type="text"
+                        value={editingPeriod.acknowledgementText || ''}
+                        onChange={e => setEditingPeriod({ ...editingPeriod, acknowledgementText: e.target.value })}
+                        placeholder="I understand the bar may be closed and my reservation is a request"
+                        className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                      <p className="text-xs text-dark-500 mt-1">Leave blank to use a default acknowledgement message.</p>
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
+++ b/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { FormSettingsPage } from '../pages/FormSettingsPage';
+import { fetchBlockedPeriods } from '../lib/api';
 
 vi.mock('../lib/usePermissions', () => ({
   usePermissions: () => ({
@@ -207,6 +208,60 @@ describe('FormSettingsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
+    });
+  });
+
+  it('reveals the acknowledgement text field when soft block is toggled on', async () => {
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Blocked Period')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Blocked Period'));
+
+    await waitFor(() => {
+      expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
+    });
+
+    // Acknowledgement field hidden until soft block is enabled
+    expect(screen.queryByText(/Acknowledgement text/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Toggle soft block'));
+
+    expect(await screen.findByText(/Acknowledgement text/i)).toBeInTheDocument();
+  });
+
+  it('shows a "Soft block" badge for soft-blocked periods', async () => {
+    vi.mocked(fetchBlockedPeriods).mockResolvedValueOnce([
+      {
+        id: 1,
+        startDate: '2026-07-01',
+        endDate: '2026-08-31',
+        reason: 'Summer closing',
+        publicMessage: 'Bar open on request only',
+        softBlock: true,
+        acknowledgementText: 'I understand the bar may be closed',
+        enabled: true,
+      },
+    ]);
+
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Summer closing')).toBeInTheDocument();
+      expect(screen.getByText('Soft block')).toBeInTheDocument();
     });
   });
 

--- a/the-harry-list-admin/src/types/reservation.ts
+++ b/the-harry-list-admin/src/types/reservation.ts
@@ -87,6 +87,10 @@ export interface BlockedPeriod {
   endTime?: string;
   reason: string;
   publicMessage?: string;
+  /** When true, the period warns but does not block reservations. */
+  softBlock?: boolean;
+  /** Optional checkbox label the guest must tick to acknowledge a soft block. */
+  acknowledgementText?: string;
   enabled: boolean;
   updatedAt?: string;
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
@@ -72,6 +72,8 @@ public class AdminBlockedPeriodController {
                     existing.setEndTime(period.getEndTime());
                     existing.setReason(period.getReason());
                     existing.setPublicMessage(period.getPublicMessage());
+                    existing.setSoftBlock(period.getSoftBlock());
+                    existing.setAcknowledgementText(period.getAcknowledgementText());
                     existing.setEnabled(period.getEnabled());
                     BlockedPeriod saved = repository.save(existing);
                     auditService.recordUpdate(AuditEntityType.BLOCKED_PERIOD, saved.getId(), label(saved),

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/BlockedPeriod.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/BlockedPeriod.java
@@ -53,6 +53,22 @@ public class BlockedPeriod {
     @Column(name = "public_message", length = 500)
     private String publicMessage;
 
+    /**
+     * When true, this period does not block reservations: bookings are still allowed,
+     * but the guest is shown a warning and must acknowledge it before continuing.
+     * When false (default), the period hard-blocks reservations as before.
+     */
+    @Column(name = "soft_block", nullable = false)
+    @Builder.Default
+    private Boolean softBlock = false;
+
+    /**
+     * Optional checkbox label the guest must tick to acknowledge a soft block before
+     * proceeding. Only relevant when {@link #softBlock} is true; a default is used when blank.
+     */
+    @Column(name = "acknowledgement_text", length = 500)
+    private String acknowledgementText;
+
     @Column(nullable = false)
     @Builder.Default
     private Boolean enabled = true;

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationService.java
@@ -174,6 +174,11 @@ public class ConstraintValidationService {
         }
 
         for (BlockedPeriod bp : blocking) {
+            // Soft blocks are advisory only: the guest is warned and must acknowledge
+            // on the form, but the booking is allowed, so they are not server-side violations.
+            if (Boolean.TRUE.equals(bp.getSoftBlock())) {
+                continue;
+            }
             String msg = bp.getPublicMessage() != null ? bp.getPublicMessage()
                     : "This date is not available for reservations";
             violations.add(msg);

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
@@ -119,6 +119,43 @@ class AdminBlockedPeriodControllerTest {
 
     @Test
     @WithMockUser(roles = "EDITOR")
+    void create_shouldPersistSoftBlockFields() throws Exception {
+        BlockedPeriod soft = samplePeriod();
+        soft.setSoftBlock(true);
+        soft.setAcknowledgementText("I understand the bar may be closed");
+        when(repository.save(any())).thenReturn(soft);
+
+        mockMvc.perform(post("/api/admin/blocked-periods")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(soft)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.softBlock").value(true))
+                .andExpect(jsonPath("$.acknowledgementText").value("I understand the bar may be closed"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void update_shouldCopySoftBlockFields() throws Exception {
+        BlockedPeriod existing = samplePeriod();
+        when(repository.findById(1L)).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        BlockedPeriod update = samplePeriod();
+        update.setSoftBlock(true);
+        update.setAcknowledgementText("Open on request");
+
+        mockMvc.perform(put("/api/admin/blocked-periods/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.softBlock").value(true))
+                .andExpect(jsonPath("$.acknowledgementText").value("Open on request"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
     void toggle_shouldFlipEnabledState() throws Exception {
         BlockedPeriod period = samplePeriod();
         period.setEnabled(true);

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationServiceTest.java
@@ -287,6 +287,65 @@ class ConstraintValidationServiceTest {
     }
 
     @Test
+    void validate_shouldNotFlagSoftBlockedPeriod() {
+        LocalDate eventDate = LocalDate.now().plusDays(5);
+
+        BlockedPeriod softBlocked = BlockedPeriod.builder()
+                .startDate(eventDate.minusDays(1))
+                .endDate(eventDate.plusDays(1))
+                .reason("Summer closing")
+                .publicMessage("Bar open on request only")
+                .softBlock(true)
+                .enabled(true)
+                .build();
+
+        when(constraintRepository.findByEnabledTrue()).thenReturn(List.of());
+        when(blockedPeriodRepository.findBlockingPeriods(eventDate, BarLocation.HUBBLE))
+                .thenReturn(List.of(softBlocked));
+
+        List<String> violations = service.validate(
+                Set.of(SpecialActivity.GRADUATION),
+                BarLocation.HUBBLE,
+                SeatingArea.INSIDE,
+                eventDate,
+                LocalTime.of(14, 0),
+                30);
+
+        assertTrue(violations.isEmpty(), "Soft blocks must not block submission server-side");
+    }
+
+    @Test
+    void validate_shouldStillFlagHardBlockAlongsideSoftBlock() {
+        LocalDate eventDate = LocalDate.now().plusDays(5);
+
+        BlockedPeriod softBlocked = BlockedPeriod.builder()
+                .startDate(eventDate).endDate(eventDate)
+                .reason("Summer closing").publicMessage("Bar open on request only")
+                .softBlock(true).enabled(true)
+                .build();
+        BlockedPeriod hardBlocked = BlockedPeriod.builder()
+                .startDate(eventDate).endDate(eventDate)
+                .reason("Private event").publicMessage("Fully booked")
+                .softBlock(false).enabled(true)
+                .build();
+
+        when(constraintRepository.findByEnabledTrue()).thenReturn(List.of());
+        when(blockedPeriodRepository.findBlockingPeriods(eventDate, BarLocation.HUBBLE))
+                .thenReturn(List.of(softBlocked, hardBlocked));
+
+        List<String> violations = service.validate(
+                Set.of(SpecialActivity.GRADUATION),
+                BarLocation.HUBBLE,
+                SeatingArea.INSIDE,
+                eventDate,
+                LocalTime.of(14, 0),
+                30);
+
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).contains("Fully booked"));
+    }
+
+    @Test
     void validate_shouldCollectMultipleViolations() {
         FormConstraint conflict = FormConstraint.builder()
                 .constraintType(FormConstraintType.ACTIVITY_CONFLICT)

--- a/the-harry-list-public/src/components/ReservationForm.test.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.test.tsx
@@ -567,6 +567,52 @@ describe('ReservationForm', () => {
       await waitFor(() =>
         expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument()
       );
+
+      // The global soft-block warning is not repeated under the location step
+      expect(screen.queryByText('The bar is closed by default this summer.')).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: 'I understand the bar may be closed' }))
+        .not.toBeInTheDocument();
+    });
+
+    it('shows a location-specific soft block on the location step with its own acknowledgement', async () => {
+      vi.mocked(fetchBlockedPeriods).mockResolvedValue([
+        {
+          id: 3,
+          location: 'HUBBLE',
+          ...wideRange,
+          reason: 'Hubble summer closing',
+          publicMessage: 'Hubble is closed by default this summer.',
+          softBlock: true,
+          acknowledgementText: 'I understand Hubble may be closed',
+          enabled: true,
+        },
+      ]);
+
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+      await fillStep2Fields(user);
+
+      // No location chosen yet → location-specific block does not surface on the date step
+      expect(screen.queryByText('Hubble is closed by default this summer.')).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() =>
+        expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument()
+      );
+
+      // Choosing Hubble triggers the soft block here, with its acknowledgement
+      await user.click(screen.getByText('Hubble'));
+      await user.click(screen.getByText('Inside')); // seating is required to advance
+      expect(await screen.findByText('Hubble is closed by default this summer.')).toBeInTheDocument();
+      const ack = screen.getByRole('checkbox', { name: 'I understand Hubble may be closed' });
+
+      // Still blocked until the soft block is acknowledged
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument();
+
+      await user.click(ack);
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() => expect(screen.getByText('Payment Information')).toBeInTheDocument());
     });
 
     it('does not allow proceeding past a hard block and shows no acknowledgement checkbox', async () => {

--- a/the-harry-list-public/src/components/ReservationForm.test.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.test.tsx
@@ -522,6 +522,78 @@ describe('ReservationForm', () => {
     });
   });
 
+  // ==================== SOFT / HARD BLOCKED PERIODS ====================
+
+  describe('blocked periods', () => {
+    // Wide global range so it always covers the "tomorrow" date used by fillStep2Fields.
+    const wideRange = { startDate: '2020-01-01', endDate: '2099-12-31' };
+
+    async function goToStep2(user: ReturnType<typeof userEvent.setup>) {
+      await user.type(screen.getByPlaceholderText('John Doe'), 'Jane Smith');
+      await user.type(screen.getByPlaceholderText('john@example.com'), 'jane@example.com');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() => expect(screen.getByText('Activity Details')).toBeInTheDocument());
+    }
+
+    it('lets the guest proceed past a soft block only after acknowledging it', async () => {
+      vi.mocked(fetchBlockedPeriods).mockResolvedValue([
+        {
+          id: 1,
+          ...wideRange,
+          reason: 'Summer closing',
+          publicMessage: 'The bar is closed by default this summer.',
+          softBlock: true,
+          acknowledgementText: 'I understand the bar may be closed',
+          enabled: true,
+        },
+      ]);
+
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+      await fillStep2Fields(user);
+
+      // Warning + acknowledgement checkbox are shown
+      expect(screen.getByText('The bar is closed by default this summer.')).toBeInTheDocument();
+      const ack = screen.getByRole('checkbox', { name: 'I understand the bar may be closed' });
+
+      // Cannot advance until acknowledged
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Activity Details')).toBeInTheDocument();
+
+      // Acknowledge, then advance succeeds
+      await user.click(ack);
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() =>
+        expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument()
+      );
+    });
+
+    it('does not allow proceeding past a hard block and shows no acknowledgement checkbox', async () => {
+      vi.mocked(fetchBlockedPeriods).mockResolvedValue([
+        {
+          id: 2,
+          ...wideRange,
+          reason: 'Renovation',
+          publicMessage: 'Closed for renovation.',
+          softBlock: false,
+          enabled: true,
+        },
+      ]);
+
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+      await fillStep2Fields(user);
+
+      expect(screen.getByText('Closed for renovation.')).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /understand/i })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Activity Details')).toBeInTheDocument();
+    });
+  });
+
   // ==================== STEP 4: PAYMENT ====================
 
   describe('step 4 - payment', () => {

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -1092,8 +1092,9 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
               </label>
             </div>
 
-            {/* Blocked period notice (shows when location triggers a location-specific block) */}
-            {blockedDateNotice}
+            {/* Blocked period notice — only for location-specific blocks here; global/time
+                blocks are already surfaced (and acknowledged) on the date step. */}
+            {blockedDateInfo?.locationSpecific && blockedDateNotice}
 
             {/* Seating Area Selection */}
             <div className="form-group">

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import * as Sentry from '@sentry/react';
 import { submitReservation, fetchFormOptions, fetchFormConstraints, fetchBlockedPeriods, getRecaptchaSiteKey } from '../lib/api';
+import { checkBlockedDate } from '../lib/blockedPeriods';
 import type { ReservationFormData, FormOptions, FormConstraint, BlockedPeriod } from '../types/reservation';
 
 // Phone number validation - allows international formats
@@ -306,31 +307,42 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
 
   // Blocked period check for selected date
   const watchEventDate = watch('eventDate');
-  const blockedDateWarning = useMemo(() => {
-    if (!watchEventDate || blockedPeriods.length === 0) return null;
-    const selectedDate = watchEventDate;
-    const selectedLocation = watchLocation;
-    const selectedTime = watchStartTime;
-    for (const bp of blockedPeriods) {
-      if (selectedDate >= bp.startDate && selectedDate <= bp.endDate) {
-        if (bp.location) {
-          // Location-specific block: only warn if user selected that exact location
-          if (!selectedLocation || selectedLocation === 'NO_PREFERENCE' || selectedLocation === '' || bp.location !== selectedLocation) {
-            continue;
-          }
-        }
-        // Time-specific block: only warn if user's start time falls within the blocked window
-        if (bp.startTime && bp.endTime) {
-          if (!selectedTime || selectedTime < bp.startTime || selectedTime >= bp.endTime) {
-            continue;
-          }
-        }
-        // Global block (no location) or matching location
-        return bp.publicMessage || 'This date is not available for reservations.';
-      }
-    }
-    return null;
-  }, [watchEventDate, blockedPeriods, watchLocation, watchStartTime]);
+  const blockedDateInfo = useMemo(
+    () => checkBlockedDate(watchEventDate, watchLocation, blockedPeriods, watchStartTime),
+    [watchEventDate, blockedPeriods, watchLocation, watchStartTime]
+  );
+
+  // A soft block is informational: the guest can proceed after acknowledging it.
+  const [softBlockAcknowledged, setSoftBlockAcknowledged] = useState(false);
+  // Reset the acknowledgement whenever the matched (soft) block changes.
+  useEffect(() => {
+    setSoftBlockAcknowledged(false);
+  }, [blockedDateInfo?.message, blockedDateInfo?.soft]);
+
+  // Notice rendered wherever a blocked period applies. Hard blocks show a red,
+  // blocking error; soft blocks show an amber warning with an acknowledgement checkbox.
+  const blockedDateNotice = !blockedDateInfo ? null : blockedDateInfo.soft ? (
+    <div className="mt-2 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 space-y-2">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+        <span>{blockedDateInfo.message}</span>
+      </div>
+      <label className="flex items-start gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={softBlockAcknowledged}
+          onChange={e => setSoftBlockAcknowledged(e.target.checked)}
+          className="mt-0.5 shrink-0"
+        />
+        <span>{blockedDateInfo.acknowledgementText}</span>
+      </label>
+    </div>
+  ) : (
+    <div className="mt-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
+      <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+      <span>{blockedDateInfo.message}</span>
+    </div>
+  );
 
   const requiresAdvanceBooking = advanceBookingDays > 0;
   const minDateForBooking = useMemo(() => {
@@ -439,9 +451,12 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
       return false;
     }
 
-    // Block advance if date is in a blocked period (step 2 for global blocks, step 3 for location-specific)
-    if ((step === 2 || step === 3) && blockedDateWarning) {
-      return false;
+    // Block advance if date is in a blocked period (step 2 for global blocks, step 3 for location-specific).
+    // Hard blocks always prevent advancing; soft blocks only until the guest acknowledges the warning.
+    if ((step === 2 || step === 3) && blockedDateInfo) {
+      if (!blockedDateInfo.soft || !softBlockAcknowledged) {
+        return false;
+      }
     }
 
     // Block step 2 advance if long reservation reason is missing
@@ -864,12 +879,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                   />
                 </div>
                 {errors.eventDate && <p id="eventDate-error" className="error-text">{errors.eventDate.message}</p>}
-                {blockedDateWarning && (
-                  <div className="mt-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
-                    <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-                    <span>{blockedDateWarning}</span>
-                  </div>
-                )}
+                {blockedDateNotice}
               </div>
 
               {/* Start Time */}
@@ -1082,13 +1092,8 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
               </label>
             </div>
 
-            {/* Blocked period warning (shows when location triggers a location-specific block) */}
-            {blockedDateWarning && (
-              <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-                <span>{blockedDateWarning}</span>
-              </div>
-            )}
+            {/* Blocked period notice (shows when location triggers a location-specific block) */}
+            {blockedDateNotice}
 
             {/* Seating Area Selection */}
             <div className="form-group">

--- a/the-harry-list-public/src/lib/blockedPeriods.ts
+++ b/the-harry-list-public/src/lib/blockedPeriods.ts
@@ -4,6 +4,13 @@ import type { BlockedPeriod } from '../types/reservation';
 export const DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT =
   'I understand the bar may be closed during this period and that my reservation is a request.';
 
+/** Default warning shown for a soft block when no public message is configured. */
+export const DEFAULT_SOFT_BLOCK_MESSAGE =
+  'We are by default closed during this period, but by acknowledging the message below you can still place a reservation request.';
+
+/** Default message shown for a (hard) block when no public message is configured. */
+export const DEFAULT_HARD_BLOCK_MESSAGE = 'This date is not available for reservations.';
+
 export interface BlockedDateMatch {
   /** Public-facing message to display to the guest. */
   message: string;
@@ -11,6 +18,8 @@ export interface BlockedDateMatch {
   soft: boolean;
   /** Checkbox label for the acknowledgement (only meaningful when soft). */
   acknowledgementText: string;
+  /** True when the block only applies because of the selected location. */
+  locationSpecific: boolean;
 }
 
 /**
@@ -41,10 +50,12 @@ export function checkBlockedDate(
           continue;
         }
       }
+      const soft = bp.softBlock === true;
       return {
-        message: bp.publicMessage || 'This date is not available for reservations.',
-        soft: bp.softBlock === true,
+        message: bp.publicMessage || (soft ? DEFAULT_SOFT_BLOCK_MESSAGE : DEFAULT_HARD_BLOCK_MESSAGE),
+        soft,
         acknowledgementText: bp.acknowledgementText?.trim() || DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT,
+        locationSpecific: !!bp.location,
       };
     }
   }

--- a/the-harry-list-public/src/lib/blockedPeriods.ts
+++ b/the-harry-list-public/src/lib/blockedPeriods.ts
@@ -1,0 +1,52 @@
+import type { BlockedPeriod } from '../types/reservation';
+
+/** Default acknowledgement label shown for a soft block when none is configured. */
+export const DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT =
+  'I understand the bar may be closed during this period and that my reservation is a request.';
+
+export interface BlockedDateMatch {
+  /** Public-facing message to display to the guest. */
+  message: string;
+  /** When true the block is advisory: the guest may proceed after acknowledging it. */
+  soft: boolean;
+  /** Checkbox label for the acknowledgement (only meaningful when soft). */
+  acknowledgementText: string;
+}
+
+/**
+ * Determine whether the chosen date/location/time falls inside an active blocked
+ * period and, if so, return how it should be surfaced to the guest.
+ *
+ * Returns null when no block applies. A hard block (soft === false) prevents the
+ * booking; a soft block warns but allows it once acknowledged.
+ */
+export function checkBlockedDate(
+  eventDate: string | null | undefined,
+  location: string | null | undefined,
+  blockedPeriods: BlockedPeriod[],
+  startTime?: string
+): BlockedDateMatch | null {
+  if (!eventDate || blockedPeriods.length === 0) return null;
+  for (const bp of blockedPeriods) {
+    if (eventDate >= bp.startDate && eventDate <= bp.endDate) {
+      if (bp.location) {
+        // Location-specific block: only applies if the guest picked that exact location.
+        if (!location || location === 'NO_PREFERENCE' || location === '' || bp.location !== location) {
+          continue;
+        }
+      }
+      // Time-specific block: only applies if the start time falls within the blocked window.
+      if (bp.startTime && bp.endTime) {
+        if (!startTime || startTime < bp.startTime || startTime >= bp.endTime) {
+          continue;
+        }
+      }
+      return {
+        message: bp.publicMessage || 'This date is not available for reservations.',
+        soft: bp.softBlock === true,
+        acknowledgementText: bp.acknowledgementText?.trim() || DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT,
+      };
+    }
+  }
+  return null;
+}

--- a/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
+++ b/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { BlockedPeriod } from '../types/reservation';
-import { checkBlockedDate, DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT } from '../lib/blockedPeriods';
+import {
+  checkBlockedDate,
+  DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT,
+  DEFAULT_SOFT_BLOCK_MESSAGE,
+} from '../lib/blockedPeriods';
 
 /**
  * Tests for the blocked period date checking logic used in ReservationForm.
@@ -178,8 +182,22 @@ describe('Soft blocked periods', () => {
     expect(result?.acknowledgementText).toBe(DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT);
   });
 
+  it('uses the soft-specific default message when no public message is set', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, publicMessage: undefined }]);
+    expect(result?.message).toBe(DEFAULT_SOFT_BLOCK_MESSAGE);
+  });
+
   it('treats a period without softBlock as a hard block', () => {
     const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, softBlock: undefined }]);
     expect(result?.soft).toBe(false);
+  });
+
+  it('flags a global block as not location-specific', () => {
+    expect(checkBlockedDate('2026-07-15', 'HUBBLE', [softPeriod])?.locationSpecific).toBe(false);
+  });
+
+  it('flags a location-scoped block as location-specific', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, location: 'HUBBLE' }]);
+    expect(result?.locationSpecific).toBe(true);
   });
 });

--- a/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
+++ b/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
@@ -1,37 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { BlockedPeriod } from '../types/reservation';
+import { checkBlockedDate, DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT } from '../lib/blockedPeriods';
 
 /**
  * Tests for the blocked period date checking logic used in ReservationForm.
- * Tests the pure logic extracted from the component's useMemo.
+ * Exercises the shared helper the component itself uses.
  */
-
-function checkBlockedDate(
-  eventDate: string,
-  location: string | null | undefined,
-  blockedPeriods: BlockedPeriod[],
-  startTime?: string
-): string | null {
-  if (!eventDate || blockedPeriods.length === 0) return null;
-  for (const bp of blockedPeriods) {
-    if (eventDate >= bp.startDate && eventDate <= bp.endDate) {
-      if (bp.location) {
-        // Location-specific block: only warn if user selected that exact location
-        if (!location || location === 'NO_PREFERENCE' || location === '' || bp.location !== location) {
-          continue;
-        }
-      }
-      // Time-specific block: only warn if user's start time falls within the blocked window
-      if (bp.startTime && bp.endTime) {
-        if (!startTime || startTime < bp.startTime || startTime >= bp.endTime) {
-          continue;
-        }
-      }
-      return bp.publicMessage || 'This date is not available for reservations.';
-    }
-  }
-  return null;
-}
 
 describe('Blocked period date validation', () => {
   const samplePeriods: BlockedPeriod[] = [
@@ -64,38 +38,32 @@ describe('Blocked period date validation', () => {
 
   it('returns warning when date falls within a location-specific blocked period', () => {
     const result = checkBlockedDate('2026-04-02', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for maintenance from April 1-3');
+    expect(result?.message).toBe('Closed for maintenance from April 1-3');
+    expect(result?.soft).toBe(false);
   });
 
   it('returns null when date is in blocked period but for a different location', () => {
-    const result = checkBlockedDate('2026-04-02', 'METEOR', samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-02', 'METEOR', samplePeriods)).toBeNull();
   });
 
   it('returns warning for global blocked period regardless of location', () => {
-    const result = checkBlockedDate('2026-12-25', 'METEOR', samplePeriods);
-    expect(result).toBe('Closed for Christmas');
+    expect(checkBlockedDate('2026-12-25', 'METEOR', samplePeriods)?.message).toBe('Closed for Christmas');
   });
 
   it('returns warning for global blocked period with HUBBLE location', () => {
-    const result = checkBlockedDate('2026-12-26', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for Christmas');
+    expect(checkBlockedDate('2026-12-26', 'HUBBLE', samplePeriods)?.message).toBe('Closed for Christmas');
   });
 
   it('skips location-specific block when user has NO_PREFERENCE', () => {
-    const result = checkBlockedDate('2026-04-01', 'NO_PREFERENCE', samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-01', 'NO_PREFERENCE', samplePeriods)).toBeNull();
   });
 
   it('skips location-specific block when location is empty string (No Preference)', () => {
-    // The form uses value="" for the "No Preference" radio
-    const result = checkBlockedDate('2026-04-01', '', samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-01', '', samplePeriods)).toBeNull();
   });
 
   it('skips location-specific block when location is null', () => {
-    const result = checkBlockedDate('2026-04-01', null, samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-01', null, samplePeriods)).toBeNull();
   });
 
   it('returns null when date is outside all blocked periods', () => {
@@ -103,13 +71,11 @@ describe('Blocked period date validation', () => {
   });
 
   it('matches on exact start date', () => {
-    const result = checkBlockedDate('2026-04-01', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for maintenance from April 1-3');
+    expect(checkBlockedDate('2026-04-01', 'HUBBLE', samplePeriods)?.message).toBe('Closed for maintenance from April 1-3');
   });
 
   it('matches on exact end date', () => {
-    const result = checkBlockedDate('2026-04-03', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for maintenance from April 1-3');
+    expect(checkBlockedDate('2026-04-03', 'HUBBLE', samplePeriods)?.message).toBe('Closed for maintenance from April 1-3');
   });
 
   it('returns default message when publicMessage is not set', () => {
@@ -122,8 +88,8 @@ describe('Blocked period date validation', () => {
         enabled: true,
       },
     ];
-    const result = checkBlockedDate('2026-06-01', 'HUBBLE', periodsNoMessage);
-    expect(result).toBe('This date is not available for reservations.');
+    expect(checkBlockedDate('2026-06-01', 'HUBBLE', periodsNoMessage)?.message)
+      .toBe('This date is not available for reservations.');
   });
 });
 
@@ -150,42 +116,70 @@ describe('Blocked period time-specific validation', () => {
   ];
 
   it('blocks when start time falls within blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '10:00');
-    expect(result).toBe('Not available in the morning');
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '10:00')?.message)
+      .toBe('Not available in the morning');
   });
 
   it('blocks at exact start of blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '09:00');
-    expect(result).toBe('Not available in the morning');
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '09:00')?.message)
+      .toBe('Not available in the morning');
   });
 
   it('does not block when start time is at or after the blocked end time', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '14:00');
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '14:00')).toBeNull();
   });
 
   it('does not block when start time is after blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '15:00');
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '15:00')).toBeNull();
   });
 
   it('does not block when start time is before blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '08:30');
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '08:30')).toBeNull();
   });
 
   it('does not block time-specific period when no start time selected', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods)).toBeNull();
   });
 
   it('blocks full-day period regardless of start time', () => {
-    const result = checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods, '10:00');
-    expect(result).toBe('Closed all day');
+    expect(checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods, '10:00')?.message).toBe('Closed all day');
   });
 
   it('blocks full-day period when no start time selected', () => {
-    const result = checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods);
-    expect(result).toBe('Closed all day');
+    expect(checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods)?.message).toBe('Closed all day');
+  });
+});
+
+describe('Soft blocked periods', () => {
+  const softPeriod: BlockedPeriod = {
+    id: 20,
+    startDate: '2026-07-01',
+    endDate: '2026-08-31',
+    reason: 'Summer closing',
+    publicMessage: 'The bar is closed by default this summer, but you can request a reservation.',
+    softBlock: true,
+    acknowledgementText: 'I understand the bar may be closed and my booking is a request',
+    enabled: true,
+  };
+
+  it('flags a soft block as soft and surfaces the public message', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [softPeriod]);
+    expect(result?.soft).toBe(true);
+    expect(result?.message).toBe(softPeriod.publicMessage);
+  });
+
+  it('returns the configured acknowledgement text', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [softPeriod]);
+    expect(result?.acknowledgementText).toBe('I understand the bar may be closed and my booking is a request');
+  });
+
+  it('falls back to the default acknowledgement text when none is configured', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, acknowledgementText: undefined }]);
+    expect(result?.acknowledgementText).toBe(DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT);
+  });
+
+  it('treats a period without softBlock as a hard block', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, softBlock: undefined }]);
+    expect(result?.soft).toBe(false);
   });
 });

--- a/the-harry-list-public/src/types/reservation.ts
+++ b/the-harry-list-public/src/types/reservation.ts
@@ -79,5 +79,9 @@ export interface BlockedPeriod {
   endTime?: string;
   reason: string;
   publicMessage?: string;
+  /** When true, the period warns but does not block reservations. */
+  softBlock?: boolean;
+  /** Optional checkbox label the guest must tick to acknowledge a soft block. */
+  acknowledgementText?: string;
   enabled: boolean;
 }


### PR DESCRIPTION
## v1.4.0

Introduces **soft-blocked periods**: a blocked period can now warn-and-allow instead of fully blocking. Closes #254.

Use it for situations like the **summer closing**, where the bar is closed by default but can still be reserved on request. Bumps all three components to `1.4.0`.

## Highlights

- **Soft block toggle** on blocked periods. A soft block keeps the period marked and shows its public message as a warning, but the guest can still book after ticking an acknowledgement checkbox.
- **Customizable acknowledgement text** per period (checkbox label), with a sensible default.
- **Clear guest feedback** — pressing Continue without acknowledging highlights the checkbox and explains why, so the form never feels broken.
- Hard blocks behave exactly as before.

## Changes by area

**Backend**
- `BlockedPeriod` gains `softBlock` (defaults `false`) + optional `acknowledgementText`.
- `ConstraintValidationService` skips soft blocks, so they never block submission server-side; hard blocks still do.
- Update controller persists the new fields; audit logging picks them up automatically.

**Admin**
- Blocked-period editor: soft-block toggle + acknowledgement-text input (shown when soft).
- Amber **"Soft block"** badge on soft-blocked rows.

**Public reservation form**
- Soft blocks render an amber warning + a required acknowledgement checkbox; hard blocks keep the red blocking notice.
- Soft-specific default message when no public message is set.
- A global soft block acknowledged on the date step is no longer repeated under the location step (location-specific blocks still surface there with their own acknowledgement).
- Continuing without ticking the box now shows an inline "please tick the box to confirm" prompt.
- Blocked-date matching extracted into a shared, tested `lib/blockedPeriods` helper.

**Docs**
- Admin in-app HelpGuide updated (hard vs. soft blocks).
- Added `docs/migration-soft-blocked-periods.md`.

## Database migration ⚠️

Production runs `ddl-auto=validate`, so the two new columns must exist **before** deploying the v1.4.0 backend:

```sql
ALTER TABLE blocked_periods
  ADD COLUMN soft_block BOOLEAN NOT NULL DEFAULT FALSE,
  ADD COLUMN acknowledgement_text VARCHAR(500) NULL;
```

- `soft_block` is `false` for all existing rows → current hard-block behavior preserved.
- Dev/test create the columns automatically (`ddl-auto=update` / H2).

Full steps, verification, and rollback in `docs/migration-soft-blocked-periods.md`.

## Backward compatibility

Additive only — no existing tables, rows, or API contracts change. Existing blocked periods stay hard blocks. Audit log and email-template features are unaffected.

## Testing

- Backend: 27 tests (soft-block service + controller cases) ✅
- Admin: 99 tests (badge + editor toggle) ✅
- Public: 94 tests (shared helper soft/hard/location cases; component gating: soft requires acknowledgement, missing-ack prompt, hard fully blocks, no step-3 duplication) ✅

## Post-merge

1. Run the SQL migration on production.
2. Deploy backend + frontends.