### PR TITLE
V1.4.0

### DIFF
--- a/docs/migration-soft-blocked-periods.md
+++ b/docs/migration-soft-blocked-periods.md
@@ -1,0 +1,60 @@
+# Soft-Blocked Periods Migration Guide
+
+## Overview
+
+This migration adds a **soft block** option to blocked periods. A soft block keeps a
+period marked and shows the customer a warning, but — unlike a normal (hard) block — it
+does **not** prevent the booking. The customer must tick an acknowledgement checkbox to
+continue. This is intended for situations such as a summer closing where the bar is closed
+by default but opens on request of a reservation.
+
+The change is **additive and backwards compatible**: it adds two nullable/defaulted columns
+to the existing `blocked_periods` table. No existing tables, rows, or API contracts change —
+existing blocked periods keep behaving as hard blocks (`soft_block = false`).
+
+## Step 1: Run SQL Migration
+
+The production backend runs with `ddl-auto=validate`, so the columns must exist **before**
+deploying the new backend. Execute the following on the production MariaDB database:
+
+```sql
+ALTER TABLE blocked_periods
+  ADD COLUMN soft_block BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN acknowledgement_text VARCHAR(500) NULL;
+```
+
+- `soft_block` — `false` (hard block) for all existing rows, preserving current behaviour.
+- `acknowledgement_text` — optional checkbox label shown for a soft block; `NULL`/blank
+  falls back to a sensible default message on the public form.
+
+Dev and test environments create the columns automatically (`ddl-auto=update` / H2), so no
+manual step is needed there.
+
+## Step 2: Deploy
+
+Deploy the new backend and frontends. Deployment order does not matter — the SQL migration
+adds the columns before the backend validates the schema, and existing endpoints/payloads
+remain valid (the new fields are optional in the API).
+
+## Step 3: Verify
+
+1. In the admin **Form Settings → Blocked Periods**, add or edit a period and enable
+   **"Soft block (allow bookings with a warning)"**. Optionally set the acknowledgement text.
+   The row shows an amber **"Soft block"** badge.
+2. On the public reservation form, choose a date inside that period:
+   - The public message appears as an amber warning with an **acknowledgement checkbox**.
+   - **Continue** is blocked until the checkbox is ticked, then the booking proceeds.
+3. Confirm a regular (hard) blocked period still fully blocks the date with a red notice and
+   no checkbox.
+4. Editing a period records the `softBlock` / `acknowledgementText` changes in the **audit log**.
+
+## Rollback
+
+The columns are additive and unused by older code. To roll back, redeploy the previous
+backend; the extra columns can be left in place harmlessly, or dropped with:
+
+```sql
+ALTER TABLE blocked_periods
+  DROP COLUMN soft_block,
+  DROP COLUMN acknowledgement_text;
+```

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -156,7 +156,12 @@ export async function fetchReservation(id: number): Promise<Reservation | null> 
   return fetchJsonWithAuth(`${API_BASE_URL}/api/reservations/${id}`) as Promise<Reservation | null>;
 }
 
-export async function updateReservation(id: number, data: Record<string, unknown>, sendEmail: boolean = true): Promise<Reservation> {
+export async function updateReservation(
+  id: number,
+  data: Record<string, unknown>,
+  sendEmail: boolean = true,
+  customMessage?: string
+): Promise<Reservation> {
   // Clean up empty strings to null for enum fields that the backend expects
   const cleanedData: Record<string, unknown> = { ...data };
   const enumFields = ['seatingArea', 'location', 'paymentOption', 'invoiceType'];
@@ -166,7 +171,11 @@ export async function updateReservation(id: number, data: Record<string, unknown
     }
   });
 
-  return fetchJsonWithAuth(`${API_BASE_URL}/api/reservations/${id}?sendEmail=${sendEmail}`, {
+  let url = `${API_BASE_URL}/api/reservations/${id}?sendEmail=${sendEmail}`;
+  if (customMessage && customMessage.trim()) {
+    url += `&customMessage=${encodeURIComponent(customMessage)}`;
+  }
+  return fetchJsonWithAuth(url, {
     method: 'PUT',
     body: JSON.stringify(cleanedData),
   }) as Promise<Reservation>;
@@ -182,11 +191,15 @@ export async function updateReservationStatus(
   id: number,
   status: string,
   confirmedBy?: string,
-  sendEmail: boolean = true
+  sendEmail: boolean = true,
+  customMessage?: string
 ): Promise<Reservation> {
   let url = `${API_BASE_URL}/api/admin/reservations/${id}/status?status=${status}&sendEmail=${sendEmail}`;
   if (confirmedBy) {
     url += `&confirmedBy=${encodeURIComponent(confirmedBy)}`;
+  }
+  if (customMessage && customMessage.trim()) {
+    url += `&customMessage=${encodeURIComponent(customMessage)}`;
   }
   return fetchJsonWithAuth(url, { method: 'PATCH' }) as Promise<Reservation>;
 }

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -259,6 +259,10 @@ Templates support **variables** that get replaced with actual reservation data w
 - \`{{location}}\` — Hubble or Meteor
 - \`{{confirmationNumber}}\` — the unique booking reference
 
+The **Reservation Confirmed/Rejected** and **Reservation Updated** templates also support:
+
+- \`{{customMessage}}\` — the optional message a staff member types when confirming, rejecting, cancelling, completing, or editing a reservation. It renders as a highlighted note, or nothing at all when no message is entered. Keep this placeholder in the template if you want those one-off messages to appear.
+
 ### Actions
 
 - **Save** — save your changes
@@ -408,7 +412,7 @@ The available actions depend on the current status:
 
 ### Pending Reservations
 - **Confirm** — approve the reservation. Optionally sends a confirmation email
-- **Reject** — decline with an optional reason (included in the rejection email)
+- **Reject** — decline the reservation. The rejection email is pre-filled with a default reason you can edit or replace
 
 ### Confirmed Reservations
 - **Complete** — mark as completed after the event has taken place
@@ -419,7 +423,10 @@ The available actions depend on the current status:
 - **Delete** — permanently remove (with confirmation dialog)
 
 ### Email Notifications
-Each status change dialog has a **"Send email notification"** checkbox. Keep this checked to automatically notify the customer. Uncheck it only if you've already communicated with them directly.`,
+Each status change dialog (and the edit form) has a **"Send email notification"** checkbox. Keep this checked to automatically notify the customer. Uncheck it only if you've already communicated with them directly.
+
+### Adding a Message to the Email
+When the email notification is on, every status dialog and the edit form shows an optional **"Add a message to the email"** box. Anything you type here appears as a highlighted note in that email — use it to clarify things the standard template doesn't cover, e.g. *"We read your special request and will keep a shaded spot for you."* For **Reject**, this box is pre-filled with a default reason that you can edit, replace, or clear before sending.`,
   },
   {
     title: 'Catering Email',

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -361,7 +361,20 @@ Click **"Add Blocked Period"** and fill in:
 2. **Location** — optionally limit the block to just Hubble or Meteor (leave empty for both)
 3. **Reason** — internal note for staff (not shown to customers)
 4. **Public message** — the message customers see when trying to book these dates
-5. **Enabled** — toggle on/off
+5. **Soft block** — see below
+6. **Enabled** — toggle on/off
+
+### Hard vs. Soft Blocks
+
+By default a blocked period is a **hard block**: customers cannot book those dates at all.
+
+Turn on **Soft block (allow bookings with a warning)** when the venue is closed *by default* but bookings are still possible — for example a summer closing where the bar opens only on request. With a soft block:
+
+- The period is still marked and the **public message** is shown as a warning.
+- The customer must tick an **acknowledgement checkbox** before continuing, then can complete the booking.
+- Soft-blocked rows are marked with an amber **"Soft block"** badge in the list.
+
+When soft block is on you can set the **acknowledgement text** — the checkbox label the customer must tick (e.g. *"I understand the bar may be closed and my reservation is a request"*). Leave it blank to use a sensible default.
 
 ### Tip
 You can create blocked periods in advance. Use the **enabled toggle** to activate them when needed instead of creating and deleting them each time.`,

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -169,7 +169,10 @@ export const exportGuide: GuideSection[] = [
 1. **Select a date** — choose the day you want the report for
 2. **Select a location** — choose either Hubble or Meteor
 3. **Confirmed only** — toggle this on to exclude pending, rejected, or cancelled reservations (recommended for daily prep sheets)
-4. Click **"Export PDF"**
+4. **Catering only** — toggle this on to include only reservations that have catering (eat a la carte, eat catering, or Catering Corona Room) — handy for the kitchen's prep list
+5. Click **"Export PDF"**
+
+You can combine the two toggles, e.g. **Confirmed only + Catering only** for a confirmed catering prep sheet.
 
 The PDF will automatically download to your device.
 

--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -305,22 +305,22 @@ export function CalendarAppointmentsPage() {
               {/* Time fields (hidden when all-day) */}
               {!editing.allDay && (
                 <div className="grid grid-cols-2 gap-4">
-                  <div>
+                  <div className="min-w-0">
                     <label className="label">Start Time *</label>
                     <input
                       type="time"
                       value={editing.startTime || ''}
                       onChange={e => setEditing({ ...editing, startTime: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label className="label">End Time *</label>
                     <input
                       type="time"
                       value={editing.endTime || ''}
                       onChange={e => setEditing({ ...editing, endTime: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
                 </div>

--- a/the-harry-list-admin/src/pages/ExportPage.tsx
+++ b/the-harry-list-admin/src/pages/ExportPage.tsx
@@ -10,6 +10,7 @@ export function ExportPage() {
   );
   const [selectedLocation, setSelectedLocation] = useState<'HUBBLE' | 'METEOR'>('HUBBLE');
   const [confirmedOnly, setConfirmedOnly] = useState(true);
+  const [cateringOnly, setCateringOnly] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,7 +20,7 @@ export function ExportPage() {
 
     try {
       const response = await fetchWithAuth(
-        `/api/admin/export/daily-report?date=${selectedDate}&location=${selectedLocation}&confirmedOnly=${confirmedOnly}`
+        `/api/admin/export/daily-report?date=${selectedDate}&location=${selectedLocation}&confirmedOnly=${confirmedOnly}&cateringOnly=${cateringOnly}`
       );
 
       if (!response.ok) {
@@ -146,18 +147,33 @@ export function ExportPage() {
               <Filter className="w-4 h-4" />
               Filter
             </label>
-            <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
-              <input
-                type="checkbox"
-                checked={confirmedOnly}
-                onChange={(e) => setConfirmedOnly(e.target.checked)}
-                className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
-              />
-              <div>
-                <span className="text-sm font-medium text-white">Confirmed reservations only</span>
-                <p className="text-xs text-dark-400">Exclude pending, rejected, and cancelled reservations</p>
-              </div>
-            </label>
+            <div className="space-y-3">
+              <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={confirmedOnly}
+                  onChange={(e) => setConfirmedOnly(e.target.checked)}
+                  className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
+                />
+                <div>
+                  <span className="text-sm font-medium text-white">Confirmed reservations only</span>
+                  <p className="text-xs text-dark-400">Exclude pending, rejected, and cancelled reservations</p>
+                </div>
+              </label>
+
+              <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={cateringOnly}
+                  onChange={(e) => setCateringOnly(e.target.checked)}
+                  className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
+                />
+                <div>
+                  <span className="text-sm font-medium text-white">Catering reservations only</span>
+                  <p className="text-xs text-dark-400">Only include reservations with catering (eat a la carte, eat catering, or Catering Corona Room)</p>
+                </div>
+              </label>
+            </div>
           </div>
 
           {/* Error Message */}

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -591,21 +591,47 @@ export function SettingsPage() {
                 <div className="grid grid-cols-2 gap-3">
                   <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">Start Time (optional)</label>
-                    <input
-                      type="time"
-                      value={editingPeriod.startTime || ''}
-                      onChange={e => setEditingPeriod({ ...editingPeriod, startTime: e.target.value || undefined })}
-                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
-                    />
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="time"
+                        value={editingPeriod.startTime || ''}
+                        onChange={e => setEditingPeriod({ ...editingPeriod, startTime: e.target.value || undefined })}
+                        className="w-full min-w-0 flex-1 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                      {editingPeriod.startTime && (
+                        <button
+                          type="button"
+                          onClick={() => setEditingPeriod({ ...editingPeriod, startTime: undefined })}
+                          aria-label="Clear start time"
+                          title="Clear start time"
+                          className="shrink-0 p-2 text-dark-400 hover:text-white"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                   <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">End Time (optional)</label>
-                    <input
-                      type="time"
-                      value={editingPeriod.endTime || ''}
-                      onChange={e => setEditingPeriod({ ...editingPeriod, endTime: e.target.value || undefined })}
-                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
-                    />
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="time"
+                        value={editingPeriod.endTime || ''}
+                        onChange={e => setEditingPeriod({ ...editingPeriod, endTime: e.target.value || undefined })}
+                        className="w-full min-w-0 flex-1 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                      {editingPeriod.endTime && (
+                        <button
+                          type="button"
+                          onClick={() => setEditingPeriod({ ...editingPeriod, endTime: undefined })}
+                          aria-label="Clear end time"
+                          title="Clear end time"
+                          className="shrink-0 p-2 text-dark-400 hover:text-white"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
 

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -568,43 +568,43 @@ export function SettingsPage() {
                 </div>
 
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">Start Date *</label>
                     <input
                       type="date"
                       value={editingPeriod.startDate}
                       onChange={e => setEditingPeriod({ ...editingPeriod, startDate: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">End Date *</label>
                     <input
                       type="date"
                       value={editingPeriod.endDate}
                       onChange={e => setEditingPeriod({ ...editingPeriod, endDate: e.target.value })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">Start Time (optional)</label>
                     <input
                       type="time"
                       value={editingPeriod.startTime || ''}
                       onChange={e => setEditingPeriod({ ...editingPeriod, startTime: e.target.value || undefined })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <label className="block text-sm text-dark-400 mb-1">End Time (optional)</label>
                     <input
                       type="time"
                       value={editingPeriod.endTime || ''}
                       onChange={e => setEditingPeriod({ ...editingPeriod, endTime: e.target.value || undefined })}
-                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      className="w-full min-w-0 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                     />
                   </div>
                 </div>

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -52,6 +52,8 @@ const emptyBlockedPeriod: BlockedPeriod = {
   endTime: '',
   reason: '',
   publicMessage: '',
+  softBlock: false,
+  acknowledgementText: '',
   enabled: true,
 };
 
@@ -353,10 +355,15 @@ export function SettingsPage() {
                   }`}
                 >
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="text-xs font-mono px-2 py-0.5 rounded bg-dark-800 text-red-400">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <span className={`text-xs font-mono px-2 py-0.5 rounded bg-dark-800 ${bp.softBlock ? 'text-amber-400' : 'text-red-400'}`}>
                         {bp.startDate} — {bp.endDate}
                       </span>
+                      {bp.softBlock && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">
+                          Soft block
+                        </span>
+                      )}
                       {bp.location && (
                         <span className="text-xs font-mono px-2 py-0.5 rounded bg-dark-800 text-amber-400">
                           {bp.location}
@@ -655,6 +662,44 @@ export function SettingsPage() {
                     placeholder="e.g. Closed for maintenance"
                     className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                   />
+                </div>
+
+                <div className="rounded-lg border border-dark-700 bg-dark-800/40 p-3 space-y-3">
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={!!editingPeriod.softBlock}
+                      onClick={() => setEditingPeriod({ ...editingPeriod, softBlock: !editingPeriod.softBlock })}
+                      className="shrink-0 mt-0.5"
+                      title="Toggle soft block"
+                    >
+                      {editingPeriod.softBlock
+                        ? <ToggleRight className="w-6 h-6 text-amber-400" />
+                        : <ToggleLeft className="w-6 h-6 text-dark-500" />}
+                    </button>
+                    <span className="text-sm text-white">
+                      Soft block (allow bookings with a warning)
+                      <span className="block text-xs text-dark-400 font-light mt-0.5">
+                        Guests can still book during this period, but must acknowledge a warning first.
+                        Use this for e.g. a summer closing where the bar opens on request.
+                      </span>
+                    </span>
+                  </label>
+
+                  {editingPeriod.softBlock && (
+                    <div>
+                      <label className="block text-sm text-dark-400 mb-1">Acknowledgement text (checkbox label)</label>
+                      <input
+                        type="text"
+                        value={editingPeriod.acknowledgementText || ''}
+                        onChange={e => setEditingPeriod({ ...editingPeriod, acknowledgementText: e.target.value })}
+                        placeholder="I understand the bar may be closed and my reservation is a request"
+                        className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                      <p className="text-xs text-dark-500 mt-1">Leave blank to use a default acknowledgement message.</p>
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -18,6 +18,39 @@ import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { reservationDetailGuide } from '../lib/guideContent';
 
+// Pre-filled (editable) default shown when rejecting a reservation. Staff can edit or clear it.
+const DEFAULT_REJECTION_MESSAGE =
+  'Unfortunately we cannot host you since we do not have any places left at this time';
+
+/**
+ * Optional free-text message added to the notification email for a reservation action.
+ * Only rendered when an email will actually be sent.
+ */
+function EmailMessageField({
+  value,
+  onChange,
+  show,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  show: boolean;
+}) {
+  if (!show) return null;
+  return (
+    <div className="mt-3">
+      <label className="block text-sm text-dark-300 mb-1">
+        Add a message to the email <span className="text-dark-500">(optional)</span>
+      </label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="input-field min-h-[80px] w-full"
+        placeholder="e.g. We read your special request and will keep a shaded spot for you."
+      />
+    </div>
+  );
+}
+
 export function ReservationDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -35,11 +68,15 @@ export function ReservationDetailPage() {
   const [showCompleteDialog, setShowCompleteDialog] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [sendEmail, setSendEmail] = useState(true);
+  // Optional free-text message added to the status-change email (pre-filled for rejections).
+  const [actionMessage, setActionMessage] = useState('');
 
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [editData, setEditData] = useState<Partial<Reservation>>({});
   const [sendEditEmail, setSendEditEmail] = useState(true);
+  // Optional free-text message added to the "reservation updated" email.
+  const [editMessage, setEditMessage] = useState('');
 
   // Catering email state
   const [showCateringEmail, setShowCateringEmail] = useState(false);
@@ -84,7 +121,8 @@ export function ReservationDetailPage() {
 
     setIsUpdating(true);
     try {
-      await updateReservationStatus(reservation.id, newStatus, userName, sendEmail);
+      await updateReservationStatus(
+        reservation.id, newStatus, userName, sendEmail, sendEmail ? actionMessage : undefined);
       setReservation({ ...reservation, status: newStatus });
       loadAuditLog();
     } catch (err) {
@@ -140,6 +178,7 @@ export function ReservationDetailPage() {
       comments: reservation.comments || '',
       internalNotes: reservation.internalNotes || '',
     });
+    setEditMessage('');
     setIsEditing(true);
   };
 
@@ -148,7 +187,8 @@ export function ReservationDetailPage() {
 
     setIsUpdating(true);
     try {
-      const updatedReservation = await updateReservation(reservation.id, editData, sendEditEmail);
+      const updatedReservation = await updateReservation(
+        reservation.id, editData, sendEditEmail, sendEditEmail ? editMessage : undefined);
       setReservation(updatedReservation);
       setIsEditing(false);
       setEditData({});
@@ -298,7 +338,7 @@ export function ReservationDetailPage() {
           {reservation.status === 'PENDING' && (
             <>
               <button
-                onClick={() => setShowConfirmDialog(true)}
+                onClick={() => { setActionMessage(''); setShowConfirmDialog(true); }}
                 disabled={isUpdating}
                 className="btn-primary flex items-center gap-2"
               >
@@ -306,7 +346,7 @@ export function ReservationDetailPage() {
                 Confirm
               </button>
               <button
-                onClick={() => setShowRejectDialog(true)}
+                onClick={() => { setActionMessage(DEFAULT_REJECTION_MESSAGE); setShowRejectDialog(true); }}
                 disabled={isUpdating}
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
               >
@@ -318,7 +358,7 @@ export function ReservationDetailPage() {
 
           {reservation.status === 'CONFIRMED' && (
             <button
-              onClick={() => setShowCompleteDialog(true)}
+              onClick={() => { setActionMessage(''); setShowCompleteDialog(true); }}
               disabled={isUpdating}
               className="btn-secondary flex items-center gap-2"
             >
@@ -329,7 +369,7 @@ export function ReservationDetailPage() {
 
           {reservation.status === 'CONFIRMED' && (
             <button
-              onClick={() => setShowCancelDialog(true)}
+              onClick={() => { setActionMessage(''); setShowCancelDialog(true); }}
               disabled={isUpdating}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors ml-auto"
             >
@@ -376,7 +416,8 @@ export function ReservationDetailPage() {
         {showConfirmDialog && (
           <div className="mt-4 p-4 rounded-xl bg-green-500/10 border border-green-500/50">
             <p className="text-green-400 mb-3">Are you sure you want to confirm this reservation? {sendEmail && 'A confirmation email will be sent to the customer.'}</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('CONFIRMED');
@@ -402,7 +443,8 @@ export function ReservationDetailPage() {
         {showRejectDialog && (
           <div className="mt-4 p-4 rounded-xl bg-red-500/10 border border-red-500/50">
             <p className="text-red-400 mb-3">Are you sure you want to reject this reservation? {sendEmail && 'A rejection email will be sent to the customer.'}</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('REJECTED');
@@ -428,7 +470,8 @@ export function ReservationDetailPage() {
         {showCompleteDialog && (
           <div className="mt-4 p-4 rounded-xl bg-blue-500/10 border border-blue-500/50">
             <p className="text-blue-400 mb-3">Are you sure you want to mark this reservation as completed?</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('COMPLETED');
@@ -454,7 +497,8 @@ export function ReservationDetailPage() {
         {showCancelDialog && (
           <div className="mt-4 p-4 rounded-xl bg-amber-500/10 border border-amber-500/50">
             <p className="text-amber-400 mb-3">Are you sure you want to cancel this reservation? {sendEmail && 'A cancellation email will be sent to the customer.'}</p>
-            <div className="flex gap-3">
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
               <button
                 onClick={() => {
                   handleStatusChange('CANCELLED');
@@ -828,6 +872,8 @@ export function ReservationDetailPage() {
                   Send email notification about changes to customer
                 </span>
               </label>
+
+              <EmailMessageField value={editMessage} onChange={setEditMessage} show={sendEditEmail} />
 
               {/* Contact Information */}
               <div>

--- a/the-harry-list-admin/src/test/ExportPage.test.tsx
+++ b/the-harry-list-admin/src/test/ExportPage.test.tsx
@@ -39,5 +39,19 @@ describe('ExportPage', () => {
     renderWithRouter(<ExportPage />);
     expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
   });
+
+  it('displays catering only filter', () => {
+    renderWithRouter(<ExportPage />);
+    expect(screen.getByText(/catering reservations only/i)).toBeInTheDocument();
+  });
+
+  it('catering filter is unchecked by default', () => {
+    renderWithRouter(<ExportPage />);
+    const cateringCheckbox = screen
+      .getByText(/catering reservations only/i)
+      .closest('label')!
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(cateringCheckbox).not.toBeChecked();
+  });
 });
 

--- a/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
+++ b/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
@@ -209,4 +209,42 @@ describe('FormSettingsPage', () => {
       expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
     });
   });
+
+  it('clears an optional blocked-period time via the clear button', async () => {
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Blocked Period')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Blocked Period'));
+
+    await waitFor(() => {
+      expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
+    });
+
+    const startTime = document.querySelector('input[type="time"]') as HTMLInputElement;
+    expect(startTime).toBeTruthy();
+
+    // No clear button while the time is empty
+    expect(screen.queryByLabelText('Clear start time')).not.toBeInTheDocument();
+
+    // Setting a value reveals the clear button
+    fireEvent.change(startTime, { target: { value: '10:30' } });
+    expect(startTime.value).toBe('10:30');
+
+    const clearBtn = await screen.findByLabelText('Clear start time');
+    fireEvent.click(clearBtn);
+
+    // Time is cleared and the clear button disappears again
+    await waitFor(() => {
+      expect((document.querySelector('input[type="time"]') as HTMLInputElement).value).toBe('');
+    });
+    expect(screen.queryByLabelText('Clear start time')).not.toBeInTheDocument();
+  });
 });

--- a/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
+++ b/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { FormSettingsPage } from '../pages/FormSettingsPage';
+import { fetchBlockedPeriods } from '../lib/api';
 
 vi.mock('../lib/usePermissions', () => ({
   usePermissions: () => ({
@@ -207,6 +208,60 @@ describe('FormSettingsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
+    });
+  });
+
+  it('reveals the acknowledgement text field when soft block is toggled on', async () => {
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Blocked Period')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Add Blocked Period'));
+
+    await waitFor(() => {
+      expect(screen.getByText('New Blocked Period')).toBeInTheDocument();
+    });
+
+    // Acknowledgement field hidden until soft block is enabled
+    expect(screen.queryByText(/Acknowledgement text/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Toggle soft block'));
+
+    expect(await screen.findByText(/Acknowledgement text/i)).toBeInTheDocument();
+  });
+
+  it('shows a "Soft block" badge for soft-blocked periods', async () => {
+    vi.mocked(fetchBlockedPeriods).mockResolvedValueOnce([
+      {
+        id: 1,
+        startDate: '2026-07-01',
+        endDate: '2026-08-31',
+        reason: 'Summer closing',
+        publicMessage: 'Bar open on request only',
+        softBlock: true,
+        acknowledgementText: 'I understand the bar may be closed',
+        enabled: true,
+      },
+    ]);
+
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Blocked Periods/).length).toBeGreaterThanOrEqual(1);
+    }, { timeout: 3000 });
+
+    const blockedBtn = screen.getAllByText(/Blocked Periods/).find(el => el.closest('button'));
+    fireEvent.click(blockedBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Summer closing')).toBeInTheDocument();
+      expect(screen.getByText('Soft block')).toBeInTheDocument();
     });
   });
 

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { ReservationDetailPage } from '../pages/ReservationDetailPage';
 
@@ -57,7 +57,10 @@ vi.mock('../lib/api', () => ({
   sendCateringEmail: vi.fn(),
 }));
 
-import { fetchReservationAuditLog } from '../lib/api';
+import { fetchReservationAuditLog, fetchReservation, updateReservationStatus } from '../lib/api';
+
+const DEFAULT_REJECTION_MESSAGE =
+  'Unfortunately we cannot host you since we do not have any places left at this time';
 
 const renderPage = () =>
   render(
@@ -100,5 +103,62 @@ describe('ReservationDetailPage — change history', () => {
 
     // The rest of the page still renders.
     expect(screen.getByText('Birthday Party')).toBeInTheDocument();
+  });
+});
+
+describe('ReservationDetailPage — custom email message', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills the editable default rejection message and sends it', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+    vi.mocked(updateReservationStatus).mockResolvedValueOnce({ ...sampleReservation, status: 'REJECTED' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }));
+
+    const textarea = await screen.findByPlaceholderText(/shaded spot/i);
+    expect(textarea).toHaveValue(DEFAULT_REJECTION_MESSAGE);
+
+    fireEvent.click(screen.getByRole('button', { name: /Yes, Reject Reservation/ }));
+
+    await waitFor(() =>
+      expect(updateReservationStatus).toHaveBeenCalledWith(
+        1, 'REJECTED', 'Staff Member', true, DEFAULT_REJECTION_MESSAGE));
+  });
+
+  it('sends a typed message when confirming', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+    vi.mocked(updateReservationStatus).mockResolvedValueOnce({ ...sampleReservation, status: 'CONFIRMED' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }));
+
+    const textarea = await screen.findByPlaceholderText(/shaded spot/i);
+    expect(textarea).toHaveValue(''); // no default for confirmations
+    fireEvent.change(textarea, { target: { value: 'We saved you a spot in the shade!' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Yes, Confirm Reservation/ }));
+
+    await waitFor(() =>
+      expect(updateReservationStatus).toHaveBeenCalledWith(
+        1, 'CONFIRMED', 'Staff Member', true, 'We saved you a spot in the shade!'));
+  });
+
+  it('hides the message field when email notification is turned off', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('checkbox')); // turn off "send email notification"
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }));
+
+    expect(screen.queryByPlaceholderText(/shaded spot/i)).not.toBeInTheDocument();
   });
 });

--- a/the-harry-list-admin/src/types/reservation.ts
+++ b/the-harry-list-admin/src/types/reservation.ts
@@ -87,6 +87,10 @@ export interface BlockedPeriod {
   endTime?: string;
   reason: string;
   publicMessage?: string;
+  /** When true, the period warns but does not block reservations. */
+  softBlock?: boolean;
+  /** Optional checkbox label the guest must tick to acknowledge a soft block. */
+  acknowledgementText?: string;
   enabled: boolean;
   updatedAt?: string;
 }

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.3.0</version>
+	<version>1.4.0</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodController.java
@@ -72,6 +72,8 @@ public class AdminBlockedPeriodController {
                     existing.setEndTime(period.getEndTime());
                     existing.setReason(period.getReason());
                     existing.setPublicMessage(period.getPublicMessage());
+                    existing.setSoftBlock(period.getSoftBlock());
+                    existing.setAcknowledgementText(period.getAcknowledgementText());
                     existing.setEnabled(period.getEnabled());
                     BlockedPeriod saved = repository.save(existing);
                     auditService.recordUpdate(AuditEntityType.BLOCKED_PERIOD, saved.getId(), label(saved),

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminEmailTemplateController.java
@@ -92,14 +92,15 @@ public class AdminEmailTemplateController {
         }
 
         Map<String, String> sampleVars = emailTemplateService.buildSampleVariables(type);
+        Map<String, String> sampleRawHtml = emailTemplateService.buildSampleRawHtmlVariables(type);
 
         String subject = (request.getSubject() != null && !request.getSubject().isBlank())
                 ? emailTemplateService.renderForTest(request.getSubject(), sampleVars)
                 : emailTemplateService.getRenderedSubject(type, sampleVars);
 
         String body = (request.getBodyTemplate() != null && !request.getBodyTemplate().isBlank())
-                ? emailTemplateService.renderForTest(request.getBodyTemplate(), sampleVars)
-                : emailTemplateService.getRenderedBody(type, sampleVars);
+                ? emailTemplateService.renderForTest(request.getBodyTemplate(), sampleVars, sampleRawHtml)
+                : emailTemplateService.getRenderedBody(type, sampleVars, sampleRawHtml);
 
         try {
             emailNotificationService.get().sendRawEmail(request.getToEmail(), subject, body);

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportController.java
@@ -34,7 +34,8 @@ public class AdminExportController {
     public ResponseEntity<byte[]> generateDailyReport(
             @RequestParam String date,
             @RequestParam String location,
-            @RequestParam(required = false, defaultValue = "true") boolean confirmedOnly) {
+            @RequestParam(required = false, defaultValue = "true") boolean confirmedOnly,
+            @RequestParam(required = false, defaultValue = "false") boolean cateringOnly) {
 
         // Parse date
         LocalDate reportDate;
@@ -53,7 +54,7 @@ public class AdminExportController {
         }
 
         try {
-            byte[] pdfBytes = pdfExportService.generateDailyReport(reportDate, reportLocation, confirmedOnly);
+            byte[] pdfBytes = pdfExportService.generateDailyReport(reportDate, reportLocation, confirmedOnly, cateringOnly);
 
             String filename = String.format("reservations-%s-%s.pdf",
                     reportLocation.name().toLowerCase(),

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -122,7 +122,7 @@ public class AdminReservationController {
                     // Send email notification if enabled
                     if (sendEmail && emailService != null) {
                         try {
-                            emailService.sendStatusChangeEmail(saved, oldStatus, confirmedBy, customMessage);
+                            emailService.sendStatusChangeEmail(saved, customMessage);
                         } catch (Exception e) {
                             log.error("Failed to send status change email, but status was updated successfully", e);
                         }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -85,6 +85,7 @@ public class AdminReservationController {
             @RequestParam ReservationStatus status,
             @RequestParam(required = false) String confirmedBy,
             @RequestParam(required = false, defaultValue = "true") boolean sendEmail,
+            @RequestParam(required = false) String customMessage,
             Principal principal) {
 
         return reservationRepository.findById(id)
@@ -108,15 +109,20 @@ public class AdminReservationController {
                             oldStatus, status, principal != null ? principal.getName() : "unknown",
                             confirmedBy != null ? " confirmedBy='" + confirmedBy + "'" : "");
 
+                    // The message content itself is not stored in the audit log (may be long); we only
+                    // record that a custom message accompanied the status change.
+                    boolean hasCustomMessage = customMessage != null && !customMessage.isBlank();
                     auditService.recordAction(AuditEntityType.RESERVATION, id, label(saved),
                             AuditAction.STATUS_CHANGE,
                             List.of(new FieldChange("status", String.valueOf(oldStatus), String.valueOf(status))),
-                            "Status changed" + (confirmedBy != null ? " (confirmed by " + confirmedBy + ")" : ""));
+                            "Status changed"
+                                    + (confirmedBy != null ? " (confirmed by " + confirmedBy + ")" : "")
+                                    + (hasCustomMessage ? " (with message)" : ""));
 
                     // Send email notification if enabled
                     if (sendEmail && emailService != null) {
                         try {
-                            emailService.sendStatusChangeEmail(saved, oldStatus, confirmedBy);
+                            emailService.sendStatusChangeEmail(saved, oldStatus, confirmedBy, customMessage);
                         } catch (Exception e) {
                             log.error("Failed to send status change email, but status was updated successfully", e);
                         }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/open/ReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/open/ReservationController.java
@@ -59,13 +59,14 @@ public class ReservationController {
     }
 
     @PutMapping("/{id}")
-    @Operation(summary = "Update a reservation", description = "Update an existing reservation (staff only). Set sendEmail=false to skip email notification.")
+    @Operation(summary = "Update a reservation", description = "Update an existing reservation (staff only). Set sendEmail=false to skip email notification. Optionally pass customMessage to add a note to the update email.")
     public ResponseEntity<Reservation> updateReservation(
             @PathVariable Long id,
             @Valid @RequestBody Reservation reservation,
-            @RequestParam(required = false, defaultValue = "true") boolean sendEmail) {
+            @RequestParam(required = false, defaultValue = "true") boolean sendEmail,
+            @RequestParam(required = false) String customMessage) {
         reservation.setId(id);
-        return updateReservationService.executeWithEmail(reservation, sendEmail);
+        return updateReservationService.executeWithEmail(reservation, sendEmail, customMessage);
     }
 
     @DeleteMapping("/{id}")

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/BlockedPeriod.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/BlockedPeriod.java
@@ -53,6 +53,22 @@ public class BlockedPeriod {
     @Column(name = "public_message", length = 500)
     private String publicMessage;
 
+    /**
+     * When true, this period does not block reservations: bookings are still allowed,
+     * but the guest is shown a warning and must acknowledge it before continuing.
+     * When false (default), the period hard-blocks reservations as before.
+     */
+    @Column(name = "soft_block", nullable = false)
+    @Builder.Default
+    private Boolean softBlock = false;
+
+    /**
+     * Optional checkbox label the guest must tick to acknowledge a soft block before
+     * proceeding. Only relevant when {@link #softBlock} is true; a default is used when blank.
+     */
+    @Column(name = "acknowledgement_text", length = 500)
+    private String acknowledgementText;
+
     @Column(nullable = false)
     @Builder.Default
     private Boolean enabled = true;

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationService.java
@@ -174,6 +174,11 @@ public class ConstraintValidationService {
         }
 
         for (BlockedPeriod bp : blocking) {
+            // Soft blocks are advisory only: the guest is warned and must acknowledge
+            // on the form, but the booking is allowed, so they are not server-side violations.
+            if (Boolean.TRUE.equals(bp.getSoftBlock())) {
+                continue;
+            }
             String msg = bp.getPublicMessage() != null ? bp.getPublicMessage()
                     : "This date is not available for reservations";
             violations.add(msg);

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailNotificationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailNotificationService.java
@@ -19,13 +19,20 @@ public interface EmailNotificationService {
 
     /**
      * Send email when reservation status changes.
+     *
+     * @param customMessage optional free-text note from staff, added to the email as a highlighted
+     *                      block; may be {@code null} or blank to omit it.
      */
-    void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy);
+    void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy,
+                               String customMessage);
 
     /**
      * Send email when reservation is updated.
+     *
+     * @param customMessage optional free-text note from staff, added to the email as a highlighted
+     *                      block; may be {@code null} or blank to omit it.
      */
-    void sendReservationUpdatedEmail(Reservation reservation);
+    void sendReservationUpdatedEmail(Reservation reservation, String customMessage);
 
     /**
      * Send email when reservation is deleted/cancelled.

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailNotificationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailNotificationService.java
@@ -2,7 +2,6 @@ package com.pimvanleeuwen.the_harry_list_backend.service;
 
 import com.pimvanleeuwen.the_harry_list_backend.model.EmailAttachment;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
-import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 
 import java.util.List;
 
@@ -23,8 +22,7 @@ public interface EmailNotificationService {
      * @param customMessage optional free-text note from staff, added to the email as a highlighted
      *                      block; may be {@code null} or blank to omit it.
      */
-    void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy,
-                               String customMessage);
+    void sendStatusChangeEmail(Reservation reservation, String customMessage);
 
     /**
      * Send email when reservation is updated.

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateService.java
@@ -39,11 +39,11 @@ public class EmailTemplateService {
         AVAILABLE_VARIABLES.put(EmailTemplateType.STATUS_CHANGED, List.of(
                 "contactName", "confirmationNumber", "eventTitle", "eventDate",
                 "startTime", "endTime", "location", "expectedGuests",
-                "status", "statusMessage", "statusColor", "barName", "staffEmail"));
+                "status", "statusMessage", "statusColor", "barName", "staffEmail", "customMessage"));
 
         AVAILABLE_VARIABLES.put(EmailTemplateType.UPDATED, List.of(
                 "contactName", "confirmationNumber", "eventTitle", "eventDate",
-                "startTime", "endTime", "location", "expectedGuests", "status", "barName"));
+                "startTime", "endTime", "location", "expectedGuests", "status", "barName", "customMessage"));
 
         AVAILABLE_VARIABLES.put(EmailTemplateType.CANCELLED, List.of(
                 "contactName", "eventTitle", "confirmationNumber", "staffEmail", "barName"));
@@ -126,6 +126,7 @@ public class EmailTemplateService {
                         <div class="content">
                             <p>Dear {{contactName}},</p>
                             <p>{{statusMessage}}</p>
+                            {{customMessage}}
                             <div class="details">
                                 <p><strong>Confirmation Number:</strong> {{confirmationNumber}}</p>
                                 <p><strong>Event:</strong> {{eventTitle}}</p>
@@ -160,6 +161,7 @@ public class EmailTemplateService {
                         <div class="content">
                             <p>Dear {{contactName}},</p>
                             <p>Your reservation has been updated. Please review the details below:</p>
+                            {{customMessage}}
                             <div class="details">
                                 <p><strong>Confirmation Number:</strong> {{confirmationNumber}}</p>
                                 <p><strong>Event:</strong> {{eventTitle}}</p>
@@ -290,10 +292,26 @@ public class EmailTemplateService {
      * All variable values are HTML-escaped before substitution to prevent XSS.
      */
     public String getRenderedBody(EmailTemplateType type, Map<String, String> variables) {
+        // Types that support an optional {{customMessage}} block default to an empty block when no
+        // message is supplied, so the placeholder never renders literally.
+        Map<String, String> rawHtmlVariables =
+                (type == EmailTemplateType.STATUS_CHANGED || type == EmailTemplateType.UPDATED)
+                        ? Map.of("customMessage", "")
+                        : Map.of();
+        return getRenderedBody(type, variables, rawHtmlVariables);
+    }
+
+    /**
+     * Render a template body with both escaped variables and pre-sanitized raw-HTML variables.
+     * Raw-HTML variables (e.g. {@code customMessage}) are substituted verbatim and must already be
+     * safe HTML — see {@link EmailTemplates#buildCustomMessageBlock(String)}.
+     */
+    public String getRenderedBody(EmailTemplateType type, Map<String, String> variables,
+                                  Map<String, String> rawHtmlVariables) {
         String template = repository.findByTemplateType(type)
                 .map(EmailTemplate::getBodyTemplate)
                 .orElse(DEFAULT_BODIES.get(type));
-        return render(template, variables);
+        return render(template, variables, rawHtmlVariables);
     }
 
     /**
@@ -303,7 +321,7 @@ public class EmailTemplateService {
         String template = repository.findByTemplateType(type)
                 .map(EmailTemplate::getSubject)
                 .orElse(DEFAULT_SUBJECTS.get(type));
-        return render(template, variables);
+        return render(template, variables, Map.of());
     }
 
     public List<EmailTemplateDto> findAll() {
@@ -374,7 +392,26 @@ public class EmailTemplateService {
 
     /** Render an arbitrary template string with the given variables (used for test previews). */
     public String renderForTest(String template, Map<String, String> variables) {
-        return render(template, variables);
+        return render(template, variables, Map.of());
+    }
+
+    /** Render an arbitrary template string with escaped variables plus pre-sanitized raw-HTML variables. */
+    public String renderForTest(String template, Map<String, String> variables,
+                                Map<String, String> rawHtmlVariables) {
+        return render(template, variables, rawHtmlVariables);
+    }
+
+    /**
+     * Returns sample raw-HTML variables (e.g. a {@code customMessage} block) for test/preview
+     * rendering, so admins can see how the optional message appears. Empty for types that do not
+     * support a custom message.
+     */
+    public Map<String, String> buildSampleRawHtmlVariables(EmailTemplateType type) {
+        if (type == EmailTemplateType.STATUS_CHANGED || type == EmailTemplateType.UPDATED) {
+            return Map.of("customMessage", EmailTemplates.buildCustomMessageBlock(
+                    "We read your special request and will make sure you have a spot in the shade."));
+        }
+        return Map.of();
     }
 
     public String getDefaultBody(EmailTemplateType type) {
@@ -399,11 +436,17 @@ public class EmailTemplateService {
                 .build();
     }
 
-    private String render(String template, Map<String, String> variables) {
+    private String render(String template, Map<String, String> variables,
+                          Map<String, String> rawHtmlVariables) {
         if (template == null) return "";
         String result = template;
         for (Map.Entry<String, String> entry : variables.entrySet()) {
             result = result.replace("{{" + entry.getKey() + "}}", escapeHtml(entry.getValue()));
+        }
+        // Raw-HTML variables are pre-sanitized and substituted verbatim (no escaping).
+        for (Map.Entry<String, String> entry : rawHtmlVariables.entrySet()) {
+            String value = entry.getValue() != null ? entry.getValue() : "";
+            result = result.replace("{{" + entry.getKey() + "}}", value);
         }
         return result;
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplates.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplates.java
@@ -430,4 +430,21 @@ public class EmailTemplates {
             escapeHtml(barName)
         );
     }
+
+    /**
+     * Builds the optional "custom message" block injected into status-change and update emails.
+     * Returns an empty string when no message is provided, so the surrounding template renders
+     * nothing. The message text is HTML-escaped (newlines become &lt;br&gt;) so the block is safe
+     * to substitute as raw HTML into a template.
+     */
+    public static String buildCustomMessageBlock(String message) {
+        if (message == null || message.isBlank()) {
+            return "";
+        }
+        String htmlMessage = escapeHtml(message).replace("\n", "<br>");
+        return String.format("""
+            <div style="background-color: #ffffff; padding: 15px; margin: 15px 0; border-left: 4px solid #6b46c1;">
+                <p style="margin: 0;">%s</p>
+            </div>""", htmlMessage);
+    }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/MicrosoftGraphEmailService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/MicrosoftGraphEmailService.java
@@ -90,8 +90,7 @@ public class MicrosoftGraphEmailService implements EmailNotificationService {
     }
 
     @Override
-    public void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy,
-                                      String customMessage) {
+    public void sendStatusChangeEmail(Reservation reservation, String customMessage) {
         try {
             Map<String, String> vars = buildStatusChangeVars(reservation);
             Map<String, String> rawHtmlVars = Map.of(

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/MicrosoftGraphEmailService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/MicrosoftGraphEmailService.java
@@ -90,11 +90,14 @@ public class MicrosoftGraphEmailService implements EmailNotificationService {
     }
 
     @Override
-    public void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy) {
+    public void sendStatusChangeEmail(Reservation reservation, ReservationStatus oldStatus, String confirmedBy,
+                                      String customMessage) {
         try {
             Map<String, String> vars = buildStatusChangeVars(reservation);
+            Map<String, String> rawHtmlVars = Map.of(
+                    "customMessage", EmailTemplates.buildCustomMessageBlock(customMessage));
             String subject = emailTemplateService.getRenderedSubject(EmailTemplateType.STATUS_CHANGED, vars);
-            String body = emailTemplateService.getRenderedBody(EmailTemplateType.STATUS_CHANGED, vars);
+            String body = emailTemplateService.getRenderedBody(EmailTemplateType.STATUS_CHANGED, vars, rawHtmlVars);
             sendEmail(reservation.getEmail(), subject, body);
             log.info("LOGGING email.status_change_sent confirmation='{}' to='{}' status={}",
                     reservation.getConfirmationNumber(), reservation.getEmail(), reservation.getStatus());
@@ -104,12 +107,14 @@ public class MicrosoftGraphEmailService implements EmailNotificationService {
     }
 
     @Override
-    public void sendReservationUpdatedEmail(Reservation reservation) {
+    public void sendReservationUpdatedEmail(Reservation reservation, String customMessage) {
         try {
             Map<String, String> vars = buildBaseVars(reservation);
             vars.put("status", reservation.getStatus().getDisplayName());
+            Map<String, String> rawHtmlVars = Map.of(
+                    "customMessage", EmailTemplates.buildCustomMessageBlock(customMessage));
             String subject = emailTemplateService.getRenderedSubject(EmailTemplateType.UPDATED, vars);
-            String body = emailTemplateService.getRenderedBody(EmailTemplateType.UPDATED, vars);
+            String body = emailTemplateService.getRenderedBody(EmailTemplateType.UPDATED, vars, rawHtmlVars);
             sendEmail(reservation.getEmail(), subject, body);
             log.info("LOGGING email.updated_sent confirmation='{}' to='{}'",
                     reservation.getConfirmationNumber(), reservation.getEmail());

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
@@ -38,11 +38,12 @@ public class PdfExportService {
         this.reservationRepository = reservationRepository;
     }
 
-    public byte[] generateDailyReport(LocalDate date, BarLocation location, boolean confirmedOnly) throws DocumentException {
+    public byte[] generateDailyReport(LocalDate date, BarLocation location, boolean confirmedOnly, boolean cateringOnly) throws DocumentException {
         List<Reservation> reservations = reservationRepository.findAll().stream()
                 .filter(r -> r.getEventDate() != null && r.getEventDate().equals(date))
                 .filter(r -> r.getLocation() != null && r.getLocation().equals(location))
                 .filter(r -> !confirmedOnly || r.getStatus() == ReservationStatus.CONFIRMED)
+                .filter(r -> !cateringOnly || hasCateringActivity(r))
                 .sorted(Comparator.comparing(r -> r.getStartTime() != null ? r.getStartTime() : java.time.LocalTime.MAX))
                 .toList();
 
@@ -227,9 +228,7 @@ public class PdfExportService {
         contentCell.addElement(content);
 
         // Add catering info if present
-        boolean hasCateringActivity = res.getSpecialActivities() != null && res.getSpecialActivities().stream()
-                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE || a == SpecialActivity.EAT_CATERING || a == SpecialActivity.CATERING_CORONA_ROOM);
-        if (hasCateringActivity) {
+        if (hasCateringActivity(res)) {
             Paragraph cateringStatusPara = new Paragraph();
             cateringStatusPara.setSpacingBefore(10);
             cateringStatusPara.add(new Chunk("Catering Arranged: ", labelFont));
@@ -468,6 +467,18 @@ public class PdfExportService {
         cell.setHorizontalAlignment(alignment);
         cell.setPaddingTop(5);
         table.addCell(cell);
+    }
+
+    /**
+     * Whether a reservation includes catering, i.e. has one of the catering-related
+     * special activities. Used both to filter the report (cateringOnly) and to decide
+     * whether to render the catering info block on a reservation card.
+     */
+    private boolean hasCateringActivity(Reservation res) {
+        return res.getSpecialActivities() != null && res.getSpecialActivities().stream()
+                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE
+                        || a == SpecialActivity.EAT_CATERING
+                        || a == SpecialActivity.CATERING_CORONA_ROOM);
     }
 
     private void addField(Paragraph para, String label, String value, Font labelFont, Font valueFont) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationService.java
@@ -39,13 +39,19 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         return executeWithEmail(input, true);
     }
 
-    /**
-     * Update a reservation with optional email notification.
-     * @param input The reservation DTO
-     * @param sendEmail Whether to send email notification
-     */
     public ResponseEntity<com.pimvanleeuwen.the_harry_list_backend.dto.Reservation> executeWithEmail(
             com.pimvanleeuwen.the_harry_list_backend.dto.Reservation input, boolean sendEmail) {
+        return executeWithEmail(input, sendEmail, null);
+    }
+
+    /**
+     * Update a reservation with optional email notification and an optional custom message.
+     * @param input The reservation DTO
+     * @param sendEmail Whether to send email notification
+     * @param customMessage Optional free-text note added to the update email; may be null/blank to omit.
+     */
+    public ResponseEntity<com.pimvanleeuwen.the_harry_list_backend.dto.Reservation> executeWithEmail(
+            com.pimvanleeuwen.the_harry_list_backend.dto.Reservation input, boolean sendEmail, String customMessage) {
         if (input.getId() == null) {
             log.error("Cannot update reservation without ID");
             return ResponseEntity.badRequest().build();
@@ -96,7 +102,7 @@ public class UpdateReservationService implements Command<com.pimvanleeuwen.the_h
         // Send email notification if enabled
         if (sendEmail && emailService != null) {
             try {
-                emailService.sendReservationUpdatedEmail(savedEntity);
+                emailService.sendReservationUpdatedEmail(savedEntity, customMessage);
             } catch (Exception e) {
                 log.error("Failed to send update email, but reservation was updated successfully", e);
             }

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminBlockedPeriodControllerTest.java
@@ -119,6 +119,43 @@ class AdminBlockedPeriodControllerTest {
 
     @Test
     @WithMockUser(roles = "EDITOR")
+    void create_shouldPersistSoftBlockFields() throws Exception {
+        BlockedPeriod soft = samplePeriod();
+        soft.setSoftBlock(true);
+        soft.setAcknowledgementText("I understand the bar may be closed");
+        when(repository.save(any())).thenReturn(soft);
+
+        mockMvc.perform(post("/api/admin/blocked-periods")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(soft)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.softBlock").value(true))
+                .andExpect(jsonPath("$.acknowledgementText").value("I understand the bar may be closed"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void update_shouldCopySoftBlockFields() throws Exception {
+        BlockedPeriod existing = samplePeriod();
+        when(repository.findById(1L)).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        BlockedPeriod update = samplePeriod();
+        update.setSoftBlock(true);
+        update.setAcknowledgementText("Open on request");
+
+        mockMvc.perform(put("/api/admin/blocked-periods/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.softBlock").value(true))
+                .andExpect(jsonPath("$.acknowledgementText").value("Open on request"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
     void toggle_shouldFlipEnabledState() throws Exception {
         BlockedPeriod period = samplePeriod();
         period.setEnabled(true);

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminExportControllerTest.java
@@ -39,7 +39,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldReturnPdf() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -55,7 +55,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldAcceptConfirmedOnlyParameter() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), eq(false)))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), eq(false), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -63,6 +63,38 @@ class AdminExportControllerTest {
                 .param("date", "2026-02-15")
                 .param("location", "HUBBLE")
                 .param("confirmedOnly", "false"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void generateDailyReport_shouldAcceptCateringOnlyParameter() throws Exception {
+        // Given
+        byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), eq(true)))
+            .thenReturn(mockPdf);
+
+        // When/Then
+        mockMvc.perform(get("/api/admin/export/daily-report")
+                .param("date", "2026-02-15")
+                .param("location", "HUBBLE")
+                .param("cateringOnly", "true"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_PDF));
+    }
+
+    @Test
+    @WithMockUser
+    void generateDailyReport_shouldDefaultCateringOnlyToFalse() throws Exception {
+        // Given - no cateringOnly param supplied, service should be called with false
+        byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), eq(false)))
+            .thenReturn(mockPdf);
+
+        // When/Then
+        mockMvc.perform(get("/api/admin/export/daily-report")
+                .param("date", "2026-02-15")
+                .param("location", "HUBBLE"))
             .andExpect(status().isOk());
     }
 
@@ -91,7 +123,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldAcceptMeteorLocation() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.METEOR), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.METEOR), anyBoolean(), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -107,7 +139,7 @@ class AdminExportControllerTest {
     void generateDailyReport_shouldAcceptLowercaseLocation() throws Exception {
         // Given
         byte[] mockPdf = "%PDF-1.4 mock pdf content".getBytes();
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), eq(BarLocation.HUBBLE), anyBoolean(), anyBoolean()))
             .thenReturn(mockPdf);
 
         // When/Then
@@ -121,7 +153,7 @@ class AdminExportControllerTest {
     @WithMockUser
     void generateDailyReport_shouldReturnInternalServerErrorOnException() throws Exception {
         // Given
-        when(pdfExportService.generateDailyReport(any(LocalDate.class), any(BarLocation.class), anyBoolean()))
+        when(pdfExportService.generateDailyReport(any(LocalDate.class), any(BarLocation.class), anyBoolean(), anyBoolean()))
             .thenThrow(new DocumentException("PDF generation failed"));
 
         // When/Then

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -221,7 +221,7 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any());
+        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any(), any());
     }
 
     @Test
@@ -240,7 +240,47 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any(), any());
+        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldForwardCustomMessageToEmail() throws Exception {
+        // Given
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        // When
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "REJECTED")
+                .param("customMessage", "Sorry, we are fully booked that day."))
+            .andExpect(status().isOk());
+
+        // Then
+        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any(),
+                eq("Sorry, we are fully booked that day."));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldNoteCustomMessageInAuditWhenProvided() throws Exception {
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "REJECTED")
+                .param("customMessage", "No space available."))
+            .andExpect(status().isOk());
+
+        verify(auditService).recordAction(
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType.RESERVATION),
+            eq(1L), any(),
+            eq(com.pimvanleeuwen.the_harry_list_backend.model.AuditAction.STATUS_CHANGE),
+            any(), contains("(with message)"));
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -221,7 +221,7 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any(), any());
+        verify(emailNotificationService).sendStatusChangeEmail(any(), any());
     }
 
     @Test
@@ -240,7 +240,7 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any(), any(), any());
+        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any());
     }
 
     @Test
@@ -259,7 +259,7 @@ class AdminReservationControllerTest {
             .andExpect(status().isOk());
 
         // Then
-        verify(emailNotificationService).sendStatusChangeEmail(any(), any(), any(),
+        verify(emailNotificationService).sendStatusChangeEmail(any(),
                 eq("Sorry, we are fully booked that day."));
     }
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/ReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/ReservationControllerTest.java
@@ -129,7 +129,7 @@ class ReservationControllerTest {
         // Given
         sampleReservation.setId(1L);
         sampleReservation.setContactName("Updated Name");
-        when(updateReservationService.executeWithEmail(any(Reservation.class), anyBoolean()))
+        when(updateReservationService.executeWithEmail(any(Reservation.class), anyBoolean(), any()))
                 .thenReturn(ResponseEntity.ok(sampleReservation));
 
         // When & Then

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationServiceTest.java
@@ -287,6 +287,65 @@ class ConstraintValidationServiceTest {
     }
 
     @Test
+    void validate_shouldNotFlagSoftBlockedPeriod() {
+        LocalDate eventDate = LocalDate.now().plusDays(5);
+
+        BlockedPeriod softBlocked = BlockedPeriod.builder()
+                .startDate(eventDate.minusDays(1))
+                .endDate(eventDate.plusDays(1))
+                .reason("Summer closing")
+                .publicMessage("Bar open on request only")
+                .softBlock(true)
+                .enabled(true)
+                .build();
+
+        when(constraintRepository.findByEnabledTrue()).thenReturn(List.of());
+        when(blockedPeriodRepository.findBlockingPeriods(eventDate, BarLocation.HUBBLE))
+                .thenReturn(List.of(softBlocked));
+
+        List<String> violations = service.validate(
+                Set.of(SpecialActivity.GRADUATION),
+                BarLocation.HUBBLE,
+                SeatingArea.INSIDE,
+                eventDate,
+                LocalTime.of(14, 0),
+                30);
+
+        assertTrue(violations.isEmpty(), "Soft blocks must not block submission server-side");
+    }
+
+    @Test
+    void validate_shouldStillFlagHardBlockAlongsideSoftBlock() {
+        LocalDate eventDate = LocalDate.now().plusDays(5);
+
+        BlockedPeriod softBlocked = BlockedPeriod.builder()
+                .startDate(eventDate).endDate(eventDate)
+                .reason("Summer closing").publicMessage("Bar open on request only")
+                .softBlock(true).enabled(true)
+                .build();
+        BlockedPeriod hardBlocked = BlockedPeriod.builder()
+                .startDate(eventDate).endDate(eventDate)
+                .reason("Private event").publicMessage("Fully booked")
+                .softBlock(false).enabled(true)
+                .build();
+
+        when(constraintRepository.findByEnabledTrue()).thenReturn(List.of());
+        when(blockedPeriodRepository.findBlockingPeriods(eventDate, BarLocation.HUBBLE))
+                .thenReturn(List.of(softBlocked, hardBlocked));
+
+        List<String> violations = service.validate(
+                Set.of(SpecialActivity.GRADUATION),
+                BarLocation.HUBBLE,
+                SeatingArea.INSIDE,
+                eventDate,
+                LocalTime.of(14, 0),
+                30);
+
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).contains("Fully booked"));
+    }
+
+    @Test
     void validate_shouldCollectMultipleViolations() {
         FormConstraint conflict = FormConstraint.builder()
                 .constraintType(FormConstraintType.ACTIVITY_CONFLICT)

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/EmailTemplateServiceTest.java
@@ -186,6 +186,114 @@ class EmailTemplateServiceTest {
         assertTrue(subject.contains("Team Lunch"));
     }
 
+    // --- Custom message block ---
+
+    private Map<String, String> statusChangeVars() {
+        Map<String, String> vars = new java.util.HashMap<>();
+        vars.put("statusColor", "#f44336");
+        vars.put("status", "Rejected");
+        vars.put("statusMessage", "Unfortunately, we're unable to accommodate your request.");
+        vars.put("contactName", "Alice");
+        vars.put("confirmationNumber", "X");
+        vars.put("eventTitle", "Borrel");
+        vars.put("eventDate", "Monday");
+        vars.put("startTime", "18:00");
+        vars.put("endTime", "22:00");
+        vars.put("location", "Hubble");
+        vars.put("expectedGuests", "20");
+        vars.put("barName", "Hubble Cafe");
+        vars.put("staffEmail", "staff@hubble.cafe");
+        vars.put("statusSubject", "Reservation Request Update");
+        return vars;
+    }
+
+    @Test
+    void statusChanged_shouldInjectCustomMessageBlockWhenProvided() {
+        String block = EmailTemplates.buildCustomMessageBlock("We will keep a shaded spot for you.");
+        String body = service.getRenderedBody(EmailTemplateType.STATUS_CHANGED,
+                statusChangeVars(), Map.of("customMessage", block));
+
+        assertTrue(body.contains("We will keep a shaded spot for you."));
+        // The block HTML must survive verbatim (not double-escaped).
+        assertTrue(body.contains("border-left: 4px solid #6b46c1"));
+        assertFalse(body.contains("{{customMessage}}"));
+    }
+
+    @Test
+    void statusChanged_shouldOmitCustomMessageWhenNoneProvided() {
+        // The 2-arg overload defaults the block to empty for status-change emails.
+        String body = service.getRenderedBody(EmailTemplateType.STATUS_CHANGED, statusChangeVars());
+
+        assertFalse(body.contains("{{customMessage}}"), "Placeholder must not render literally");
+        assertFalse(body.contains("border-left: 4px solid #6b46c1"), "No block when no message");
+    }
+
+    @Test
+    void updated_shouldInjectCustomMessageBlockWhenProvided() {
+        Map<String, String> vars = new java.util.HashMap<>();
+        vars.put("contactName", "Bob");
+        vars.put("confirmationNumber", "U1");
+        vars.put("eventTitle", "Workshop");
+        vars.put("eventDate", "Tuesday");
+        vars.put("startTime", "10:00");
+        vars.put("endTime", "12:00");
+        vars.put("location", "Meteor");
+        vars.put("expectedGuests", "12");
+        vars.put("status", "Confirmed");
+        vars.put("barName", "Meteor Cafe");
+
+        String block = EmailTemplates.buildCustomMessageBlock("We moved you to the larger room.");
+        String body = service.getRenderedBody(EmailTemplateType.UPDATED, vars,
+                Map.of("customMessage", block));
+
+        assertTrue(body.contains("We moved you to the larger room."));
+        assertFalse(body.contains("{{customMessage}}"));
+    }
+
+    @Test
+    void customMessageBlock_shouldEscapeHtmlButRenderVerbatim() {
+        String block = EmailTemplates.buildCustomMessageBlock("<script>alert('x')</script>");
+        String body = service.getRenderedBody(EmailTemplateType.STATUS_CHANGED,
+                statusChangeVars(), Map.of("customMessage", block));
+
+        assertFalse(body.contains("<script>"), "Message text must be escaped");
+        assertTrue(body.contains("&lt;script&gt;"));
+        // The wrapping div is intentional HTML and must remain.
+        assertTrue(body.contains("<div"));
+    }
+
+    @Test
+    void buildCustomMessageBlock_shouldReturnEmptyForBlankOrNull() {
+        assertEquals("", EmailTemplates.buildCustomMessageBlock(null));
+        assertEquals("", EmailTemplates.buildCustomMessageBlock(""));
+        assertEquals("", EmailTemplates.buildCustomMessageBlock("   "));
+    }
+
+    @Test
+    void buildCustomMessageBlock_shouldConvertNewlinesToBreaks() {
+        String block = EmailTemplates.buildCustomMessageBlock("line one\nline two");
+        assertTrue(block.contains("line one<br>line two"));
+    }
+
+    @Test
+    void availableVariables_shouldIncludeCustomMessageForStatusAndUpdatedOnly() {
+        assertTrue(service.getAvailableVariables(EmailTemplateType.STATUS_CHANGED).contains("customMessage"));
+        assertTrue(service.getAvailableVariables(EmailTemplateType.UPDATED).contains("customMessage"));
+        assertFalse(service.getAvailableVariables(EmailTemplateType.SUBMITTED).contains("customMessage"));
+        assertFalse(service.getAvailableVariables(EmailTemplateType.CANCELLED).contains("customMessage"));
+    }
+
+    @Test
+    void buildSampleRawHtmlVariables_shouldProvideBlockForStatusAndUpdatedOnly() {
+        assertTrue(service.buildSampleRawHtmlVariables(EmailTemplateType.STATUS_CHANGED)
+                .containsKey("customMessage"));
+        assertFalse(service.buildSampleRawHtmlVariables(EmailTemplateType.STATUS_CHANGED)
+                .get("customMessage").isBlank());
+        assertTrue(service.buildSampleRawHtmlVariables(EmailTemplateType.UPDATED)
+                .containsKey("customMessage"));
+        assertTrue(service.buildSampleRawHtmlVariables(EmailTemplateType.SUBMITTED).isEmpty());
+    }
+
     // --- Default content ---
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportServiceTest.java
@@ -1,0 +1,166 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import org.openpdf.text.DocumentException;
+import org.openpdf.text.pdf.PdfReader;
+import org.openpdf.text.pdf.parser.PdfTextExtractor;
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+import com.pimvanleeuwen.the_harry_list_backend.model.SpecialActivity;
+import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for PdfExportService, focusing on the reservation filtering logic
+ * (confirmed-only and catering-only) applied before rendering the daily report.
+ */
+@ExtendWith(MockitoExtension.class)
+class PdfExportServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @InjectMocks
+    private PdfExportService pdfExportService;
+
+    private static final LocalDate REPORT_DATE = LocalDate.of(2026, 2, 15);
+
+    @Test
+    void generateDailyReport_cateringOnly_includesOnlyCateringReservations() throws Exception {
+        // Given: one catering reservation and one non-catering reservation on the same day/location
+        Reservation catering = reservation("Catering Dinner", LocalTime.of(18, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_CATERING));
+        Reservation nonCatering = reservation("Plain Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(catering, nonCatering));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, true);
+
+        // Then: only the catering reservation appears
+        String text = extractText(pdf);
+        assertTrue(text.contains("Catering Dinner"), "Catering reservation should be included");
+        assertFalse(text.contains("Plain Drinks"), "Non-catering reservation should be excluded");
+    }
+
+    @Test
+    void generateDailyReport_cateringOnlyFalse_includesAllReservations() throws Exception {
+        // Given
+        Reservation catering = reservation("Catering Dinner", LocalTime.of(18, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_A_LA_CARTE));
+        Reservation nonCatering = reservation("Plain Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(catering, nonCatering));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        // Then: both reservations appear
+        String text = extractText(pdf);
+        assertTrue(text.contains("Catering Dinner"));
+        assertTrue(text.contains("Plain Drinks"));
+    }
+
+    @Test
+    void generateDailyReport_cateringOnly_recognisesAllCateringActivities() throws Exception {
+        // Given: each of the three catering activities should qualify
+        Reservation alaCarte = reservation("A La Carte Lunch", LocalTime.of(12, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_A_LA_CARTE));
+        Reservation cateringEvent = reservation("Full Catering", LocalTime.of(15, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_CATERING));
+        Reservation coronaRoom = reservation("Corona Room Catering", LocalTime.of(17, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.CATERING_CORONA_ROOM));
+        Reservation graduation = reservation("Graduation Only", LocalTime.of(19, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.GRADUATION));
+        when(reservationRepository.findAll())
+                .thenReturn(List.of(alaCarte, cateringEvent, coronaRoom, graduation));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, true);
+
+        // Then
+        String text = extractText(pdf);
+        assertTrue(text.contains("A La Carte Lunch"));
+        assertTrue(text.contains("Full Catering"));
+        assertTrue(text.contains("Corona Room Catering"));
+        assertFalse(text.contains("Graduation Only"), "Non-catering activity should be excluded");
+    }
+
+    @Test
+    void generateDailyReport_cateringOnly_combinesWithConfirmedOnly() throws Exception {
+        // Given: a confirmed catering reservation and a pending catering reservation
+        Reservation confirmedCatering = reservation("Confirmed Catering", LocalTime.of(18, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.EAT_CATERING));
+        Reservation pendingCatering = reservation("Pending Catering", LocalTime.of(20, 0),
+                ReservationStatus.PENDING, Set.of(SpecialActivity.EAT_CATERING));
+        when(reservationRepository.findAll()).thenReturn(List.of(confirmedCatering, pendingCatering));
+
+        // When: both filters active
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, true, true);
+
+        // Then: only the confirmed catering reservation remains
+        String text = extractText(pdf);
+        assertTrue(text.contains("Confirmed Catering"));
+        assertFalse(text.contains("Pending Catering"));
+    }
+
+    @Test
+    void generateDailyReport_cateringOnly_withNoMatches_producesEmptyReport() throws Exception {
+        // Given: only non-catering reservations
+        Reservation nonCatering = reservation("Plain Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(nonCatering));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, true);
+
+        // Then: a valid PDF is still produced with the "no reservations" message
+        assertNotNull(pdf);
+        assertTrue(pdf.length > 0);
+        String text = extractText(pdf);
+        assertTrue(text.contains("No reservations for this date."));
+        assertFalse(text.contains("Plain Drinks"));
+    }
+
+    // --- helpers ---
+
+    private Reservation reservation(String title, LocalTime start, ReservationStatus status,
+                                    Set<SpecialActivity> activities) {
+        Reservation r = new Reservation();
+        r.setEventTitle(title);
+        r.setContactName("Test Contact");
+        r.setEmail("test@example.com");
+        r.setEventDate(REPORT_DATE);
+        r.setStartTime(start);
+        r.setEndTime(start.plusHours(2));
+        r.setLocation(BarLocation.HUBBLE);
+        r.setExpectedGuests(10);
+        r.setStatus(status);
+        r.setSpecialActivities(activities);
+        return r;
+    }
+
+    private String extractText(byte[] pdf) throws IOException {
+        PdfReader reader = new PdfReader(pdf);
+        PdfTextExtractor extractor = new PdfTextExtractor(reader);
+        StringBuilder sb = new StringBuilder();
+        for (int page = 1; page <= reader.getNumberOfPages(); page++) {
+            sb.append(extractor.getTextFromPage(page)).append('\n');
+        }
+        reader.close();
+        return sb.toString();
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/UpdateReservationServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,6 +39,9 @@ class UpdateReservationServiceTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private EmailNotificationService emailService;
+
     @InjectMocks
     private UpdateReservationService updateReservationService;
 
@@ -48,6 +52,9 @@ class UpdateReservationServiceTest {
     void setUp() {
         sampleDto = createSampleDto();
         existingEntity = createExistingEntity();
+        // emailService is an optional (@Autowired(required=false)) field, not a constructor arg, so
+        // @InjectMocks (constructor injection) doesn't set it — wire the mock in explicitly.
+        ReflectionTestUtils.setField(updateReservationService, "emailService", emailService);
     }
 
     @Test
@@ -95,6 +102,44 @@ class UpdateReservationServiceTest {
                 c.field().equals("contactName")
                         && "Original Name".equals(c.oldValue())
                         && "Updated Name".equals(c.newValue())));
+    }
+
+    @Test
+    void executeWithEmail_shouldForwardCustomMessageToEmail() {
+        // Given
+        sampleDto.setId(1L);
+        com.pimvanleeuwen.the_harry_list_backend.model.Reservation incoming = createExistingEntity();
+        incoming.setContactName("Updated Name");
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(reservationMapper.toEntity(sampleDto)).thenReturn(incoming);
+        when(reservationRepository.save(any())).thenReturn(incoming);
+        when(reservationMapper.toDto(incoming)).thenReturn(sampleDto);
+
+        // When
+        updateReservationService.executeWithEmail(sampleDto, true, "We moved your booking to the terrace.");
+
+        // Then
+        verify(emailService).sendReservationUpdatedEmail(any(), eq("We moved your booking to the terrace."));
+    }
+
+    @Test
+    void executeWithEmail_shouldNotSendEmailWhenDisabled() {
+        // Given
+        sampleDto.setId(1L);
+        com.pimvanleeuwen.the_harry_list_backend.model.Reservation incoming = createExistingEntity();
+        incoming.setContactName("Updated Name");
+
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(existingEntity));
+        when(reservationMapper.toEntity(sampleDto)).thenReturn(incoming);
+        when(reservationRepository.save(any())).thenReturn(incoming);
+        when(reservationMapper.toDto(incoming)).thenReturn(sampleDto);
+
+        // When
+        updateReservationService.executeWithEmail(sampleDto, false, "ignored message");
+
+        // Then
+        verify(emailService, never()).sendReservationUpdatedEmail(any(), any());
     }
 
     @Test

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.55.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-public/src/components/ReservationForm.test.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.test.tsx
@@ -567,6 +567,52 @@ describe('ReservationForm', () => {
       await waitFor(() =>
         expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument()
       );
+
+      // The global soft-block warning is not repeated under the location step
+      expect(screen.queryByText('The bar is closed by default this summer.')).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: 'I understand the bar may be closed' }))
+        .not.toBeInTheDocument();
+    });
+
+    it('shows a location-specific soft block on the location step with its own acknowledgement', async () => {
+      vi.mocked(fetchBlockedPeriods).mockResolvedValue([
+        {
+          id: 3,
+          location: 'HUBBLE',
+          ...wideRange,
+          reason: 'Hubble summer closing',
+          publicMessage: 'Hubble is closed by default this summer.',
+          softBlock: true,
+          acknowledgementText: 'I understand Hubble may be closed',
+          enabled: true,
+        },
+      ]);
+
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+      await fillStep2Fields(user);
+
+      // No location chosen yet → location-specific block does not surface on the date step
+      expect(screen.queryByText('Hubble is closed by default this summer.')).not.toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() =>
+        expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument()
+      );
+
+      // Choosing Hubble triggers the soft block here, with its acknowledgement
+      await user.click(screen.getByText('Hubble'));
+      await user.click(screen.getByText('Inside')); // seating is required to advance
+      expect(await screen.findByText('Hubble is closed by default this summer.')).toBeInTheDocument();
+      const ack = screen.getByRole('checkbox', { name: 'I understand Hubble may be closed' });
+
+      // Still blocked until the soft block is acknowledged
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument();
+
+      await user.click(ack);
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() => expect(screen.getByText('Payment Information')).toBeInTheDocument());
     });
 
     it('does not allow proceeding past a hard block and shows no acknowledgement checkbox', async () => {

--- a/the-harry-list-public/src/components/ReservationForm.test.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.test.tsx
@@ -522,6 +522,78 @@ describe('ReservationForm', () => {
     });
   });
 
+  // ==================== SOFT / HARD BLOCKED PERIODS ====================
+
+  describe('blocked periods', () => {
+    // Wide global range so it always covers the "tomorrow" date used by fillStep2Fields.
+    const wideRange = { startDate: '2020-01-01', endDate: '2099-12-31' };
+
+    async function goToStep2(user: ReturnType<typeof userEvent.setup>) {
+      await user.type(screen.getByPlaceholderText('John Doe'), 'Jane Smith');
+      await user.type(screen.getByPlaceholderText('john@example.com'), 'jane@example.com');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() => expect(screen.getByText('Activity Details')).toBeInTheDocument());
+    }
+
+    it('lets the guest proceed past a soft block only after acknowledging it', async () => {
+      vi.mocked(fetchBlockedPeriods).mockResolvedValue([
+        {
+          id: 1,
+          ...wideRange,
+          reason: 'Summer closing',
+          publicMessage: 'The bar is closed by default this summer.',
+          softBlock: true,
+          acknowledgementText: 'I understand the bar may be closed',
+          enabled: true,
+        },
+      ]);
+
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+      await fillStep2Fields(user);
+
+      // Warning + acknowledgement checkbox are shown
+      expect(screen.getByText('The bar is closed by default this summer.')).toBeInTheDocument();
+      const ack = screen.getByRole('checkbox', { name: 'I understand the bar may be closed' });
+
+      // Cannot advance until acknowledged
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Activity Details')).toBeInTheDocument();
+
+      // Acknowledge, then advance succeeds
+      await user.click(ack);
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await waitFor(() =>
+        expect(screen.getByText('Where would you like to host your event?')).toBeInTheDocument()
+      );
+    });
+
+    it('does not allow proceeding past a hard block and shows no acknowledgement checkbox', async () => {
+      vi.mocked(fetchBlockedPeriods).mockResolvedValue([
+        {
+          id: 2,
+          ...wideRange,
+          reason: 'Renovation',
+          publicMessage: 'Closed for renovation.',
+          softBlock: false,
+          enabled: true,
+        },
+      ]);
+
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+      await fillStep2Fields(user);
+
+      expect(screen.getByText('Closed for renovation.')).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /understand/i })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Activity Details')).toBeInTheDocument();
+    });
+  });
+
   // ==================== STEP 4: PAYMENT ====================
 
   describe('step 4 - payment', () => {

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -1092,8 +1092,9 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
               </label>
             </div>
 
-            {/* Blocked period notice (shows when location triggers a location-specific block) */}
-            {blockedDateNotice}
+            {/* Blocked period notice — only for location-specific blocks here; global/time
+                blocks are already surfaced (and acknowledged) on the date step. */}
+            {blockedDateInfo?.locationSpecific && blockedDateNotice}
 
             {/* Seating Area Selection */}
             <div className="form-group">

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import * as Sentry from '@sentry/react';
 import { submitReservation, fetchFormOptions, fetchFormConstraints, fetchBlockedPeriods, getRecaptchaSiteKey } from '../lib/api';
+import { checkBlockedDate } from '../lib/blockedPeriods';
 import type { ReservationFormData, FormOptions, FormConstraint, BlockedPeriod } from '../types/reservation';
 
 // Phone number validation - allows international formats
@@ -306,31 +307,42 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
 
   // Blocked period check for selected date
   const watchEventDate = watch('eventDate');
-  const blockedDateWarning = useMemo(() => {
-    if (!watchEventDate || blockedPeriods.length === 0) return null;
-    const selectedDate = watchEventDate;
-    const selectedLocation = watchLocation;
-    const selectedTime = watchStartTime;
-    for (const bp of blockedPeriods) {
-      if (selectedDate >= bp.startDate && selectedDate <= bp.endDate) {
-        if (bp.location) {
-          // Location-specific block: only warn if user selected that exact location
-          if (!selectedLocation || selectedLocation === 'NO_PREFERENCE' || selectedLocation === '' || bp.location !== selectedLocation) {
-            continue;
-          }
-        }
-        // Time-specific block: only warn if user's start time falls within the blocked window
-        if (bp.startTime && bp.endTime) {
-          if (!selectedTime || selectedTime < bp.startTime || selectedTime >= bp.endTime) {
-            continue;
-          }
-        }
-        // Global block (no location) or matching location
-        return bp.publicMessage || 'This date is not available for reservations.';
-      }
-    }
-    return null;
-  }, [watchEventDate, blockedPeriods, watchLocation, watchStartTime]);
+  const blockedDateInfo = useMemo(
+    () => checkBlockedDate(watchEventDate, watchLocation, blockedPeriods, watchStartTime),
+    [watchEventDate, blockedPeriods, watchLocation, watchStartTime]
+  );
+
+  // A soft block is informational: the guest can proceed after acknowledging it.
+  const [softBlockAcknowledged, setSoftBlockAcknowledged] = useState(false);
+  // Reset the acknowledgement whenever the matched (soft) block changes.
+  useEffect(() => {
+    setSoftBlockAcknowledged(false);
+  }, [blockedDateInfo?.message, blockedDateInfo?.soft]);
+
+  // Notice rendered wherever a blocked period applies. Hard blocks show a red,
+  // blocking error; soft blocks show an amber warning with an acknowledgement checkbox.
+  const blockedDateNotice = !blockedDateInfo ? null : blockedDateInfo.soft ? (
+    <div className="mt-2 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 space-y-2">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+        <span>{blockedDateInfo.message}</span>
+      </div>
+      <label className="flex items-start gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={softBlockAcknowledged}
+          onChange={e => setSoftBlockAcknowledged(e.target.checked)}
+          className="mt-0.5 shrink-0"
+        />
+        <span>{blockedDateInfo.acknowledgementText}</span>
+      </label>
+    </div>
+  ) : (
+    <div className="mt-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
+      <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+      <span>{blockedDateInfo.message}</span>
+    </div>
+  );
 
   const requiresAdvanceBooking = advanceBookingDays > 0;
   const minDateForBooking = useMemo(() => {
@@ -439,9 +451,12 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
       return false;
     }
 
-    // Block advance if date is in a blocked period (step 2 for global blocks, step 3 for location-specific)
-    if ((step === 2 || step === 3) && blockedDateWarning) {
-      return false;
+    // Block advance if date is in a blocked period (step 2 for global blocks, step 3 for location-specific).
+    // Hard blocks always prevent advancing; soft blocks only until the guest acknowledges the warning.
+    if ((step === 2 || step === 3) && blockedDateInfo) {
+      if (!blockedDateInfo.soft || !softBlockAcknowledged) {
+        return false;
+      }
     }
 
     // Block step 2 advance if long reservation reason is missing
@@ -864,12 +879,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                   />
                 </div>
                 {errors.eventDate && <p id="eventDate-error" className="error-text">{errors.eventDate.message}</p>}
-                {blockedDateWarning && (
-                  <div className="mt-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
-                    <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-                    <span>{blockedDateWarning}</span>
-                  </div>
-                )}
+                {blockedDateNotice}
               </div>
 
               {/* Start Time */}
@@ -1082,13 +1092,8 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
               </label>
             </div>
 
-            {/* Blocked period warning (shows when location triggers a location-specific block) */}
-            {blockedDateWarning && (
-              <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-                <span>{blockedDateWarning}</span>
-              </div>
-            )}
+            {/* Blocked period notice (shows when location triggers a location-specific block) */}
+            {blockedDateNotice}
 
             {/* Seating Area Selection */}
             <div className="form-group">

--- a/the-harry-list-public/src/lib/blockedPeriods.ts
+++ b/the-harry-list-public/src/lib/blockedPeriods.ts
@@ -4,6 +4,13 @@ import type { BlockedPeriod } from '../types/reservation';
 export const DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT =
   'I understand the bar may be closed during this period and that my reservation is a request.';
 
+/** Default warning shown for a soft block when no public message is configured. */
+export const DEFAULT_SOFT_BLOCK_MESSAGE =
+  'We are by default closed during this period, but by acknowledging the message below you can still place a reservation request.';
+
+/** Default message shown for a (hard) block when no public message is configured. */
+export const DEFAULT_HARD_BLOCK_MESSAGE = 'This date is not available for reservations.';
+
 export interface BlockedDateMatch {
   /** Public-facing message to display to the guest. */
   message: string;
@@ -11,6 +18,8 @@ export interface BlockedDateMatch {
   soft: boolean;
   /** Checkbox label for the acknowledgement (only meaningful when soft). */
   acknowledgementText: string;
+  /** True when the block only applies because of the selected location. */
+  locationSpecific: boolean;
 }
 
 /**
@@ -41,10 +50,12 @@ export function checkBlockedDate(
           continue;
         }
       }
+      const soft = bp.softBlock === true;
       return {
-        message: bp.publicMessage || 'This date is not available for reservations.',
-        soft: bp.softBlock === true,
+        message: bp.publicMessage || (soft ? DEFAULT_SOFT_BLOCK_MESSAGE : DEFAULT_HARD_BLOCK_MESSAGE),
+        soft,
         acknowledgementText: bp.acknowledgementText?.trim() || DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT,
+        locationSpecific: !!bp.location,
       };
     }
   }

--- a/the-harry-list-public/src/lib/blockedPeriods.ts
+++ b/the-harry-list-public/src/lib/blockedPeriods.ts
@@ -1,0 +1,52 @@
+import type { BlockedPeriod } from '../types/reservation';
+
+/** Default acknowledgement label shown for a soft block when none is configured. */
+export const DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT =
+  'I understand the bar may be closed during this period and that my reservation is a request.';
+
+export interface BlockedDateMatch {
+  /** Public-facing message to display to the guest. */
+  message: string;
+  /** When true the block is advisory: the guest may proceed after acknowledging it. */
+  soft: boolean;
+  /** Checkbox label for the acknowledgement (only meaningful when soft). */
+  acknowledgementText: string;
+}
+
+/**
+ * Determine whether the chosen date/location/time falls inside an active blocked
+ * period and, if so, return how it should be surfaced to the guest.
+ *
+ * Returns null when no block applies. A hard block (soft === false) prevents the
+ * booking; a soft block warns but allows it once acknowledged.
+ */
+export function checkBlockedDate(
+  eventDate: string | null | undefined,
+  location: string | null | undefined,
+  blockedPeriods: BlockedPeriod[],
+  startTime?: string
+): BlockedDateMatch | null {
+  if (!eventDate || blockedPeriods.length === 0) return null;
+  for (const bp of blockedPeriods) {
+    if (eventDate >= bp.startDate && eventDate <= bp.endDate) {
+      if (bp.location) {
+        // Location-specific block: only applies if the guest picked that exact location.
+        if (!location || location === 'NO_PREFERENCE' || location === '' || bp.location !== location) {
+          continue;
+        }
+      }
+      // Time-specific block: only applies if the start time falls within the blocked window.
+      if (bp.startTime && bp.endTime) {
+        if (!startTime || startTime < bp.startTime || startTime >= bp.endTime) {
+          continue;
+        }
+      }
+      return {
+        message: bp.publicMessage || 'This date is not available for reservations.',
+        soft: bp.softBlock === true,
+        acknowledgementText: bp.acknowledgementText?.trim() || DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT,
+      };
+    }
+  }
+  return null;
+}

--- a/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
+++ b/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { BlockedPeriod } from '../types/reservation';
-import { checkBlockedDate, DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT } from '../lib/blockedPeriods';
+import {
+  checkBlockedDate,
+  DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT,
+  DEFAULT_SOFT_BLOCK_MESSAGE,
+} from '../lib/blockedPeriods';
 
 /**
  * Tests for the blocked period date checking logic used in ReservationForm.
@@ -178,8 +182,22 @@ describe('Soft blocked periods', () => {
     expect(result?.acknowledgementText).toBe(DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT);
   });
 
+  it('uses the soft-specific default message when no public message is set', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, publicMessage: undefined }]);
+    expect(result?.message).toBe(DEFAULT_SOFT_BLOCK_MESSAGE);
+  });
+
   it('treats a period without softBlock as a hard block', () => {
     const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, softBlock: undefined }]);
     expect(result?.soft).toBe(false);
+  });
+
+  it('flags a global block as not location-specific', () => {
+    expect(checkBlockedDate('2026-07-15', 'HUBBLE', [softPeriod])?.locationSpecific).toBe(false);
+  });
+
+  it('flags a location-scoped block as location-specific', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, location: 'HUBBLE' }]);
+    expect(result?.locationSpecific).toBe(true);
   });
 });

--- a/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
+++ b/the-harry-list-public/src/test/BlockedPeriodWarning.test.tsx
@@ -1,37 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { BlockedPeriod } from '../types/reservation';
+import { checkBlockedDate, DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT } from '../lib/blockedPeriods';
 
 /**
  * Tests for the blocked period date checking logic used in ReservationForm.
- * Tests the pure logic extracted from the component's useMemo.
+ * Exercises the shared helper the component itself uses.
  */
-
-function checkBlockedDate(
-  eventDate: string,
-  location: string | null | undefined,
-  blockedPeriods: BlockedPeriod[],
-  startTime?: string
-): string | null {
-  if (!eventDate || blockedPeriods.length === 0) return null;
-  for (const bp of blockedPeriods) {
-    if (eventDate >= bp.startDate && eventDate <= bp.endDate) {
-      if (bp.location) {
-        // Location-specific block: only warn if user selected that exact location
-        if (!location || location === 'NO_PREFERENCE' || location === '' || bp.location !== location) {
-          continue;
-        }
-      }
-      // Time-specific block: only warn if user's start time falls within the blocked window
-      if (bp.startTime && bp.endTime) {
-        if (!startTime || startTime < bp.startTime || startTime >= bp.endTime) {
-          continue;
-        }
-      }
-      return bp.publicMessage || 'This date is not available for reservations.';
-    }
-  }
-  return null;
-}
 
 describe('Blocked period date validation', () => {
   const samplePeriods: BlockedPeriod[] = [
@@ -64,38 +38,32 @@ describe('Blocked period date validation', () => {
 
   it('returns warning when date falls within a location-specific blocked period', () => {
     const result = checkBlockedDate('2026-04-02', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for maintenance from April 1-3');
+    expect(result?.message).toBe('Closed for maintenance from April 1-3');
+    expect(result?.soft).toBe(false);
   });
 
   it('returns null when date is in blocked period but for a different location', () => {
-    const result = checkBlockedDate('2026-04-02', 'METEOR', samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-02', 'METEOR', samplePeriods)).toBeNull();
   });
 
   it('returns warning for global blocked period regardless of location', () => {
-    const result = checkBlockedDate('2026-12-25', 'METEOR', samplePeriods);
-    expect(result).toBe('Closed for Christmas');
+    expect(checkBlockedDate('2026-12-25', 'METEOR', samplePeriods)?.message).toBe('Closed for Christmas');
   });
 
   it('returns warning for global blocked period with HUBBLE location', () => {
-    const result = checkBlockedDate('2026-12-26', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for Christmas');
+    expect(checkBlockedDate('2026-12-26', 'HUBBLE', samplePeriods)?.message).toBe('Closed for Christmas');
   });
 
   it('skips location-specific block when user has NO_PREFERENCE', () => {
-    const result = checkBlockedDate('2026-04-01', 'NO_PREFERENCE', samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-01', 'NO_PREFERENCE', samplePeriods)).toBeNull();
   });
 
   it('skips location-specific block when location is empty string (No Preference)', () => {
-    // The form uses value="" for the "No Preference" radio
-    const result = checkBlockedDate('2026-04-01', '', samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-01', '', samplePeriods)).toBeNull();
   });
 
   it('skips location-specific block when location is null', () => {
-    const result = checkBlockedDate('2026-04-01', null, samplePeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-04-01', null, samplePeriods)).toBeNull();
   });
 
   it('returns null when date is outside all blocked periods', () => {
@@ -103,13 +71,11 @@ describe('Blocked period date validation', () => {
   });
 
   it('matches on exact start date', () => {
-    const result = checkBlockedDate('2026-04-01', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for maintenance from April 1-3');
+    expect(checkBlockedDate('2026-04-01', 'HUBBLE', samplePeriods)?.message).toBe('Closed for maintenance from April 1-3');
   });
 
   it('matches on exact end date', () => {
-    const result = checkBlockedDate('2026-04-03', 'HUBBLE', samplePeriods);
-    expect(result).toBe('Closed for maintenance from April 1-3');
+    expect(checkBlockedDate('2026-04-03', 'HUBBLE', samplePeriods)?.message).toBe('Closed for maintenance from April 1-3');
   });
 
   it('returns default message when publicMessage is not set', () => {
@@ -122,8 +88,8 @@ describe('Blocked period date validation', () => {
         enabled: true,
       },
     ];
-    const result = checkBlockedDate('2026-06-01', 'HUBBLE', periodsNoMessage);
-    expect(result).toBe('This date is not available for reservations.');
+    expect(checkBlockedDate('2026-06-01', 'HUBBLE', periodsNoMessage)?.message)
+      .toBe('This date is not available for reservations.');
   });
 });
 
@@ -150,42 +116,70 @@ describe('Blocked period time-specific validation', () => {
   ];
 
   it('blocks when start time falls within blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '10:00');
-    expect(result).toBe('Not available in the morning');
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '10:00')?.message)
+      .toBe('Not available in the morning');
   });
 
   it('blocks at exact start of blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '09:00');
-    expect(result).toBe('Not available in the morning');
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '09:00')?.message)
+      .toBe('Not available in the morning');
   });
 
   it('does not block when start time is at or after the blocked end time', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '14:00');
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '14:00')).toBeNull();
   });
 
   it('does not block when start time is after blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '15:00');
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '15:00')).toBeNull();
   });
 
   it('does not block when start time is before blocked time window', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '08:30');
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods, '08:30')).toBeNull();
   });
 
   it('does not block time-specific period when no start time selected', () => {
-    const result = checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods);
-    expect(result).toBeNull();
+    expect(checkBlockedDate('2026-05-01', 'HUBBLE', timeSpecificPeriods)).toBeNull();
   });
 
   it('blocks full-day period regardless of start time', () => {
-    const result = checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods, '10:00');
-    expect(result).toBe('Closed all day');
+    expect(checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods, '10:00')?.message).toBe('Closed all day');
   });
 
   it('blocks full-day period when no start time selected', () => {
-    const result = checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods);
-    expect(result).toBe('Closed all day');
+    expect(checkBlockedDate('2026-05-10', 'HUBBLE', timeSpecificPeriods)?.message).toBe('Closed all day');
+  });
+});
+
+describe('Soft blocked periods', () => {
+  const softPeriod: BlockedPeriod = {
+    id: 20,
+    startDate: '2026-07-01',
+    endDate: '2026-08-31',
+    reason: 'Summer closing',
+    publicMessage: 'The bar is closed by default this summer, but you can request a reservation.',
+    softBlock: true,
+    acknowledgementText: 'I understand the bar may be closed and my booking is a request',
+    enabled: true,
+  };
+
+  it('flags a soft block as soft and surfaces the public message', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [softPeriod]);
+    expect(result?.soft).toBe(true);
+    expect(result?.message).toBe(softPeriod.publicMessage);
+  });
+
+  it('returns the configured acknowledgement text', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [softPeriod]);
+    expect(result?.acknowledgementText).toBe('I understand the bar may be closed and my booking is a request');
+  });
+
+  it('falls back to the default acknowledgement text when none is configured', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, acknowledgementText: undefined }]);
+    expect(result?.acknowledgementText).toBe(DEFAULT_SOFT_BLOCK_ACKNOWLEDGEMENT);
+  });
+
+  it('treats a period without softBlock as a hard block', () => {
+    const result = checkBlockedDate('2026-07-15', 'HUBBLE', [{ ...softPeriod, softBlock: undefined }]);
+    expect(result?.soft).toBe(false);
   });
 });

--- a/the-harry-list-public/src/types/reservation.ts
+++ b/the-harry-list-public/src/types/reservation.ts
@@ -79,5 +79,9 @@ export interface BlockedPeriod {
   endTime?: string;
   reason: string;
   publicMessage?: string;
+  /** When true, the period warns but does not block reservations. */
+  softBlock?: boolean;
+  /** Optional checkbox label the guest must tick to acknowledge a soft block. */
+  acknowledgementText?: string;
   enabled: boolean;
 }


### PR DESCRIPTION
# Release v1.4.0

Closes #254 #253, #280, and #279.

## What's included

### Soft-blocked periods (#254)
A blocked period can now **warn-and-allow** instead of fully blocking for cases like the summer closing, where the bar is closed by default but can still be reserved on request.
- **Soft block toggle** on blocked periods, with a **customizable acknowledgement text** (and a sensible default).
- Public form shows an amber warning + a **required acknowledgement checkbox**; pressing Continue without ticking it now shows a clear "please tick the box" prompt so the form never feels broken.
- Amber **"Soft block"** badge in the admin list; soft blocks never block submission server-side.
- Hard blocks behave exactly as before.

### Mobile date/time fields (#253)
- Fixes date/time fields overlapping / not loading correctly on mobile.
- Allows clearing optional blocked-period start/end times.

### Catering export (#280)
- Catering-only toggle on the export page.
- `cateringOnly` filter on the daily-report export.

### Custom email message (#279)
- Add a custom message when sending reservation status-change / update emails.
- `{{customMessage}}` block wired through the status-change and update email templates.

## Database migration ⚠️ (required for #254)

Production runs `ddl-auto=validate`, so the two new `blocked_periods` columns must exist **before** deploying the v1.4.0 backend:

```sql
ALTER TABLE blocked_periods
  ADD COLUMN soft_block BOOLEAN NOT NULL DEFAULT FALSE,
  ADD COLUMN acknowledgement_text VARCHAR(500) NULL;
```

- `soft_block` is `false` for all existing rows → current hard-block behavior preserved.
- Dev/test create the columns automatically (`ddl-auto=update` / H2).

Full steps, verification, and rollback in `docs/migration-soft-blocked-periods.md`. (No migration needed for #253, #280, or #279.)

## Testing

- Backend: soft-block service + controller cases ✅
- Admin: badge + editor toggle cases ✅
- Public: shared helper (soft/hard/location) + component gating (acknowledgement required, missing-ack prompt, hard fully blocks, no step-3 duplication) ✅
- Full suites green across all three components.