### PR TITLE
287 feature playwright testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *' # nightly at 03:00 UTC
+  workflow_dispatch:
+
+# Cancel in-progress runs for the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: e2e
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # Boots the e2e stack via the webServer config (docker compose up --build),
+      # waits for the backend + both frontends, then runs the suite.
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload Playwright HTML report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload traces, screenshots & videos
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-test-results
+          path: e2e/test-results/
+          retention-days: 14
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: docker compose -f ../docker-compose.e2e.yml logs backend --tail=200 || true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -32,6 +32,8 @@ regexes = [
   '''harrypass''',
   '''harryuser''',
   '''rootpass''',
+  # Non-secret token used only by the e2e calendar-feed test stack.
+  '''e2e-feed-token''',
 ]
 
 commits = []

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -27,9 +27,11 @@ regexes = [
   '''__[A-Z_]+__''',
   # Spring Boot property placeholders
   '''\$\{[A-Z_]+:[^}]*\}''',
-  # Example/placeholder credentials in application.properties (dev only)
+  # Example/placeholder credentials in application.properties and the dev/e2e
+  # docker-compose stacks (throwaway local/test databases only — never real).
   '''harrypass''',
   '''harryuser''',
+  '''rootpass''',
 ]
 
 commits = []

--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ Bar reservation system for Stichting Bar Potential.
    - Backend API: http://localhost:8080
    - Swagger UI: http://localhost:8080/swagger-ui/index.html
 
+## Testing
+
+Each component has its own fast test suite:
+
+- **Backend:** `cd the-harry-list-backend && ./mvnw test`
+- **Public / Admin frontends:** `cd the-harry-list-<public|admin> && npm run test:run`
+
+**End-to-end (Playwright):** full-stack browser tests that drive the real public + admin
+apps and assert on UI, database, and email (via Mailpit), with screenshots/traces/emails as
+evidence. They run on PRs via `.github/workflows/e2e.yml`.
+
+```bash
+cd e2e
+npm install && npx playwright install --with-deps chromium
+npm test
+```
+
+See [`e2e/README.md`](e2e/README.md) for the architecture, how to read the evidence, the
+**regression coverage map**, and how to maintain/add specs.
+
 ## Production Deployment
 
 ### Prerequisites

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -82,7 +82,7 @@ services:
     networks: [e2e]
 
   # Admin portal. Azure is intentionally unset; the admin e2e auth bridge
-  # (added in the next step) uses the X-Test-* headers the e2e backend accepts.
+  # uses the X-Test-* headers the e2e backend accepts.
   admin:
     build:
       context: ./the-harry-list-admin

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -57,6 +57,7 @@ services:
       - SPRING_MAIL_HOST=mailpit
       - SPRING_MAIL_PORT=1025
       - CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
+      - CALENDAR_FEED_TOKEN=e2e-feed-token
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,105 @@
+# =====================================================================
+# End-to-end test stack — boots the whole system with test-only swaps so
+# Playwright (see ./e2e) can drive the real apps and assert on real email + DB.
+#
+#   docker compose -f docker-compose.e2e.yml up --build
+#
+# Test-only differences from dev/prod:
+#   - backend runs the `e2e` Spring profile: SMTP -> Mailpit, header-based
+#     test auth, and a throwaway MariaDB (ddl-auto=update).
+#   - Mailpit catches all outgoing mail; its REST API (:8025) lets tests read it.
+#   - MariaDB uses tmpfs, so every boot starts from a clean database.
+#
+# NEVER use this file in production. It exists purely for automated testing.
+# =====================================================================
+
+name: harry-list-e2e
+
+services:
+  # Throwaway database — tmpfs means a clean schema/data on every boot.
+  mariadb-e2e:
+    image: mariadb:11
+    environment:
+      MARIADB_ROOT_PASSWORD: rootpass
+      MARIADB_DATABASE: harrylist_e2e
+      MARIADB_USER: harryuser
+      MARIADB_PASSWORD: harrypass
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+    networks: [e2e]
+
+  # Mail catcher — backend sends here over SMTP; tests read via the REST API.
+  mailpit:
+    image: axllent/mailpit:latest
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
+    ports:
+      - "8025:8025" # web UI + REST API used by Playwright to assert emails
+    networks: [e2e]
+
+  backend:
+    build:
+      context: ./the-harry-list-backend
+      dockerfile: Dockerfile
+    environment:
+      - SPRING_PROFILES_ACTIVE=e2e
+      - TZ=Europe/Amsterdam
+      - SPRING_DATASOURCE_URL=jdbc:mariadb://mariadb-e2e:3306/harrylist_e2e
+      - SPRING_DATASOURCE_USERNAME=harryuser
+      - SPRING_DATASOURCE_PASSWORD=harrypass
+      - SPRING_MAIL_HOST=mailpit
+      - SPRING_MAIL_PORT=1025
+      - CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
+    ports:
+      - "8080:8080"
+    depends_on:
+      mariadb-e2e:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
+    networks: [e2e]
+
+  # Public reservation form. The browser runs on the host, so it calls the
+  # backend at the host-published address (http://localhost:8080).
+  public:
+    build:
+      context: ./the-harry-list-public
+      dockerfile: Dockerfile
+    environment:
+      - API_URL=http://localhost:8080
+    ports:
+      - "5173:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks: [e2e]
+
+  # Admin portal. Azure is intentionally unset; the admin e2e auth bridge
+  # (added in the next step) uses the X-Test-* headers the e2e backend accepts.
+  admin:
+    build:
+      context: ./the-harry-list-admin
+      dockerfile: Dockerfile
+    environment:
+      - API_URL=http://localhost:8080
+      - E2E_AUTH_OID=e2e-admin
+      - E2E_AUTH_ROLE=ADMIN
+      - AZURE_CLIENT_ID=
+      - AZURE_TENANT_ID=
+      - REDIRECT_URI=http://localhost:5174
+    ports:
+      - "5174:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks: [e2e]
+
+networks:
+  e2e:

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+blob-report/
+.playwright/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,14 +1,49 @@
 # End-to-end tests (Playwright)
 
-Drives the **real** public and admin apps against the e2e docker stack
-(`../docker-compose.e2e.yml`) and asserts on real UI, database state, and email
-(via Mailpit). A fuller architecture + maintenance guide lands in the docs step;
-this is the quick-start.
+These tests drive the **real** public and admin apps against a throwaway full stack and
+assert on real UI, database state, and email — with screenshots, traces, and the actual
+delivered emails attached to the report as evidence.
+
+They complement (not replace) the fast layers: most logic is covered by backend unit/
+integration tests and frontend component tests. E2E covers the **critical user journeys
+and the wiring between the apps**. See the [coverage map](#regression-coverage-map).
+
+## Architecture
+
+```
+Playwright (chromium)
+  ├── public app   (http://localhost:5173)  ─┐
+  └── admin app    (http://localhost:5174)  ─┤ HTTP
+                                              ▼
+                          backend  (http://localhost:8080, Spring profile "e2e")
+                            ├── MariaDB (tmpfs — clean every boot)
+                            └── SMTP ──► Mailpit (http://localhost:8025, REST API)
+```
+
+Everything is launched by `docker-compose.e2e.yml` (repo root). The backend runs the
+**`e2e` Spring profile**, which swaps in test-only behaviour that never exists in dev/prod:
+
+- **Email** goes over SMTP to **Mailpit** (`SmtpEmailService`, `@Profile("e2e")`) instead of
+  Microsoft Graph, so tests can read the real rendered messages.
+- **Auth** is header-based (`E2eSecurityConfig`): the admin app and API requests send
+  `X-Test-Oid`, and the real `RoleAuthorizationFilter` resolves the role from the DB — so
+  RBAC and audit attribution behave exactly like production.
+- **Seed/reset** endpoints (`TestSupportController`, `/test/*`) let specs set up and clear
+  state without going through Azure-authenticated APIs.
+
+All of the above is gated to the `e2e` profile and verified by `E2eProfileGuardTest` — it
+cannot load in dev or production.
+
+The **admin app** participates via an env-gated bridge (`lib/e2eAuth.ts`): when
+`E2E_AUTH_OID` is injected at runtime (only by `docker-compose.e2e.yml`), it skips MSAL and
+sends the `X-Test-*` headers. Inert everywhere else.
 
 ## Prerequisites
+
 - Docker (to boot the stack) and Node 20+.
 
 ## Install
+
 ```bash
 cd e2e
 npm install
@@ -16,25 +51,108 @@ npx playwright install --with-deps chromium
 ```
 
 ## Run
+
 ```bash
-# Boots the whole stack (MariaDB + backend[e2e] + Mailpit + frontends), runs the suite,
-# and tears nothing down between specs (state is reset per-test via /test/reset).
+# Boots the whole stack, runs the suite, resets state per-test via /test/reset.
 npm test
 ```
 
 Faster iteration against an already-running stack:
+
 ```bash
-npm run stack:up            # start the stack in the background
-E2E_NO_WEBSERVER=1 npm test # reuse it instead of booting a fresh one
-npm run stack:down          # stop + wipe when done
+npm run stack:up              # start the stack in the background
+E2E_NO_WEBSERVER=1 npm test   # reuse it instead of booting a fresh one
+npm run stack:down            # stop + wipe when done
 ```
 
+Useful flags: `npm test -- public/soft-block.spec.ts` (one file), `npm run test:headed`,
+`npm run test:ui`, `npm run report` (open the last HTML report), `npm run typecheck`.
+
 ## Evidence
-- HTML report: `npm run report` (also written to `playwright-report/`).
-- Traces (on retry), screenshots and video (on failure) are attached to the report.
-- Emails are asserted from Mailpit (`http://localhost:8025`) and can be attached to a test.
+
+Every run is self-documenting:
+
+- **Trace** for every test (`trace: 'on'`) — an interactive timeline (DOM/network/console).
+  Open with `npx playwright show-trace <trace.zip>` or drag it into
+  [trace.playwright.dev](https://trace.playwright.dev).
+- **Curated screenshots** at key moments via `captureScreenshot` (animations disabled so the
+  final state is captured, not a mid-transition frame).
+- **Real emails** from Mailpit attached as HTML (`attachHtml`), the catering PDF, the iCal
+  feed, and DB/API snapshots (`attachJson`).
+- Screenshots + video are also auto-captured on failure.
+
+In CI (`.github/workflows/e2e.yml`) the HTML report and all artifacts are uploaded, and the
+backend log is dumped on failure.
 
 ## Layout
-- `playwright.config.ts` — projects (`public`, `admin`, `mobile-public`), webServer, reporters.
-- `fixtures/` — `mailpit.ts` (read delivered email), `backend.ts` (seed/reset via `/test/*`).
-- `tests/<project>/` — specs per surface.
+
+```
+e2e/
+  playwright.config.ts        projects (public, admin, mobile-public), webServer, reporters
+  fixtures/
+    backend.ts                /test/* seed + reset helpers, admin auth headers
+    mailpit.ts                read/clear/poll delivered email
+    evidence.ts               screenshot / html / json / text attachments
+  pages/
+    ReservationFormPage.ts    the public multi-step form
+    AdminSettingsPage.ts      admin Form Settings (constraints + blocked periods)
+  tests/
+    public/                   public reservation form journeys
+    admin/                    admin journeys (API + UI)
+    mobile-public/            phone-viewport (Pixel 5 / chromium)
+```
+
+## How the pieces fit (for writing/maintaining specs)
+
+- **Selectors** are `data-testid`-first. When the UI changes, update the test id in the app
+  and the page object — not every spec.
+- **Page objects** (`pages/`) own the selectors and flows for a screen. Specs read as prose.
+- **Seeding** goes through `fixtures/backend.ts` (`/test/*`), never the UI, so tests start
+  from a known state and stay isolated (`resetBackend` in `beforeEach`).
+- **Admin auth**: seed a user with `seedUser({ oid: 'e2e-admin', role })`; the admin SPA uses
+  `e2e-admin`. For direct API calls use `adminAuthHeaders(oid)`.
+
+### When a feature changes
+1. Update the affected component's `data-testid`(s) if markup changed.
+2. Update the relevant **page object** method(s).
+3. Run the affected spec; update assertions/seed data if behaviour legitimately changed.
+4. If a user journey changed, update (or add) its spec.
+
+### When you add a user-facing feature
+1. Add `data-testid` hooks to the new controls.
+2. Add a page-object method if it's a new screen/flow.
+3. Seed via a `/test/*` helper (extend `TestSupportController` + `fixtures/backend.ts` if needed).
+4. Write the spec, attach evidence (screenshot / email / etc.).
+5. Add a row to the coverage map below.
+
+> Gotchas worth knowing: hidden radios need `.check({ force: true })`; `getByText` is
+> strict — prefer `getByRole('heading', …)` or a test id when text repeats (nav + heading);
+> confirming a reservation requires a concrete location; activity conflicts are seeded in
+> both directions.
+
+## Regression coverage map
+
+E2E asserts journeys + wiring with a representative case; the exhaustive matrix lives in the
+faster layers.
+
+| Area | Unit / component | Backend integration | E2E spec |
+|------|------------------|---------------------|----------|
+| Make a reservation (happy + many options) | form unit tests | `CreateReservationService*` | `public/happy-path`, `public/booking-options` |
+| Soft / hard blocked periods | `blockedPeriods` + form tests | `ConstraintValidationServiceTest` | `public/soft-block`, `public/hard-block`, `admin/blocked-periods` |
+| Form constraints (all types) | form tests | `ConstraintValidationServiceTest` | `public/constraints-blocking`, `public/constraints-dynamic`, `admin/constraints-roundtrip` |
+| Confirm a reservation (appears in admin) | `ReservationsPage`/detail tests | controller tests | `admin/reservation-lifecycle` #1 |
+| Edit / remove a reservation | `ReservationDetailPage` test | `Update`/`DeleteReservationServiceTest` | `admin/reservation-lifecycle` #2 |
+| Status-change email + custom message | — | `AdminReservationControllerTest` | `admin/status-email` |
+| Editable email templates | — | `EmailTemplateServiceTest` | `admin/email-template` |
+| RBAC (viewer/editor/admin) | `usePermissions` | filter tests | `admin/rbac` |
+| Audit log | `AuditDiff`/`AuditService` | controller tests | `admin/audit-log` |
+| Catering-only export (#280) | — | `PdfExportServiceTest` | `admin/catering-export` |
+| Week overview | `WeekOverviewPage` test | — | `admin/week-overview` |
+| Calendar feeds (iCal) | — | `ICalendarServiceTest` | `public/calendar-feed` |
+| Mobile date/time fields (#253) | — | — | `mobile-public/datetime` |
+
+## CI
+
+`.github/workflows/e2e.yml` runs the suite on PRs to `main` (and on demand), boots the
+stack, and uploads the HTML report + traces/screenshots/videos. Making it a required check
+is a branch-protection setting.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,40 @@
+# End-to-end tests (Playwright)
+
+Drives the **real** public and admin apps against the e2e docker stack
+(`../docker-compose.e2e.yml`) and asserts on real UI, database state, and email
+(via Mailpit). A fuller architecture + maintenance guide lands in the docs step;
+this is the quick-start.
+
+## Prerequisites
+- Docker (to boot the stack) and Node 20+.
+
+## Install
+```bash
+cd e2e
+npm install
+npx playwright install --with-deps chromium
+```
+
+## Run
+```bash
+# Boots the whole stack (MariaDB + backend[e2e] + Mailpit + frontends), runs the suite,
+# and tears nothing down between specs (state is reset per-test via /test/reset).
+npm test
+```
+
+Faster iteration against an already-running stack:
+```bash
+npm run stack:up            # start the stack in the background
+E2E_NO_WEBSERVER=1 npm test # reuse it instead of booting a fresh one
+npm run stack:down          # stop + wipe when done
+```
+
+## Evidence
+- HTML report: `npm run report` (also written to `playwright-report/`).
+- Traces (on retry), screenshots and video (on failure) are attached to the report.
+- Emails are asserted from Mailpit (`http://localhost:8025`) and can be attached to a test.
+
+## Layout
+- `playwright.config.ts` — projects (`public`, `admin`, `mobile-public`), webServer, reporters.
+- `fixtures/` — `mailpit.ts` (read delivered email), `backend.ts` (seed/reset via `/test/*`).
+- `tests/<project>/` — specs per surface.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -81,8 +81,10 @@ Every run is self-documenting:
   feed, and DB/API snapshots (`attachJson`).
 - Screenshots + video are also auto-captured on failure.
 
-In CI (`.github/workflows/e2e.yml`) the HTML report and all artifacts are uploaded, and the
-backend log is dumped on failure.
+In CI (`.github/workflows/e2e.yml`) a per-test summary table (status, duration, errors) is
+written directly to the GitHub Actions run page via `@estruyf/github-actions-reporter`, so
+you can see results without downloading anything. The HTML report and all artifacts are also
+uploaded, and the backend log is dumped on failure.
 
 ## Layout
 
@@ -154,5 +156,5 @@ faster layers.
 ## CI
 
 `.github/workflows/e2e.yml` runs the suite on PRs to `main` (and on demand), boots the
-stack, and uploads the HTML report + traces/screenshots/videos. Making it a required check
-is a branch-protection setting.
+stack, writes a per-test summary table to the run page, and uploads the HTML report +
+traces/screenshots/videos. Making it a required check is a branch-protection setting.

--- a/e2e/fixtures/backend.ts
+++ b/e2e/fixtures/backend.ts
@@ -47,3 +47,54 @@ export async function seedBlockedPeriod(
   });
   if (!res.ok()) throw new Error(`/test/blocked-periods failed: ${res.status()}`);
 }
+
+export interface SeedConstraint {
+  constraintType: string;
+  triggerActivity?: string;
+  targetValue?: string;
+  numericValue?: number;
+  secondaryValue?: string;
+  message: string;
+  enabled?: boolean;
+}
+
+/** Seed a form constraint (e.g. GUEST_LIMIT, LOCATION_LOCK) for public-form scenarios. */
+export async function seedConstraint(
+  request: APIRequestContext,
+  constraint: SeedConstraint
+): Promise<void> {
+  const res = await request.post(`${BACKEND_URL}/test/constraints`, {
+    data: { enabled: true, ...constraint },
+  });
+  if (!res.ok()) throw new Error(`/test/constraints failed: ${res.status()}`);
+}
+
+export interface SeedReservation {
+  contactName: string;
+  email: string;
+  eventTitle: string;
+  description?: string;
+  eventDate: string;
+  startTime: string;
+  endTime: string;
+  expectedGuests?: number;
+  location?: string;
+  seatingArea: string;
+  paymentOption: string;
+  status?: string;
+}
+
+/** Seed a reservation directly; returns the saved row (with its id). */
+export async function seedReservation(
+  request: APIRequestContext,
+  reservation: SeedReservation
+): Promise<{ id: number; confirmationNumber: string; email: string }> {
+  const res = await request.post(`${BACKEND_URL}/test/reservations`, { data: reservation });
+  if (!res.ok()) throw new Error(`/test/reservations failed: ${res.status()}`);
+  return res.json();
+}
+
+/** Auth headers for calling /api/admin/* as a seeded user in e2e (see E2eSecurityConfig). */
+export function adminAuthHeaders(oid: string): Record<string, string> {
+  return { 'X-Test-Oid': oid };
+}

--- a/e2e/fixtures/backend.ts
+++ b/e2e/fixtures/backend.ts
@@ -1,0 +1,49 @@
+import type { APIRequestContext } from '@playwright/test';
+import { BACKEND_URL } from '../playwright.config';
+
+/**
+ * Helpers for the backend's e2e-only /test endpoints (see TestSupportController).
+ * These seed and reset state directly, so specs start from a known baseline without
+ * going through Azure-authenticated admin APIs.
+ */
+
+/** Wipe mutable state (reservations, blocked periods, constraints, audit, users). */
+export async function resetBackend(request: APIRequestContext): Promise<void> {
+  const res = await request.post(`${BACKEND_URL}/test/reset`);
+  if (!res.ok()) throw new Error(`/test/reset failed: ${res.status()}`);
+}
+
+export type AdminRole = 'VIEWER' | 'EDITOR' | 'ADMIN';
+
+/** Create/update an admin user with a given role, for RBAC scenarios. */
+export async function seedUser(
+  request: APIRequestContext,
+  user: { oid: string; email?: string; name?: string; role: AdminRole }
+): Promise<void> {
+  const res = await request.post(`${BACKEND_URL}/test/users`, { data: user });
+  if (!res.ok()) throw new Error(`/test/users failed: ${res.status()}`);
+}
+
+export interface SeedBlockedPeriod {
+  location?: string | null;
+  startDate: string;
+  endDate: string;
+  startTime?: string | null;
+  endTime?: string | null;
+  reason: string;
+  publicMessage?: string;
+  softBlock?: boolean;
+  acknowledgementText?: string;
+  enabled?: boolean;
+}
+
+/** Seed a blocked period (hard or soft) for public-form scenarios. */
+export async function seedBlockedPeriod(
+  request: APIRequestContext,
+  period: SeedBlockedPeriod
+): Promise<void> {
+  const res = await request.post(`${BACKEND_URL}/test/blocked-periods`, {
+    data: { enabled: true, ...period },
+  });
+  if (!res.ok()) throw new Error(`/test/blocked-periods failed: ${res.status()}`);
+}

--- a/e2e/fixtures/backend.ts
+++ b/e2e/fixtures/backend.ts
@@ -82,6 +82,7 @@ export interface SeedReservation {
   seatingArea: string;
   paymentOption: string;
   status?: string;
+  specialActivities?: string[];
 }
 
 /** Seed a reservation directly; returns the saved row (with its id). */

--- a/e2e/fixtures/evidence.ts
+++ b/e2e/fixtures/evidence.ts
@@ -1,0 +1,28 @@
+import type { Page, TestInfo } from '@playwright/test';
+
+/**
+ * Helpers for attaching curated, human-readable evidence to the HTML report — so a
+ * passing run shows positive proof of each flow (not just a green check), and a failing
+ * run has the exact UI/email/DB state at the point of interest.
+ */
+
+/** Attach a full-page screenshot under a descriptive step name. */
+export async function captureScreenshot(testInfo: TestInfo, page: Page, name: string): Promise<void> {
+  await testInfo.attach(name, {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: 'image/png',
+  });
+}
+
+/** Attach rendered email HTML (e.g. from Mailpit) so the report shows what was sent. */
+export async function attachHtml(testInfo: TestInfo, name: string, html: string): Promise<void> {
+  await testInfo.attach(name, { body: html, contentType: 'text/html' });
+}
+
+/** Attach an object as pretty JSON (e.g. a DB/API snapshot). */
+export async function attachJson(testInfo: TestInfo, name: string, value: unknown): Promise<void> {
+  await testInfo.attach(name, {
+    body: JSON.stringify(value, null, 2),
+    contentType: 'application/json',
+  });
+}

--- a/e2e/fixtures/evidence.ts
+++ b/e2e/fixtures/evidence.ts
@@ -6,10 +6,16 @@ import type { Page, TestInfo } from '@playwright/test';
  * run has the exact UI/email/DB state at the point of interest.
  */
 
-/** Attach a full-page screenshot under a descriptive step name. */
+/**
+ * Attach a full-page screenshot under a descriptive step name.
+ *
+ * Uses `animations: 'disabled'` so Playwright fast-forwards CSS transitions/animations
+ * (the form fades between steps) to their final state before capturing — otherwise a
+ * screenshot can catch a mid-animation frame before the desired result has rendered.
+ */
 export async function captureScreenshot(testInfo: TestInfo, page: Page, name: string): Promise<void> {
   await testInfo.attach(name, {
-    body: await page.screenshot({ fullPage: true }),
+    body: await page.screenshot({ fullPage: true, animations: 'disabled', caret: 'hide' }),
     contentType: 'image/png',
   });
 }

--- a/e2e/fixtures/evidence.ts
+++ b/e2e/fixtures/evidence.ts
@@ -25,6 +25,11 @@ export async function attachHtml(testInfo: TestInfo, name: string, html: string)
   await testInfo.attach(name, { body: html, contentType: 'text/html' });
 }
 
+/** Attach plain text (e.g. an .ics calendar feed) for the report. */
+export async function attachText(testInfo: TestInfo, name: string, text: string): Promise<void> {
+  await testInfo.attach(name, { body: text, contentType: 'text/plain' });
+}
+
 /** Attach an object as pretty JSON (e.g. a DB/API snapshot). */
 export async function attachJson(testInfo: TestInfo, name: string, value: unknown): Promise<void> {
   await testInfo.attach(name, {

--- a/e2e/fixtures/mailpit.ts
+++ b/e2e/fixtures/mailpit.ts
@@ -1,0 +1,58 @@
+import type { APIRequestContext } from '@playwright/test';
+import { MAILPIT_URL } from '../playwright.config';
+
+/**
+ * Minimal client for the Mailpit REST API (https://mailpit.axllent.org/docs/api-v1/).
+ * Lets specs assert on the emails the backend actually delivered during a flow.
+ */
+
+export interface MailpitMessageSummary {
+  ID: string;
+  Subject: string;
+  To: Array<{ Address: string; Name: string }>;
+  From: { Address: string; Name: string };
+}
+
+export interface MailpitMessage extends MailpitMessageSummary {
+  HTML: string;
+  Text: string;
+}
+
+/** Delete all captured messages — call in beforeEach to isolate email assertions. */
+export async function clearMailbox(request: APIRequestContext): Promise<void> {
+  await request.delete(`${MAILPIT_URL}/api/v1/messages`);
+}
+
+/** List message summaries, newest first. */
+export async function listMessages(request: APIRequestContext): Promise<MailpitMessageSummary[]> {
+  const res = await request.get(`${MAILPIT_URL}/api/v1/messages`);
+  if (!res.ok()) throw new Error(`Mailpit list failed: ${res.status()}`);
+  return (await res.json()).messages ?? [];
+}
+
+/** Fetch the full (rendered) message by id. */
+export async function getMessage(request: APIRequestContext, id: string): Promise<MailpitMessage> {
+  const res = await request.get(`${MAILPIT_URL}/api/v1/message/${id}`);
+  if (!res.ok()) throw new Error(`Mailpit get failed: ${res.status()}`);
+  return res.json();
+}
+
+/**
+ * Poll until an email addressed to `recipient` arrives, then return it fully rendered.
+ * Email delivery is async, so we retry briefly rather than asserting immediately.
+ */
+export async function waitForEmailTo(
+  request: APIRequestContext,
+  recipient: string,
+  { timeoutMs = 10_000, intervalMs = 500 }: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<MailpitMessage> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const summary = (await listMessages(request)).find(m =>
+      m.To.some(t => t.Address.toLowerCase() === recipient.toLowerCase())
+    );
+    if (summary) return getMessage(request, summary.ID);
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  throw new Error(`No email to ${recipient} arrived within ${timeoutMs}ms`);
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "devDependencies": {
         "@playwright/test": "^1.49.0",
-        "@types/node": "^22.10.0"
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -83,6 +84,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,9 +8,68 @@
       "name": "the-harry-list-e2e",
       "version": "0.0.0",
       "devDependencies": {
+        "@estruyf/github-actions-reporter": "^1.9.0",
         "@playwright/test": "^1.49.0",
         "@types/node": "^22.10.0",
         "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@estruyf/github-actions-reporter": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@estruyf/github-actions-reporter/-/github-actions-reporter-1.12.0.tgz",
+      "integrity": "sha512-330qmwv9EgpV93se59HoY1rj2XJxsjBREVpMh72BjCYKtyFru+YcFeDYUNPk2DCACNQQRilnm/yUMZZyosvhLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^3.0.0",
+        "ansi-to-html": "^0.7.2",
+        "marked": "^12.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/estruyf"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.42.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -39,6 +98,32 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/ansi-to-html": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+      "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.2.0"
+      },
+      "bin": {
+        "ansi-to-html": "bin/ansi-to-html"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -52,6 +137,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/playwright": {
@@ -86,6 +184,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -98,6 +206,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "the-harry-list-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "the-harry-list-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.10.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "the-harry-list-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "End-to-end (Playwright) tests for The Harry List — drives the public + admin apps against the e2e docker stack.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report",
+    "stack:up": "docker compose -f ../docker-compose.e2e.yml up --build -d",
+    "stack:down": "docker compose -f ../docker-compose.e2e.yml down -v"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.10.0"
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,12 +8,14 @@
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
+    "typecheck": "tsc --noEmit",
     "report": "playwright show-report",
     "stack:up": "docker compose -f ../docker-compose.e2e.yml up --build -d",
     "stack:down": "docker compose -f ../docker-compose.e2e.yml down -v"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",
-    "@types/node": "^22.10.0"
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,7 @@
     "stack:down": "docker compose -f ../docker-compose.e2e.yml down -v"
   },
   "devDependencies": {
+    "@estruyf/github-actions-reporter": "^1.9.0",
     "@playwright/test": "^1.49.0",
     "@types/node": "^22.10.0",
     "typescript": "^5.7.0"

--- a/e2e/pages/AdminSettingsPage.ts
+++ b/e2e/pages/AdminSettingsPage.ts
@@ -16,6 +16,34 @@ export class AdminSettingsPage {
     await this.page.getByRole('button', { name: /Blocked Periods/ }).click();
   }
 
+  // ---- Form constraints ----
+  constraintRows(): Locator {
+    return this.page.getByTestId('constraint-row');
+  }
+
+  /** Create a form constraint through the editor modal. */
+  async createConstraint(opts: {
+    type: string;
+    triggerActivity?: string;
+    targetValue?: string;
+    numericValue?: number;
+    message: string;
+  }): Promise<void> {
+    await this.page.getByTestId('add-constraint').click();
+    await this.page.getByTestId('constraint-type').selectOption(opts.type);
+    if (opts.triggerActivity) {
+      await this.page.getByTestId('constraint-trigger').selectOption(opts.triggerActivity);
+    }
+    if (opts.targetValue !== undefined) {
+      await this.page.getByTestId('constraint-target').fill(opts.targetValue);
+    }
+    if (opts.numericValue !== undefined) {
+      await this.page.getByTestId('constraint-numeric').fill(String(opts.numericValue));
+    }
+    await this.page.getByTestId('constraint-message').fill(opts.message);
+    await this.page.getByTestId('save-constraint').click();
+  }
+
   async openNewBlockedPeriod(): Promise<void> {
     await this.page.getByTestId('add-blocked-period').click();
     await expect(this.page.getByText('New Blocked Period')).toBeVisible();

--- a/e2e/pages/AdminSettingsPage.ts
+++ b/e2e/pages/AdminSettingsPage.ts
@@ -9,7 +9,8 @@ export class AdminSettingsPage {
 
   async goto(): Promise<void> {
     await this.page.goto('/settings');
-    await expect(this.page.getByText('Settings')).toBeVisible();
+    // Assert the page heading specifically — "Settings" also appears in the nav/sidebar.
+    await expect(this.page.getByRole('heading', { name: 'Settings' })).toBeVisible();
   }
 
   async openBlockedPeriodsTab(): Promise<void> {

--- a/e2e/pages/AdminSettingsPage.ts
+++ b/e2e/pages/AdminSettingsPage.ts
@@ -1,0 +1,73 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page object for the admin Form Settings page (constraints + blocked periods).
+ * Centralizes selectors so feature changes touch this file, not every spec.
+ */
+export class AdminSettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/settings');
+    await expect(this.page.getByText('Settings')).toBeVisible();
+  }
+
+  async openBlockedPeriodsTab(): Promise<void> {
+    await this.page.getByRole('button', { name: /Blocked Periods/ }).click();
+  }
+
+  async openNewBlockedPeriod(): Promise<void> {
+    await this.page.getByTestId('add-blocked-period').click();
+    await expect(this.page.getByText('New Blocked Period')).toBeVisible();
+  }
+
+  softBlockToggle(): Locator {
+    return this.page.getByTestId('soft-block-toggle');
+  }
+
+  ackTextInput(): Locator {
+    return this.page.getByTestId('ack-text-input');
+  }
+
+  blockedPeriodRows(): Locator {
+    return this.page.getByTestId('blocked-period-row');
+  }
+
+  softBlockBadge(): Locator {
+    return this.page.getByTestId('soft-block-badge');
+  }
+
+  async saveBlockedPeriod(): Promise<void> {
+    await this.page.getByTestId('save-blocked-period').click();
+  }
+
+  /**
+   * Fill and save a new blocked period from the editor modal. The modal's date/reason
+   * fields have no test ids yet, so they're located by type/placeholder within the modal.
+   */
+  async createBlockedPeriod(opts: {
+    startDate: string;
+    endDate: string;
+    reason: string;
+    publicMessage?: string;
+    soft?: boolean;
+    acknowledgementText?: string;
+  }): Promise<void> {
+    await this.openNewBlockedPeriod();
+
+    const dates = this.page.locator('input[type="date"]');
+    await dates.nth(0).fill(opts.startDate);
+    await dates.nth(1).fill(opts.endDate);
+    await this.page.getByPlaceholder('e.g. Holiday closure, Maintenance').fill(opts.reason);
+    if (opts.publicMessage) {
+      await this.page.getByPlaceholder('e.g. Closed for maintenance').fill(opts.publicMessage);
+    }
+    if (opts.soft) {
+      await this.softBlockToggle().click();
+      if (opts.acknowledgementText) {
+        await this.ackTextInput().fill(opts.acknowledgementText);
+      }
+    }
+    await this.saveBlockedPeriod();
+  }
+}

--- a/e2e/pages/ReservationFormPage.ts
+++ b/e2e/pages/ReservationFormPage.ts
@@ -1,0 +1,139 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export interface ContactInfo {
+  name: string;
+  email: string;
+}
+
+export interface ActivityInfo {
+  title: string;
+  description?: string;
+  date: string; // yyyy-mm-dd
+  startTime?: string; // HH:mm
+  endTime?: string; // HH:mm
+  guests?: number;
+}
+
+export type Location = 'HUBBLE' | 'METEOR' | 'NO_PREFERENCE';
+export type Seating = 'INSIDE' | 'OUTSIDE';
+
+/**
+ * Page object for the public multi-step reservation form.
+ *
+ * Selectors are centralized here: when the form's markup changes, update this file
+ * (and the data-testid hooks in ReservationForm.tsx) — not every spec.
+ */
+export class ReservationFormPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/');
+    await expect(this.page.getByText('Contact Information')).toBeVisible();
+  }
+
+  continueButton(): Locator {
+    return this.page.getByRole('button', { name: 'Continue' });
+  }
+
+  async continue(): Promise<void> {
+    await this.continueButton().click();
+  }
+
+  async expectStep(heading: string): Promise<void> {
+    await expect(this.page.getByText(heading)).toBeVisible();
+  }
+
+  // ---- Step 1: Contact ----
+  async fillContact({ name, email }: ContactInfo): Promise<void> {
+    await this.page.getByTestId('contact-name').fill(name);
+    await this.page.getByTestId('contact-email').fill(email);
+  }
+
+  // ---- Step 2: Activity ----
+  async fillActivity({
+    title,
+    description = 'E2E test event',
+    date,
+    startTime = '14:00',
+    endTime = '16:00',
+    guests,
+  }: ActivityInfo): Promise<void> {
+    await this.page.getByTestId('event-title').fill(title);
+    await this.page.getByPlaceholder('Tell us more about your event...').fill(description);
+    await this.page.getByTestId('event-date').fill(date);
+    await this.page.getByTestId('start-time').selectOption(startTime);
+    await this.page.getByTestId('end-time').selectOption(endTime);
+    if (guests !== undefined) {
+      await this.page.getByTestId('expected-guests').fill(String(guests));
+    }
+  }
+
+  /** Toggle a special activity by its visible label (e.g. "Catering"). */
+  async toggleActivity(label: string): Promise<void> {
+    await this.page.getByText(label, { exact: true }).click();
+  }
+
+  // ---- Blocked-period notice (soft or hard) ----
+  blockedNotice(): Locator {
+    return this.page.getByTestId('blocked-date-notice');
+  }
+
+  softAckCheckbox(): Locator {
+    return this.page.getByTestId('soft-block-ack');
+  }
+
+  softAckError(): Locator {
+    return this.page.getByTestId('soft-block-ack-error');
+  }
+
+  async acknowledgeSoftBlock(): Promise<void> {
+    await this.softAckCheckbox().check();
+  }
+
+  // ---- Step 3: Location & seating (radios are visually hidden -> force) ----
+  async selectLocation(location: Location): Promise<void> {
+    await this.page.getByTestId(`location-${location}`).check({ force: true });
+  }
+
+  async selectSeating(seating: Seating): Promise<void> {
+    await this.page.getByTestId(`seating-${seating}`).check({ force: true });
+  }
+
+  // ---- Step 4: Payment ----
+  async selectPayment(label: string): Promise<void> {
+    await this.page.getByText(label, { exact: true }).click();
+  }
+
+  // ---- Step 5: Confirm ----
+  async acceptTerms(): Promise<void> {
+    await this.page.getByTestId('terms-accepted').check();
+  }
+
+  async submit(): Promise<void> {
+    await this.page.getByTestId('submit-reservation').click();
+  }
+
+  /**
+   * Drive every step of a clean booking (no blocks/constraints in the way).
+   * Leaves the form on the confirmation result.
+   */
+  async completeBooking(opts: {
+    contact: ContactInfo;
+    activity: ActivityInfo;
+    location?: Location;
+    seating?: Seating;
+    payment?: string;
+  }): Promise<void> {
+    await this.fillContact(opts.contact);
+    await this.continue();
+    await this.fillActivity(opts.activity);
+    await this.continue();
+    await this.selectLocation(opts.location ?? 'NO_PREFERENCE');
+    await this.selectSeating(opts.seating ?? 'INSIDE');
+    await this.continue();
+    await this.selectPayment(opts.payment ?? 'People pay individually');
+    await this.continue();
+    await this.acceptTerms();
+    await this.submit();
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
     ? [['github'], ['html', { open: 'never' }], ['list']]
     : [['html', { open: 'never' }], ['list']],
   use: {
-    trace: 'on-first-retry',
+    // Capture a full, replayable trace for every run (pass or fail) so each spec
+    // is self-documenting in the HTML report. Specs also attach curated
+    // screenshots + email/DB snapshots at key moments (see fixtures/evidence.ts).
+    trace: 'on',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -35,12 +35,30 @@ export default defineConfig({
    */
   webServer: process.env.E2E_NO_WEBSERVER
     ? undefined
-    : {
-        command: 'docker compose -f ../docker-compose.e2e.yml up --build',
-        url: `${BACKEND_URL}/actuator/health`,
-        reuseExistingServer: !process.env.CI,
-        timeout: 240_000,
-      },
+    : [
+        {
+          // Boots the whole stack. Backend health gates that the API is ready.
+          command: 'docker compose -f ../docker-compose.e2e.yml up --build',
+          url: `${BACKEND_URL}/actuator/health`,
+          reuseExistingServer: !process.env.CI,
+          timeout: 240_000,
+        },
+        {
+          // Wait for the public frontend nginx to actually serve before testing
+          // (it comes up after the backend, so gating only on the API races).
+          command: 'node -e "setInterval(() => {}, 1 << 30)"',
+          url: PUBLIC_BASE_URL,
+          reuseExistingServer: true,
+          timeout: 240_000,
+        },
+        {
+          // Likewise for the admin frontend.
+          command: 'node -e "setInterval(() => {}, 1 << 30)"',
+          url: ADMIN_BASE_URL,
+          reuseExistingServer: true,
+          timeout: 240_000,
+        },
+      ],
 
   projects: [
     {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,59 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Service URLs. Defaults match docker-compose.e2e.yml's published ports, but can be
+ * overridden (e.g. when pointing the suite at an already-running stack or staging).
+ */
+export const PUBLIC_BASE_URL = process.env.PUBLIC_BASE_URL ?? 'http://localhost:5173';
+export const ADMIN_BASE_URL = process.env.ADMIN_BASE_URL ?? 'http://localhost:5174';
+export const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080';
+export const MAILPIT_URL = process.env.MAILPIT_URL ?? 'http://localhost:8025';
+
+export default defineConfig({
+  testDir: './tests',
+  // The suite shares one backend + database, so tests run serially for isolation.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }], ['list']]
+    : [['html', { open: 'never' }], ['list']],
+  use: {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  /**
+   * Boot the full e2e stack (MariaDB + backend[e2e] + Mailpit + frontends) before the run.
+   * Set E2E_NO_WEBSERVER=1 to skip this when the stack is already running locally
+   * (e.g. `npm run stack:up` in another terminal) for faster iteration.
+   */
+  webServer: process.env.E2E_NO_WEBSERVER
+    ? undefined
+    : {
+        command: 'docker compose -f ../docker-compose.e2e.yml up --build',
+        url: `${BACKEND_URL}/actuator/health`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 240_000,
+      },
+
+  projects: [
+    {
+      name: 'public',
+      testDir: './tests/public',
+      use: { ...devices['Desktop Chrome'], baseURL: PUBLIC_BASE_URL },
+    },
+    {
+      name: 'admin',
+      testDir: './tests/admin',
+      use: { ...devices['Desktop Chrome'], baseURL: ADMIN_BASE_URL },
+    },
+    {
+      name: 'mobile-public',
+      testDir: './tests/mobile-public',
+      use: { ...devices['iPhone 13'], baseURL: PUBLIC_BASE_URL },
+    },
+  ],
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,6 +9,9 @@ export const ADMIN_BASE_URL = process.env.ADMIN_BASE_URL ?? 'http://localhost:51
 export const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080';
 export const MAILPIT_URL = process.env.MAILPIT_URL ?? 'http://localhost:8025';
 
+// CI builds all images from scratch, so allow plenty of time for the stack to come up.
+const WEBSERVER_TIMEOUT = process.env.CI ? 600_000 : 240_000;
+
 export default defineConfig({
   testDir: './tests',
   // The suite shares one backend + database, so tests run serially for isolation.
@@ -41,7 +44,7 @@ export default defineConfig({
           command: 'docker compose -f ../docker-compose.e2e.yml up --build',
           url: `${BACKEND_URL}/actuator/health`,
           reuseExistingServer: !process.env.CI,
-          timeout: 240_000,
+          timeout: WEBSERVER_TIMEOUT,
         },
         {
           // Wait for the public frontend nginx to actually serve before testing
@@ -49,14 +52,14 @@ export default defineConfig({
           command: 'node -e "setInterval(() => {}, 1 << 30)"',
           url: PUBLIC_BASE_URL,
           reuseExistingServer: true,
-          timeout: 240_000,
+          timeout: WEBSERVER_TIMEOUT,
         },
         {
           // Likewise for the admin frontend.
           command: 'node -e "setInterval(() => {}, 1 << 30)"',
           url: ADMIN_BASE_URL,
           reuseExistingServer: true,
-          timeout: 240_000,
+          timeout: WEBSERVER_TIMEOUT,
         },
       ],
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -75,9 +75,11 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], baseURL: ADMIN_BASE_URL },
     },
     {
+      // Pixel 5 is a Chromium-based mobile device, so the suite only needs the
+      // chromium browser (iPhone devices would require WebKit).
       name: 'mobile-public',
       testDir: './tests/mobile-public',
-      use: { ...devices['iPhone 13'], baseURL: PUBLIC_BASE_URL },
+      use: { ...devices['Pixel 5'], baseURL: PUBLIC_BASE_URL },
     },
   ],
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,7 +20,15 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI
-    ? [['github'], ['html', { open: 'never' }], ['list']]
+    ? [
+        // Inline annotations on failing lines.
+        ['github'],
+        // A readable per-test summary table on the GitHub Actions run page
+        // (no need to download the HTML report just to see what passed/failed).
+        ['@estruyf/github-actions-reporter', { title: 'Playwright E2E results', useDetails: true, showError: true }],
+        ['html', { open: 'never' }],
+        ['list'],
+      ]
     : [['html', { open: 'never' }], ['list']],
   use: {
     // Capture a full, replayable trace for every run (pass or fail) so each spec

--- a/e2e/tests/admin/audit-log.spec.ts
+++ b/e2e/tests/admin/audit-log.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend, seedUser, adminAuthHeaders } from '../../fixtures/backend';
+import { attachJson } from '../../fixtures/evidence';
+import { BACKEND_URL } from '../../playwright.config';
+
+/**
+ * Audit log (backward-compatibility feature): an admin mutation is recorded in the audit
+ * log. We create a blocked period, then read the audit log and assert the entry is there.
+ */
+test.describe('admin: actions are recorded in the audit log', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', role: 'ADMIN' });
+  });
+
+  test('creating a blocked period produces an audit entry', async ({ request }, testInfo) => {
+    const create = await request.post(`${BACKEND_URL}/api/admin/blocked-periods`, {
+      headers: adminAuthHeaders('e2e-admin'),
+      data: {
+        startDate: '2031-03-01',
+        endDate: '2031-03-02',
+        reason: 'Audited closure',
+        softBlock: false,
+        enabled: true,
+      },
+    });
+    expect(create.status()).toBe(201);
+
+    const audit = await request.get(`${BACKEND_URL}/api/admin/audit`, {
+      headers: adminAuthHeaders('e2e-admin'),
+    });
+    expect(audit.ok()).toBeTruthy();
+
+    const body = await audit.text();
+    await attachJson(testInfo, 'audit-response.json', JSON.parse(body));
+    // The audit entry references the blocked-period entity type.
+    expect(body).toContain('BLOCKED_PERIOD');
+  });
+});

--- a/e2e/tests/admin/blocked-periods.spec.ts
+++ b/e2e/tests/admin/blocked-periods.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { AdminSettingsPage } from '../../pages/AdminSettingsPage';
+import { resetBackend, seedUser } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Admin can configure a soft block through the real UI (#254). The admin app authenticates
+ * via the e2e header bridge as the seeded "e2e-admin" user.
+ */
+test.describe('admin: manage blocked periods', () => {
+  test.beforeEach(async ({ request }) => {
+    // The admin SPA sends X-Test-Oid=e2e-admin (docker-compose.e2e.yml); give it a role.
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', email: 'admin@e2e.test', role: 'ADMIN' });
+  });
+
+  test('creates a soft block and shows the "Soft block" badge', async ({ page }, testInfo) => {
+    const settings = new AdminSettingsPage(page);
+    await settings.goto();
+    await settings.openBlockedPeriodsTab();
+
+    await settings.createBlockedPeriod({
+      startDate: '2030-07-01',
+      endDate: '2030-08-31',
+      reason: 'Summer closing',
+      publicMessage: 'Open on request only',
+      soft: true,
+      acknowledgementText: 'I understand the bar may be closed',
+    });
+
+    await expect(settings.blockedPeriodRows()).toHaveCount(1);
+    await expect(settings.softBlockBadge()).toBeVisible();
+    await captureScreenshot(testInfo, page, '1-soft-block-created');
+  });
+});

--- a/e2e/tests/admin/catering-export.spec.ts
+++ b/e2e/tests/admin/catering-export.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { statSync } from 'node:fs';
+import { resetBackend, seedUser, seedReservation } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Catering-only export (#280): the export page can produce a catering-only daily PDF.
+ * Verifies the UI toggle -> endpoint -> PDF download path end-to-end (the filtering logic
+ * itself is unit-tested in PdfExportServiceTest). A catering reservation is seeded so the
+ * report has content.
+ */
+test.describe('admin: catering-only PDF export', () => {
+  const DATE = '2030-12-12';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', role: 'ADMIN' });
+    await seedReservation(request, {
+      contactName: 'Catering Guest',
+      email: 'catering@example.com',
+      eventTitle: 'Catered lunch',
+      description: 'Food',
+      eventDate: DATE,
+      startTime: '12:00',
+      endTime: '14:00',
+      expectedGuests: 30,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INVOICE',
+      status: 'CONFIRMED',
+      specialActivities: ['EAT_CATERING'],
+    });
+  });
+
+  test('downloads a catering-only PDF for the day', async ({ page }, testInfo) => {
+    await page.goto('/export');
+    await page.getByTestId('export-date').fill(DATE);
+    // Location defaults to HUBBLE, matching the seeded reservation.
+    await page.getByTestId('export-catering-only').check();
+    await captureScreenshot(testInfo, page, '1-export-options');
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByTestId('export-submit').click(),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+    const path = await download.path();
+    expect(statSync(path).size).toBeGreaterThan(0);
+    await testInfo.attach('catering-daily-report.pdf', { path, contentType: 'application/pdf' });
+  });
+});

--- a/e2e/tests/admin/constraints-roundtrip.spec.ts
+++ b/e2e/tests/admin/constraints-roundtrip.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { AdminSettingsPage } from '../../pages/AdminSettingsPage';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedUser } from '../../fixtures/backend';
+import { PUBLIC_BASE_URL } from '../../playwright.config';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Round-trip: a constraint created through the admin UI is actually enforced on the public
+ * form. Proves the admin editor -> persistence -> public form path is wired end-to-end.
+ */
+test.describe('admin: a constraint created in the UI is enforced on the public form', () => {
+  const MESSAGE = 'E2E round-trip: à la carte is limited to 15 guests.';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', role: 'ADMIN' });
+  });
+
+  test('a guest-limit constraint blocks an over-limit public booking', async ({ page }, testInfo) => {
+    // Create it via the admin UI (constraints tab is the default on Settings).
+    const settings = new AdminSettingsPage(page);
+    await settings.goto();
+    await settings.createConstraint({
+      type: 'GUEST_LIMIT',
+      triggerActivity: 'EAT_A_LA_CARTE',
+      numericValue: 15,
+      message: MESSAGE,
+    });
+    await expect(settings.constraintRows().filter({ hasText: 'à la carte is limited' })).toHaveCount(1);
+    await captureScreenshot(testInfo, page, '1-constraint-created-admin');
+
+    // Now verify the public form enforces it.
+    await page.goto(PUBLIC_BASE_URL);
+    const form = new ReservationFormPage(page);
+    await expect(page.getByText('Contact Information')).toBeVisible();
+    await form.fillContact({ name: 'Jane Smith', email: 'jane@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+    await form.fillActivity({ title: 'Big dinner', date: '2030-09-10', guests: 20 });
+    await form.toggleActivity('Eat a la carte');
+
+    await expect(page.getByText(MESSAGE)).toBeVisible();
+    await captureScreenshot(testInfo, page, '2-constraint-enforced-public');
+
+    await form.continue();
+    await form.expectStep('Activity Details'); // blocked by the constraint
+  });
+});

--- a/e2e/tests/admin/email-template.spec.ts
+++ b/e2e/tests/admin/email-template.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend, seedUser, seedReservation, adminAuthHeaders } from '../../fixtures/backend';
+import { clearMailbox, waitForEmailTo } from '../../fixtures/mailpit';
+import { attachHtml } from '../../fixtures/evidence';
+import { BACKEND_URL } from '../../playwright.config';
+
+/**
+ * Editable email templates (backward-compatibility feature): a template edited by an admin
+ * is actually used when an email is sent. We edit the STATUS_CHANGED template to include a
+ * unique marker, trigger a status-change email, and assert the marker arrives.
+ */
+test.describe('admin: edited email template is used when sending', () => {
+  const MARKER = 'E2E-TEMPLATE-MARKER-7f3a';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', role: 'ADMIN' });
+  });
+
+  test('a customized template body appears in the delivered email', async ({ request }, testInfo) => {
+    // Admin edits the status-change template.
+    const put = await request.put(`${BACKEND_URL}/api/admin/email-templates/STATUS_CHANGED`, {
+      headers: adminAuthHeaders('e2e-admin'),
+      data: {
+        subject: 'Your reservation for {{eventTitle}}',
+        bodyTemplate: `<p>${MARKER} — {{eventTitle}}</p>{{customMessage}}`,
+      },
+    });
+    expect(put.ok()).toBeTruthy();
+
+    const reservation = await seedReservation(request, {
+      contactName: 'Guest Two',
+      email: 'guest.two@example.com',
+      eventTitle: 'Anniversary',
+      description: 'Dinner',
+      eventDate: '2030-11-05',
+      startTime: '19:00',
+      endTime: '23:00',
+      expectedGuests: 8,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INDIVIDUAL',
+    });
+    await clearMailbox(request);
+
+    const res = await request.patch(
+      `${BACKEND_URL}/api/admin/reservations/${reservation.id}/status`,
+      {
+        headers: adminAuthHeaders('e2e-admin'),
+        params: { status: 'CONFIRMED', customMessage: 'See you soon', sendEmail: 'true' },
+      }
+    );
+    expect(res.ok()).toBeTruthy();
+
+    const email = await waitForEmailTo(request, 'guest.two@example.com');
+    await attachHtml(testInfo, 'templated-email.html', email.HTML);
+    expect(email.HTML).toContain(MARKER);
+    expect(email.HTML).toContain('Anniversary');
+  });
+});

--- a/e2e/tests/admin/rbac.spec.ts
+++ b/e2e/tests/admin/rbac.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend, seedUser, adminAuthHeaders } from '../../fixtures/backend';
+import { BACKEND_URL } from '../../playwright.config';
+import { attachJson } from '../../fixtures/evidence';
+
+/**
+ * RBAC is ultimately enforced by the backend (@PreAuthorize), so we assert it there:
+ * a VIEWER may read but not mutate, an EDITOR may mutate. This guards the real security
+ * boundary regardless of any UI button-hiding.
+ */
+test.describe('admin: RBAC is enforced by the backend', () => {
+  const newPeriod = {
+    startDate: '2031-01-01',
+    endDate: '2031-01-02',
+    reason: 'rbac probe',
+    softBlock: false,
+    enabled: true,
+  };
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-viewer', role: 'VIEWER' });
+    await seedUser(request, { oid: 'e2e-editor', role: 'EDITOR' });
+  });
+
+  test('a VIEWER can read but not mutate; an EDITOR can mutate', async ({ request }, testInfo) => {
+    const viewerRead = await request.get(`${BACKEND_URL}/api/admin/blocked-periods`, {
+      headers: adminAuthHeaders('e2e-viewer'),
+    });
+    const viewerWrite = await request.post(`${BACKEND_URL}/api/admin/blocked-periods`, {
+      headers: adminAuthHeaders('e2e-viewer'),
+      data: newPeriod,
+    });
+    const editorWrite = await request.post(`${BACKEND_URL}/api/admin/blocked-periods`, {
+      headers: adminAuthHeaders('e2e-editor'),
+      data: newPeriod,
+    });
+
+    const editorWriteBody = await editorWrite.text();
+    await attachJson(testInfo, 'rbac-results.json', {
+      viewerRead: viewerRead.status(),
+      viewerWrite: viewerWrite.status(),
+      editorWrite: editorWrite.status(),
+      editorWriteBody,
+    });
+
+    expect(viewerRead.status()).toBe(200); // reads are allowed
+    expect(viewerWrite.status()).toBe(403); // viewers cannot mutate
+    expect(editorWrite.status(), `editor create response: ${editorWriteBody}`).toBe(201); // editors can
+  });
+});

--- a/e2e/tests/admin/reservation-lifecycle.spec.ts
+++ b/e2e/tests/admin/reservation-lifecycle.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedUser, seedReservation } from '../../fixtures/backend';
+import { clearMailbox, waitForEmailTo } from '../../fixtures/mailpit';
+import { captureScreenshot, attachHtml } from '../../fixtures/evidence';
+import { PUBLIC_BASE_URL } from '../../playwright.config';
+
+/**
+ * Full reservation lifecycle through the real admin UI:
+ *   submit (public) -> appears in admin list -> confirm -> edit -> remove.
+ * Split into two tests so each is a focused, readable journey.
+ */
+test.describe('admin: reservation lifecycle', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    // The admin SPA authenticates as e2e-admin (docker-compose.e2e.yml).
+    await seedUser(request, { oid: 'e2e-admin', email: 'admin@e2e.test', role: 'ADMIN' });
+  });
+
+  test('a public submission appears in the admin list and can be confirmed', async ({ page, request }, testInfo) => {
+    const title = `Lifecycle Booking ${Date.now()}`;
+    const guestEmail = 'lifecycle.guest@example.com';
+
+    // 1) Guest submits via the public form (a concrete location so it can be confirmed).
+    await page.goto(PUBLIC_BASE_URL);
+    const form = new ReservationFormPage(page);
+    await expect(page.getByText('Contact Information')).toBeVisible();
+    await form.completeBooking({
+      contact: { name: 'Lifecycle Guest', email: guestEmail },
+      activity: { title, date: '2030-11-20' },
+      location: 'HUBBLE',
+      seating: 'INSIDE',
+      payment: 'People pay individually',
+    });
+    await expect(page.getByText('Reservation Submitted!')).toBeVisible();
+    await clearMailbox(request); // isolate the confirmation email from the submission emails
+
+    // 2) It shows up in the admin reservations list as PENDING.
+    await page.goto('/reservations');
+    await page.getByPlaceholder(/Search by name/).fill(title);
+    const row = page.getByTestId('reservation-row').filter({ hasText: title });
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText('PENDING');
+    await captureScreenshot(testInfo, page, '1-appears-in-admin-list');
+
+    // 3) Open it and confirm via the UI.
+    await row.click();
+    await expect(page.getByTestId('reservation-status')).toContainText('PENDING');
+    await page.getByTestId('confirm-reservation').click();
+    await page.getByTestId('confirm-dialog-submit').click();
+    await expect(page.getByTestId('reservation-status')).toContainText('CONFIRMED');
+    await captureScreenshot(testInfo, page, '2-confirmed-in-admin');
+
+    // 4) The guest receives the confirmation email.
+    const mail = await waitForEmailTo(request, guestEmail);
+    await attachHtml(testInfo, 'confirmation-email.html', mail.HTML);
+  });
+
+  test('an editor can edit and then remove a reservation', async ({ page, request }, testInfo) => {
+    await seedReservation(request, {
+      contactName: 'Edit Guest',
+      email: 'edit.guest@example.com',
+      eventTitle: 'Editable Booking',
+      description: 'To be edited and removed',
+      eventDate: '2030-11-21',
+      startTime: '14:00',
+      endTime: '16:00',
+      expectedGuests: 10,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INDIVIDUAL',
+      status: 'PENDING',
+    });
+
+    // Open it from the list (so the admin SPA is fully booted with the role loaded,
+    // rather than deep-linking into the detail page before the role resolves).
+    await page.goto('/reservations');
+    await page.getByPlaceholder(/Search by name/).fill('Editable Booking');
+    const row = page.getByTestId('reservation-row').filter({ hasText: 'Editable Booking' });
+    await expect(row).toHaveCount(1);
+    await row.click();
+    await expect(page.getByTestId('reservation-status')).toContainText('PENDING');
+
+    // Edit the guest count.
+    await page.getByTestId('edit-reservation').click();
+    await page.getByTestId('edit-guests').fill('137');
+    await page.getByTestId('edit-save').click();
+    await expect(page.getByTestId('edit-save')).toHaveCount(0); // edit mode closed
+    // The new guest count shows in the details (it also appears in the history timeline,
+    // hence .first()).
+    await expect(page.getByText('137').first()).toBeVisible();
+    await captureScreenshot(testInfo, page, '1-edited-guests');
+
+    // Remove it: reject (PENDING -> REJECTED), then delete.
+    await page.getByTestId('reject-reservation').click();
+    await page.getByTestId('reject-dialog-submit').click();
+    await expect(page.getByTestId('reservation-status')).toContainText('REJECTED');
+    await page.getByTestId('remove-reservation').click();
+    await page.getByTestId('delete-dialog-submit').click();
+
+    // Back on the list and the reservation is gone.
+    await expect(page).toHaveURL(/\/reservations$/);
+    await expect(page.getByTestId('reservation-row').filter({ hasText: 'Editable Booking' })).toHaveCount(0);
+    await captureScreenshot(testInfo, page, '2-removed');
+  });
+});

--- a/e2e/tests/admin/status-email.spec.ts
+++ b/e2e/tests/admin/status-email.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend, seedUser, seedReservation, adminAuthHeaders } from '../../fixtures/backend';
+import { clearMailbox, waitForEmailTo } from '../../fixtures/mailpit';
+import { attachHtml } from '../../fixtures/evidence';
+import { BACKEND_URL } from '../../playwright.config';
+
+/**
+ * Status-change email with a custom staff message (#279), end-to-end: a real status change
+ * triggers a real email (SMTP -> Mailpit) whose body contains the custom message.
+ */
+test.describe('admin: status-change email with custom message', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', role: 'ADMIN' });
+  });
+
+  test('confirming a reservation emails the guest including the custom message', async ({ request }, testInfo) => {
+    const reservation = await seedReservation(request, {
+      contactName: 'Guest One',
+      email: 'guest.one@example.com',
+      eventTitle: 'Birthday',
+      description: 'A party',
+      eventDate: '2030-10-01',
+      startTime: '18:00',
+      endTime: '22:00',
+      expectedGuests: 12,
+      location: 'HUBBLE', // a concrete location is required before a reservation can be confirmed
+      seatingArea: 'INSIDE',
+      paymentOption: 'INDIVIDUAL',
+    });
+    await clearMailbox(request);
+
+    const customMessage = 'Looking forward to hosting you — please arrive 15 minutes early.';
+    const res = await request.patch(
+      `${BACKEND_URL}/api/admin/reservations/${reservation.id}/status`,
+      {
+        headers: adminAuthHeaders('e2e-admin'),
+        params: { status: 'CONFIRMED', customMessage, sendEmail: 'true' },
+      }
+    );
+    if (!res.ok()) {
+      await attachHtml(testInfo, 'status-change-error.txt', `${res.status()}\n${await res.text()}`);
+    }
+    expect(res.ok()).toBeTruthy();
+
+    const email = await waitForEmailTo(request, 'guest.one@example.com');
+    await attachHtml(testInfo, 'status-change-email.html', email.HTML);
+    expect(email.HTML).toContain(customMessage);
+  });
+});

--- a/e2e/tests/admin/week-overview.spec.ts
+++ b/e2e/tests/admin/week-overview.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend, seedUser, seedReservation } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Week overview: a reservation shows up in the correct week. We pin the displayed week via
+ * the ?week= URL param so the test isn't coupled to "today".
+ */
+test.describe('admin: week overview shows reservations', () => {
+  const EVENT_DATE = '2030-10-16'; // a fixed date; ?week= will resolve its Monday
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', role: 'ADMIN' });
+    await seedReservation(request, {
+      contactName: 'Week Guest',
+      email: 'week@example.com',
+      eventTitle: 'Week Overview Event',
+      description: 'Shows in the week grid',
+      eventDate: EVENT_DATE,
+      startTime: '14:00',
+      endTime: '16:00',
+      expectedGuests: 15,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INDIVIDUAL',
+      status: 'CONFIRMED',
+    });
+  });
+
+  test('a reservation appears in its week', async ({ page }, testInfo) => {
+    await page.goto(`/week-overview?week=${EVENT_DATE}`);
+    await expect(page.getByText('Week Overview')).toBeVisible();
+
+    const card = page.getByTestId('week-reservation').filter({ hasText: 'Week Overview Event' });
+    await expect(card).toHaveCount(1);
+    await expect(card).toContainText('CONFIRMED');
+    await captureScreenshot(testInfo, page, '1-week-overview-event');
+  });
+});

--- a/e2e/tests/admin/week-overview.spec.ts
+++ b/e2e/tests/admin/week-overview.spec.ts
@@ -30,7 +30,7 @@ test.describe('admin: week overview shows reservations', () => {
 
   test('a reservation appears in its week', async ({ page }, testInfo) => {
     await page.goto(`/week-overview?week=${EVENT_DATE}`);
-    await expect(page.getByText('Week Overview')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Week Overview' })).toBeVisible();
 
     const card = page.getByTestId('week-reservation').filter({ hasText: 'Week Overview Event' });
     await expect(card).toHaveCount(1);

--- a/e2e/tests/mobile-public/datetime.spec.ts
+++ b/e2e/tests/mobile-public/datetime.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Mobile date/time fields (#253): on a phone viewport the date and time controls must
+ * render and be usable (the bug was them overlapping / not loading). Runs under the
+ * mobile-public project (iPhone 13).
+ */
+test.describe('mobile: date & time fields', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+  });
+
+  test('date and time fields render and accept input on mobile', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+    await form.fillContact({ name: 'Mobile User', email: 'mobile@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+
+    const date = page.getByTestId('event-date');
+    const start = page.getByTestId('start-time');
+    const end = page.getByTestId('end-time');
+
+    // Visible and enabled (not hidden/overlapping/disabled).
+    await expect(date).toBeVisible();
+    await expect(start).toBeVisible();
+    await expect(end).toBeVisible();
+    await expect(date).toBeEnabled();
+
+    // And actually accept input.
+    await form.fillActivity({ title: 'Mobile booking', date: '2030-09-10', startTime: '14:00', endTime: '16:00' });
+    await expect(date).toHaveValue('2030-09-10');
+    await expect(start).toHaveValue('14:00');
+    await expect(end).toHaveValue('16:00');
+    await captureScreenshot(testInfo, page, '1-mobile-datetime-filled');
+  });
+});

--- a/e2e/tests/public/booking-options.spec.ts
+++ b/e2e/tests/public/booking-options.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend } from '../../fixtures/backend';
+import { clearMailbox, waitForEmailTo } from '../../fixtures/mailpit';
+import { captureScreenshot, attachHtml } from '../../fixtures/evidence';
+
+/**
+ * A second accepted booking exercising more of the options than the basic happy path:
+ * organization + phone, a special activity, a concrete location (Hubble), outside seating,
+ * and invoice payment with an invoice type + cost centre.
+ */
+test.describe('public: booking with many options', () => {
+  const CONTACT = { name: 'Org Booker', email: 'org.booker@example.com' };
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await clearMailbox(request);
+  });
+
+  test('accepts a Hubble + special activity + invoice booking', async ({ page, request }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+
+    // Step 1 — contact, with organization + phone.
+    await form.fillContact(CONTACT);
+    await page.locator('input[name="phoneNumber"]').fill('+31 6 12345678');
+    await page.locator('input[name="organizationName"]').fill('Study Association E2E');
+    await form.continue();
+
+    // Step 2 — activity + a special activity.
+    await form.expectStep('Activity Details');
+    await form.fillActivity({ title: 'Graduation drinks', date: '2030-09-18', guests: 40 });
+    await form.toggleActivity('Graduation / PhD Defense');
+    await form.continue();
+
+    // Step 3 — Hubble, outside.
+    await form.expectStep('Where would you like to host your event?');
+    await form.selectLocation('HUBBLE');
+    await form.selectSeating('OUTSIDE');
+    await form.continue();
+
+    // Step 4 — invoice payment with type + cost centre.
+    await form.expectStep('Payment Information');
+    await form.selectPayment('Invoice (>50 euros only)');
+    await page.locator('select[name="invoiceType"]').selectOption('TUE');
+    await page.locator('input[name="costCenter"]').fill('CC-12345');
+    await captureScreenshot(testInfo, page, '1-invoice-payment');
+    await form.continue();
+
+    // Step 5 — confirm.
+    await form.acceptTerms();
+    await form.submit();
+
+    await expect(page.getByText('Reservation Submitted!')).toBeVisible();
+    await captureScreenshot(testInfo, page, '2-confirmation');
+
+    const email = await waitForEmailTo(request, CONTACT.email);
+    await attachHtml(testInfo, 'confirmation-email.html', email.HTML);
+    expect(email.HTML).toContain('Graduation drinks');
+  });
+});

--- a/e2e/tests/public/calendar-feed.spec.ts
+++ b/e2e/tests/public/calendar-feed.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend, seedReservation } from '../../fixtures/backend';
+import { attachText } from '../../fixtures/evidence';
+import { BACKEND_URL } from '../../playwright.config';
+
+/**
+ * Calendar feed (iCal): the token-protected feed serves reservations as an .ics calendar.
+ * The token is configured in docker-compose.e2e.yml (CALENDAR_FEED_TOKEN).
+ */
+const FEED_TOKEN = 'e2e-feed-token';
+
+test.describe('calendar feed (iCal)', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedReservation(request, {
+      contactName: 'Feed Guest',
+      email: 'feed@example.com',
+      eventTitle: 'Calendar Feed Event',
+      description: 'In the feed',
+      eventDate: '2030-10-20',
+      startTime: '15:00',
+      endTime: '17:00',
+      expectedGuests: 10,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INDIVIDUAL',
+      status: 'CONFIRMED',
+    });
+  });
+
+  test('rejects a missing token and serves events with a valid one', async ({ request }, testInfo) => {
+    // Missing token is rejected.
+    const noToken = await request.get(`${BACKEND_URL}/api/calendar/feed.ics`);
+    expect(noToken.status()).toBe(401);
+
+    // Valid token returns a calendar containing the reservation.
+    const ok = await request.get(`${BACKEND_URL}/api/calendar/feed.ics?token=${FEED_TOKEN}`);
+    expect(ok.status()).toBe(200);
+    expect(ok.headers()['content-type']).toContain('text/calendar');
+
+    const ics = await ok.text();
+    await attachText(testInfo, 'feed.ics', ics);
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('BEGIN:VEVENT');
+    expect(ics).toContain('Calendar Feed Event');
+  });
+});

--- a/e2e/tests/public/constraints-blocking.spec.ts
+++ b/e2e/tests/public/constraints-blocking.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedConstraint } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Proves form constraints are still wired end-to-end (public form -> backend). The full
+ * permutation matrix lives in ConstraintValidationServiceTest; here we assert one
+ * representative constraint actually blocks a submission with its configured message.
+ */
+test.describe('public: form constraints are enforced', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedConstraint(request, {
+      constraintType: 'GUEST_LIMIT',
+      triggerActivity: 'EAT_A_LA_CARTE',
+      numericValue: 15,
+      message: 'A la carte dining is limited to 15 guests.',
+    });
+  });
+
+  test('a guest-limit constraint blocks advancing and shows its message', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+
+    await form.fillContact({ name: 'Jane Smith', email: 'jane@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+
+    await form.fillActivity({ title: 'Big dinner', date: '2030-09-10', guests: 20 });
+    await form.toggleActivity('Eat a la carte');
+
+    // The constraint message is shown...
+    await expect(page.getByText('A la carte dining is limited to 15 guests.')).toBeVisible();
+    await captureScreenshot(testInfo, page, '1-constraint-warning');
+
+    // ...and the form refuses to advance.
+    await form.continue();
+    await form.expectStep('Activity Details');
+  });
+});

--- a/e2e/tests/public/constraints-dynamic.spec.ts
+++ b/e2e/tests/public/constraints-dynamic.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedConstraint } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Dynamic constraint behaviour on the form: an ACTIVITY_CONFLICT makes the conflicting
+ * activity un-selectable once its counterpart is chosen. Representative of the form
+ * reacting live to configured constraints (full matrix is unit-tested server-side).
+ */
+test.describe('public: activity-conflict constraint disables the conflicting option', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    // Activity conflicts are directional and seeded both ways in production, so the
+    // form can disable whichever side the guest hasn't picked yet.
+    await seedConstraint(request, {
+      constraintType: 'ACTIVITY_CONFLICT',
+      triggerActivity: 'EAT_CATERING',
+      targetValue: 'EAT_A_LA_CARTE',
+      message: 'Catering and à la carte cannot be combined.',
+    });
+    await seedConstraint(request, {
+      constraintType: 'ACTIVITY_CONFLICT',
+      triggerActivity: 'EAT_A_LA_CARTE',
+      targetValue: 'EAT_CATERING',
+      message: 'Catering and à la carte cannot be combined.',
+    });
+  });
+
+  test('selecting catering disables the à la carte option', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+    await form.fillContact({ name: 'Jane Smith', email: 'jane@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+
+    const alaCarte = page.getByRole('checkbox', { name: 'Eat a la carte' });
+    await expect(alaCarte).toBeEnabled();
+
+    await form.toggleActivity('Eat catering');
+
+    await expect(alaCarte).toBeDisabled();
+    await captureScreenshot(testInfo, page, '1-conflicting-activity-disabled');
+  });
+});

--- a/e2e/tests/public/happy-path.spec.ts
+++ b/e2e/tests/public/happy-path.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend } from '../../fixtures/backend';
+import { clearMailbox, waitForEmailTo } from '../../fixtures/mailpit';
+import { captureScreenshot, attachHtml } from '../../fixtures/evidence';
+
+/**
+ * The golden path: a guest completes all five steps with nothing in the way, the
+ * reservation is created, and the confirmation email is delivered. Captures a screenshot
+ * at every step plus the actual delivered email as report evidence.
+ */
+test.describe('public: full booking happy path', () => {
+  const CONTACT = { name: 'Alex Tester', email: 'alex.happy@example.com' };
+  const ACTIVITY = {
+    title: 'Summer Drinks 2030',
+    date: '2030-09-10',
+    startTime: '14:00',
+    endTime: '16:00',
+    guests: 20,
+  };
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await clearMailbox(request);
+  });
+
+  test('submits a reservation end-to-end and emails the guest', async ({ page, request }, testInfo) => {
+    const form = new ReservationFormPage(page);
+
+    // Step 1 — Contact
+    await form.goto();
+    await form.fillContact(CONTACT);
+    await captureScreenshot(testInfo, page, '1-contact');
+    await form.continue();
+
+    // Step 2 — Activity
+    await form.expectStep('Activity Details');
+    await form.fillActivity(ACTIVITY);
+    await captureScreenshot(testInfo, page, '2-activity');
+    await form.continue();
+
+    // Step 3 — Location & seating
+    await form.expectStep('Where would you like to host your event?');
+    await form.selectLocation('NO_PREFERENCE');
+    await form.selectSeating('INSIDE');
+    await captureScreenshot(testInfo, page, '3-location');
+    await form.continue();
+
+    // Step 4 — Payment
+    await form.expectStep('Payment Information');
+    await form.selectPayment('People pay individually');
+    await captureScreenshot(testInfo, page, '4-payment');
+    await form.continue();
+
+    // Step 5 — Confirm
+    await form.acceptTerms();
+    await captureScreenshot(testInfo, page, '5-review');
+    await form.submit();
+
+    // Confirmation screen
+    await expect(page.getByText('Reservation Submitted!')).toBeVisible();
+    await expect(page.getByText(CONTACT.email)).toBeVisible();
+    await captureScreenshot(testInfo, page, '6-confirmation');
+
+    // The guest actually receives the confirmation email.
+    const email = await waitForEmailTo(request, CONTACT.email);
+    await attachHtml(testInfo, 'confirmation-email.html', email.HTML);
+    expect(email.HTML).toContain(ACTIVITY.title);
+  });
+});

--- a/e2e/tests/public/hard-block.spec.ts
+++ b/e2e/tests/public/hard-block.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedBlockedPeriod } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Hard block (default): the date is fully unavailable — a red notice, no acknowledgement
+ * option, and no way to advance. Contrast with the soft block in soft-block.spec.ts.
+ */
+test.describe('public: hard-blocked period', () => {
+  const BLOCK = {
+    startDate: '2030-07-01',
+    endDate: '2030-08-31',
+    reason: 'Renovation',
+    publicMessage: 'Closed for renovation.',
+    softBlock: false,
+  };
+  const DATE_IN_BLOCK = '2030-07-15';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedBlockedPeriod(request, BLOCK);
+  });
+
+  test('fully blocks the date with no acknowledgement and no way to proceed', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+
+    await form.fillContact({ name: 'Jane Smith', email: 'jane@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+
+    await form.fillActivity({ title: 'Hard block test', date: DATE_IN_BLOCK });
+
+    await expect(form.blockedNotice()).toBeVisible();
+    await expect(form.blockedNotice()).toContainText('Closed for renovation.');
+    await expect(form.blockedNotice()).toHaveAttribute('data-soft', 'false');
+    // A hard block offers no acknowledgement checkbox.
+    await expect(form.softAckCheckbox()).toHaveCount(0);
+    await captureScreenshot(testInfo, page, '1-hard-block-shown');
+
+    // Continue does not advance.
+    await form.continue();
+    await form.expectStep('Activity Details');
+  });
+});

--- a/e2e/tests/public/smoke.spec.ts
+++ b/e2e/tests/public/smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { resetBackend } from '../../fixtures/backend';
+
+/**
+ * Smoke test: proves the harness is wired up — the public app is served, talks to the
+ * backend, and the seed/reset endpoint is reachable. Real flows are added in later specs.
+ */
+test.describe('harness smoke', () => {
+  test('public reservation form loads', async ({ page, request }) => {
+    await resetBackend(request);
+
+    await page.goto('/');
+
+    await expect(page.getByText('Contact Information')).toBeVisible();
+    await expect(page.getByTestId('contact-name')).toBeVisible();
+    await expect(page.getByTestId('contact-email')).toBeVisible();
+  });
+});

--- a/e2e/tests/public/soft-block.spec.ts
+++ b/e2e/tests/public/soft-block.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedBlockedPeriod } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Soft block (#254): the period is announced as a warning, the guest must acknowledge it,
+ * but the booking is still allowed. Mirrors the summer-closing "open on request" scenario.
+ */
+test.describe('public: soft-blocked period', () => {
+  const BLOCK = {
+    startDate: '2030-07-01',
+    endDate: '2030-08-31',
+    reason: 'Summer closing',
+    publicMessage: 'The bar is closed by default this summer, but you can request a reservation.',
+    softBlock: true,
+    acknowledgementText: 'I understand the bar may be closed and my booking is a request',
+  };
+  const DATE_IN_BLOCK = '2030-07-15';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedBlockedPeriod(request, BLOCK);
+  });
+
+  test('warns, gates on acknowledgement, then allows the booking to proceed', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+
+    await form.fillContact({ name: 'Jane Smith', email: 'jane@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+
+    await form.fillActivity({ title: 'Soft block test', date: DATE_IN_BLOCK });
+
+    // The warning and acknowledgement checkbox are shown for the soft block.
+    await expect(form.blockedNotice()).toBeVisible();
+    await expect(form.blockedNotice()).toContainText('closed by default this summer');
+    await expect(form.softAckCheckbox()).toBeVisible();
+    await captureScreenshot(testInfo, page, '1-soft-block-warning-shown');
+
+    // Pressing Continue without acknowledging keeps us on the step and explains why.
+    await form.continue();
+    await form.expectStep('Activity Details');
+    await expect(form.softAckError()).toBeVisible();
+    await captureScreenshot(testInfo, page, '2-acknowledgement-required-prompt');
+
+    // After acknowledging, the prompt clears and the booking can proceed.
+    await form.acknowledgeSoftBlock();
+    await expect(form.softAckError()).toHaveCount(0);
+    await form.continue();
+    await form.expectStep('Where would you like to host your event?');
+    await captureScreenshot(testInfo, page, '3-proceeded-to-location-step');
+
+    // The global soft-block warning is not repeated under the location step.
+    await expect(form.blockedNotice()).toHaveCount(0);
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/the-harry-list-admin/Dockerfile
+++ b/the-harry-list-admin/Dockerfile
@@ -43,6 +43,9 @@ RUN echo '#!/bin/sh' > /docker-entrypoint.d/40-inject-config.sh && \
     echo '  REDIRECT_URI: "${REDIRECT_URI:-}",' >> /docker-entrypoint.d/40-inject-config.sh && \
     echo '  ALLOWED_GROUP_ID: "${ALLOWED_GROUP_ID:-}",' >> /docker-entrypoint.d/40-inject-config.sh && \
     echo '  SENTRY_DSN: "${SENTRY_DSN:-}",' >> /docker-entrypoint.d/40-inject-config.sh && \
+    echo '  E2E_AUTH_OID: "${E2E_AUTH_OID:-}",' >> /docker-entrypoint.d/40-inject-config.sh && \
+    echo '  E2E_AUTH_EMAIL: "${E2E_AUTH_EMAIL:-}",' >> /docker-entrypoint.d/40-inject-config.sh && \
+    echo '  E2E_AUTH_NAME: "${E2E_AUTH_NAME:-}",' >> /docker-entrypoint.d/40-inject-config.sh && \
     echo '};' >> /docker-entrypoint.d/40-inject-config.sh && \
     echo 'EOF' >> /docker-entrypoint.d/40-inject-config.sh && \
     chmod +x /docker-entrypoint.d/40-inject-config.sh

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/App.tsx
+++ b/the-harry-list-admin/src/App.tsx
@@ -13,6 +13,7 @@ import { WeekOverviewPage } from './pages/WeekOverviewPage';
 import { AuditLogPage } from './pages/AuditLogPage';
 import { Layout } from './components/Layout';
 import { useGroupAuthorization } from './lib/useGroupAuthorization';
+import { isE2E } from './lib/e2eAuth';
 import { ThemeProvider } from './lib/ThemeContext';
 import { RoleProvider } from './lib/RoleContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -22,11 +23,12 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isMsalAuthenticated = useIsAuthenticated();
   const { isLoading: isCheckingGroup, isAuthorized, error: groupError } = useGroupAuthorization();
 
-  // Only Microsoft authentication is allowed
-  const isAuthenticated = isMsalAuthenticated;
+  // e2e runs bypass MSAL/group checks; backend RBAC still applies via X-Test-* headers.
+  const e2e = isE2E();
+  const isAuthenticated = isMsalAuthenticated || e2e;
 
   // Show loading while checking group membership
-  if (isAuthenticated && isCheckingGroup) {
+  if (isAuthenticated && !e2e && isCheckingGroup) {
     return (
       <div className="min-h-screen bg-dark-950 flex items-center justify-center">
         <div className="text-center">
@@ -38,7 +40,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   }
 
   // Show unauthorized message if user is not in the allowed group
-  if (isAuthenticated && !isAuthorized) {
+  if (isAuthenticated && !e2e && !isAuthorized) {
     return (
       <div className="min-h-screen bg-dark-950 flex items-center justify-center p-4">
         <div className="max-w-md w-full bg-dark-900 border border-dark-800 rounded-xl p-8 text-center">

--- a/the-harry-list-admin/src/lib/RoleContext.tsx
+++ b/the-harry-list-admin/src/lib/RoleContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { useIsAuthenticated } from '@azure/msal-react';
 import { fetchCurrentUser, type AdminUser } from './api';
+import { isE2E } from './e2eAuth';
 
 type AdminRole = 'VIEWER' | 'EDITOR' | 'ADMIN';
 
@@ -26,7 +27,8 @@ export function useRole() {
 }
 
 export function RoleProvider({ children }: { children: ReactNode }) {
-  const isAuthenticated = useIsAuthenticated();
+  // e2e runs aren't MSAL-authenticated but should still load their role from the backend.
+  const isAuthenticated = useIsAuthenticated() || isE2E();
   const [user, setUser] = useState<AdminUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/the-harry-list-admin/src/lib/api.ts
+++ b/the-harry-list-admin/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { PublicClientApplication } from '@azure/msal-browser';
 import * as Sentry from '@sentry/react';
+import { getE2eAuth } from './e2eAuth';
 // Note: Window.__RUNTIME_CONFIG__ type is declared in authConfig.ts
 
 // Get API URL from runtime config or fall back to build-time env
@@ -72,11 +73,6 @@ const getAccessToken = async (): Promise<string | null> => {
 
 // Main fetch function with authentication
 export async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
-  const token = await getAccessToken();
-  if (!token) {
-    throw new Error('Not authenticated');
-  }
-
   // Ensure URL is absolute
   const fullUrl = url.startsWith('http') ? url : `${API_BASE_URL}${url}`;
 
@@ -84,8 +80,22 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}): Pro
   const isFormData = options.body instanceof FormData;
   const headers: Record<string, string> = {
     ...options.headers as Record<string, string>,
-    'Authorization': `Bearer ${token}`,
   };
+
+  // In e2e runs, authenticate via X-Test-* headers instead of MSAL (see e2eAuth.ts).
+  const e2e = getE2eAuth();
+  if (e2e) {
+    headers['X-Test-Oid'] = e2e.oid;
+    if (e2e.email) headers['X-Test-Email'] = e2e.email;
+    if (e2e.name) headers['X-Test-Name'] = e2e.name;
+  } else {
+    const token = await getAccessToken();
+    if (!token) {
+      throw new Error('Not authenticated');
+    }
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
   if (!isFormData) {
     headers['Content-Type'] = 'application/json';
   }

--- a/the-harry-list-admin/src/lib/authConfig.ts
+++ b/the-harry-list-admin/src/lib/authConfig.ts
@@ -11,6 +11,10 @@ declare global {
       REDIRECT_URI?: string;
       ALLOWED_GROUP_ID?: string;
       SENTRY_DSN?: string;
+      // e2e-only: injected by docker-compose.e2e.yml to bypass MSAL in tests.
+      E2E_AUTH_OID?: string;
+      E2E_AUTH_EMAIL?: string;
+      E2E_AUTH_NAME?: string;
     };
   }
 }

--- a/the-harry-list-admin/src/lib/e2eAuth.ts
+++ b/the-harry-list-admin/src/lib/e2eAuth.ts
@@ -1,0 +1,35 @@
+/**
+ * End-to-end test authentication bridge.
+ *
+ * The admin app normally authenticates with Microsoft (MSAL) and sends a Bearer token.
+ * That can't be driven in a headless test, so the e2e docker image injects an
+ * {@code E2E_AUTH_OID} runtime value. When present, the app skips MSAL and instead sends
+ * {@code X-Test-*} headers that the backend's e2e security chain understands.
+ *
+ * This is inert in dev and production: the runtime value is only ever set by
+ * docker-compose.e2e.yml, so {@link isE2E} returns false everywhere else.
+ */
+
+function clean(value: string | undefined): string | undefined {
+  if (!value || value.startsWith('__') || value.trim() === '') return undefined;
+  return value;
+}
+
+export interface E2eAuth {
+  oid: string;
+  email?: string;
+  name?: string;
+}
+
+/** Returns the injected e2e identity, or null when not running under the e2e stack. */
+export function getE2eAuth(): E2eAuth | null {
+  const cfg = window.__RUNTIME_CONFIG__;
+  const oid = clean(cfg?.E2E_AUTH_OID);
+  if (!oid) return null;
+  return { oid, email: clean(cfg?.E2E_AUTH_EMAIL), name: clean(cfg?.E2E_AUTH_NAME) };
+}
+
+/** True only when the app is running under the e2e test stack. */
+export function isE2E(): boolean {
+  return getE2eAuth() !== null;
+}

--- a/the-harry-list-admin/src/pages/ExportPage.tsx
+++ b/the-harry-list-admin/src/pages/ExportPage.tsx
@@ -81,6 +81,7 @@ export function ExportPage() {
             </label>
             <input
               type="date"
+              data-testid="export-date"
               value={selectedDate}
               onChange={(e) => setSelectedDate(e.target.value)}
               className="w-full px-4 py-3 bg-dark-800 border border-dark-700 rounded-xl text-white
@@ -164,6 +165,7 @@ export function ExportPage() {
               <label className="flex items-center gap-3 p-4 bg-dark-800/50 border border-dark-700 rounded-xl cursor-pointer hover:border-dark-600 transition-colors">
                 <input
                   type="checkbox"
+                  data-testid="export-catering-only"
                   checked={cateringOnly}
                   onChange={(e) => setCateringOnly(e.target.checked)}
                   className="w-5 h-5 rounded border-dark-600 bg-dark-800 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-0"
@@ -187,6 +189,7 @@ export function ExportPage() {
           {/* Export Button */}
           <button
             onClick={handleExport}
+            data-testid="export-submit"
             disabled={loading}
             className={`
               w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl font-medium transition-all

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -279,6 +279,7 @@ export function SettingsPage() {
               {constraints.map((c) => (
                 <div
                   key={c.id}
+                  data-testid="constraint-row"
                   className={`bg-dark-900 border rounded-xl p-4 flex items-start gap-4 transition-colors ${
                     c.enabled ? 'border-dark-800' : 'border-dark-800/50 opacity-60'
                   }`}
@@ -434,6 +435,7 @@ export function SettingsPage() {
                 <div>
                   <label className="block text-sm text-dark-400 mb-1">Constraint Type</label>
                   <select
+                    data-testid="constraint-type"
                     value={editingConstraint.constraintType}
                     onChange={e => setEditingConstraint({
                       ...editingConstraint,
@@ -452,6 +454,7 @@ export function SettingsPage() {
                   <div>
                     <label className="block text-sm text-dark-400 mb-1">Trigger Activity</label>
                     <select
+                      data-testid="constraint-trigger"
                       value={editingConstraint.triggerActivity}
                       onChange={e => setEditingConstraint({ ...editingConstraint, triggerActivity: e.target.value })}
                       className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
@@ -467,6 +470,7 @@ export function SettingsPage() {
                   <label className="block text-sm text-dark-400 mb-1">Target Value</label>
                   <input
                     type="text"
+                    data-testid="constraint-target"
                     value={editingConstraint.targetValue || ''}
                     onChange={e => setEditingConstraint({ ...editingConstraint, targetValue: e.target.value })}
                     placeholder="e.g. EAT_A_LA_CARTE, HUBBLE, INSIDE"
@@ -494,6 +498,7 @@ export function SettingsPage() {
                     </label>
                     <input
                       type="number"
+                      data-testid="constraint-numeric"
                       value={editingConstraint.numericValue ?? ''}
                       onChange={e => setEditingConstraint({
                         ...editingConstraint,
@@ -520,6 +525,7 @@ export function SettingsPage() {
                 <div>
                   <label className="block text-sm text-dark-400 mb-1">Message (shown to users)</label>
                   <textarea
+                    data-testid="constraint-message"
                     value={editingConstraint.message}
                     onChange={e => setEditingConstraint({ ...editingConstraint, message: e.target.value })}
                     rows={2}
@@ -537,6 +543,7 @@ export function SettingsPage() {
                 </button>
                 <button
                   onClick={handleSaveConstraint}
+                  data-testid="save-constraint"
                   disabled={savingConstraint || !editingConstraint.message}
                   className="flex-1 px-4 py-2 bg-hubble-600 hover:bg-hubble-500 text-white rounded-lg text-sm transition-colors disabled:opacity-50"
                 >

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -265,6 +265,7 @@ export function SettingsPage() {
             </p>
             <button
               onClick={() => setEditingConstraint({ ...emptyConstraint })}
+              data-testid="add-constraint"
               className="flex items-center gap-2 px-3 py-2 bg-hubble-600 hover:bg-hubble-500 text-white rounded-lg text-sm transition-colors"
             >
               <Plus className="w-4 h-4" /> Add Constraint
@@ -337,6 +338,7 @@ export function SettingsPage() {
             </p>
             <button
               onClick={() => setEditingPeriod({ ...emptyBlockedPeriod })}
+              data-testid="add-blocked-period"
               className="flex items-center gap-2 px-3 py-2 bg-hubble-600 hover:bg-hubble-500 text-white rounded-lg text-sm transition-colors"
             >
               <Plus className="w-4 h-4" /> Add Blocked Period
@@ -350,6 +352,7 @@ export function SettingsPage() {
               {blockedPeriods.map((bp) => (
                 <div
                   key={bp.id}
+                  data-testid="blocked-period-row"
                   className={`bg-dark-900 border rounded-xl p-4 flex items-start gap-4 transition-colors ${
                     bp.enabled ? 'border-dark-800' : 'border-dark-800/50 opacity-60'
                   }`}
@@ -360,7 +363,7 @@ export function SettingsPage() {
                         {bp.startDate} — {bp.endDate}
                       </span>
                       {bp.softBlock && (
-                        <span className="text-xs font-medium px-2 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">
+                        <span data-testid="soft-block-badge" className="text-xs font-medium px-2 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">
                           Soft block
                         </span>
                       )}
@@ -669,6 +672,7 @@ export function SettingsPage() {
                     <button
                       type="button"
                       role="switch"
+                      data-testid="soft-block-toggle"
                       aria-checked={!!editingPeriod.softBlock}
                       onClick={() => setEditingPeriod({ ...editingPeriod, softBlock: !editingPeriod.softBlock })}
                       className="shrink-0 mt-0.5"
@@ -692,6 +696,7 @@ export function SettingsPage() {
                       <label className="block text-sm text-dark-400 mb-1">Acknowledgement text (checkbox label)</label>
                       <input
                         type="text"
+                        data-testid="ack-text-input"
                         value={editingPeriod.acknowledgementText || ''}
                         onChange={e => setEditingPeriod({ ...editingPeriod, acknowledgementText: e.target.value })}
                         placeholder="I understand the bar may be closed and my reservation is a request"
@@ -712,6 +717,7 @@ export function SettingsPage() {
                 </button>
                 <button
                   onClick={handleSavePeriod}
+                  data-testid="save-blocked-period"
                   disabled={savingPeriod || !editingPeriod.reason || !editingPeriod.startDate || !editingPeriod.endDate}
                   className="flex-1 px-4 py-2 bg-hubble-600 hover:bg-hubble-500 text-white rounded-lg text-sm transition-colors disabled:opacity-50"
                 >

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -317,6 +317,7 @@ export function ReservationDetailPage() {
           {/* Edit Details Button */}
           <button
             onClick={startEditing}
+            data-testid="edit-reservation"
             disabled={isUpdating}
             className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-hubble-500/20 text-hubble-400 hover:bg-hubble-500/30 transition-colors"
           >
@@ -339,6 +340,7 @@ export function ReservationDetailPage() {
             <>
               <button
                 onClick={() => { setActionMessage(''); setShowConfirmDialog(true); }}
+                data-testid="confirm-reservation"
                 disabled={isUpdating}
                 className="btn-primary flex items-center gap-2"
               >
@@ -347,6 +349,7 @@ export function ReservationDetailPage() {
               </button>
               <button
                 onClick={() => { setActionMessage(DEFAULT_REJECTION_MESSAGE); setShowRejectDialog(true); }}
+                data-testid="reject-reservation"
                 disabled={isUpdating}
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
               >
@@ -370,6 +373,7 @@ export function ReservationDetailPage() {
           {reservation.status === 'CONFIRMED' && (
             <button
               onClick={() => { setActionMessage(''); setShowCancelDialog(true); }}
+              data-testid="cancel-reservation"
               disabled={isUpdating}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors ml-auto"
             >
@@ -381,6 +385,7 @@ export function ReservationDetailPage() {
           {(reservation.status === 'CANCELLED' || reservation.status === 'REJECTED') && (
             <button
               onClick={() => setShowDeleteConfirm(true)}
+              data-testid="remove-reservation"
               disabled={isUpdating}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-red-500/50 text-red-400 hover:bg-red-500/10 transition-colors ml-auto"
             >
@@ -397,6 +402,7 @@ export function ReservationDetailPage() {
             <div className="flex gap-3">
               <button
                 onClick={handleDelete}
+                data-testid="delete-dialog-submit"
                 disabled={isUpdating}
                 className="px-4 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors"
               >
@@ -423,6 +429,7 @@ export function ReservationDetailPage() {
                   handleStatusChange('CONFIRMED');
                   setShowConfirmDialog(false);
                 }}
+                data-testid="confirm-dialog-submit"
                 disabled={isUpdating}
                 className="px-4 py-2 rounded-lg bg-green-500 text-white hover:bg-green-600 transition-colors flex items-center gap-2"
               >
@@ -450,6 +457,7 @@ export function ReservationDetailPage() {
                   handleStatusChange('REJECTED');
                   setShowRejectDialog(false);
                 }}
+                data-testid="reject-dialog-submit"
                 disabled={isUpdating}
                 className="px-4 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors flex items-center gap-2"
               >
@@ -504,6 +512,7 @@ export function ReservationDetailPage() {
                   handleStatusChange('CANCELLED');
                   setShowCancelDialog(false);
                 }}
+                data-testid="cancel-dialog-submit"
                 disabled={isUpdating}
                 className="px-4 py-2 rounded-lg bg-amber-500 text-white hover:bg-amber-600 transition-colors flex items-center gap-2"
               >
@@ -972,6 +981,7 @@ export function ReservationDetailPage() {
                     <label className="label">Expected Guests</label>
                     <input
                       type="number"
+                      data-testid="edit-guests"
                       value={editData.expectedGuests || ''}
                       onChange={(e) => setEditData({ ...editData, expectedGuests: parseInt(e.target.value) })}
                       className="input-field"
@@ -1182,6 +1192,7 @@ export function ReservationDetailPage() {
               </button>
               <button
                 onClick={handleEditSave}
+                data-testid="edit-save"
                 disabled={isUpdating}
                 className="btn-primary flex items-center gap-2"
               >
@@ -1236,7 +1247,9 @@ function StatusBadge({ status, large }: { status: string; large?: boolean }) {
   const { color, bg } = config[status] || config.PENDING;
 
   return (
-    <span className={`
+    <span
+      data-testid="reservation-status"
+      className={`
       inline-flex items-center gap-2 px-3 py-1.5 rounded-xl font-medium
       ${bg} ${color}
       ${large ? 'text-sm' : 'text-xs'}

--- a/the-harry-list-admin/src/pages/ReservationsPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationsPage.tsx
@@ -197,6 +197,7 @@ export function ReservationsPage() {
                 {items.map((reservation) => (
                   <Link
                     key={reservation.id}
+                    data-testid="reservation-row"
                     to={`/reservations/${reservation.id}`}
                     className="card block hover:border-hubble-500/50 transition-all"
                   >

--- a/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
+++ b/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
@@ -399,6 +399,7 @@ function WeekReservationCard({
   return (
     <Link
       to={`/reservations/${reservation.id}`}
+      data-testid="week-reservation"
       className={`block rounded-lg bg-dark-800/80 hover:bg-dark-800 border-l-2 p-2 transition-colors ${STATUS_COLORS[reservation.status] || 'border-l-dark-600'}`}
     >
       {/* Status badge */}

--- a/the-harry-list-admin/src/test/e2eAuth.test.ts
+++ b/the-harry-list-admin/src/test/e2eAuth.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getE2eAuth, isE2E } from '../lib/e2eAuth';
+
+/**
+ * The e2e auth bridge must be completely inert unless an E2E_AUTH_OID runtime value
+ * is injected (only docker-compose.e2e.yml does this). These tests guard that gate.
+ */
+describe('e2eAuth', () => {
+  afterEach(() => {
+    delete (window as { __RUNTIME_CONFIG__?: unknown }).__RUNTIME_CONFIG__;
+  });
+
+  it('is inert when no runtime config is present', () => {
+    expect(getE2eAuth()).toBeNull();
+    expect(isE2E()).toBe(false);
+  });
+
+  it('is inert when the oid is an unsubstituted placeholder', () => {
+    window.__RUNTIME_CONFIG__ = { E2E_AUTH_OID: '__E2E_AUTH_OID__' };
+    expect(isE2E()).toBe(false);
+  });
+
+  it('is inert when the oid is empty', () => {
+    window.__RUNTIME_CONFIG__ = { E2E_AUTH_OID: '' };
+    expect(isE2E()).toBe(false);
+  });
+
+  it('activates and returns the identity when an oid is injected', () => {
+    window.__RUNTIME_CONFIG__ = {
+      E2E_AUTH_OID: 'e2e-admin',
+      E2E_AUTH_EMAIL: 'admin@e2e.test',
+      E2E_AUTH_NAME: 'E2E Admin',
+    };
+    expect(isE2E()).toBe(true);
+    expect(getE2eAuth()).toEqual({ oid: 'e2e-admin', email: 'admin@e2e.test', name: 'E2E Admin' });
+  });
+
+  it('omits optional fields when they are blank or placeholders', () => {
+    window.__RUNTIME_CONFIG__ = {
+      E2E_AUTH_OID: 'e2e-admin',
+      E2E_AUTH_EMAIL: '',
+      E2E_AUTH_NAME: '__E2E_AUTH_NAME__',
+    };
+    expect(getE2eAuth()).toEqual({ oid: 'e2e-admin', email: undefined, name: undefined });
+  });
+});

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -52,6 +52,13 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!-- SMTP mail sender — used by the e2e profile to deliver email to a local
+		     catcher (Mailpit) so end-to-end tests can assert real messages. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.4.2</version>
+	<version>1.5.0</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/E2eSecurityConfig.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/E2eSecurityConfig.java
@@ -102,8 +102,12 @@ public class E2eSecurityConfig {
         protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
                 throws ServletException, IOException {
             String oid = request.getHeader("X-Test-Oid");
-            if (oid != null && !oid.isBlank()
-                    && SecurityContextHolder.getContext().getAuthentication() == null) {
+            // Set our token whenever the header is present and we haven't already authenticated
+            // via JWT. We must overwrite any AnonymousAuthenticationToken (Spring's anonymous
+            // filter runs before this one), otherwise admin requests stay anonymous -> 403.
+            boolean alreadyJwt = SecurityContextHolder.getContext().getAuthentication()
+                    instanceof JwtAuthenticationToken;
+            if (oid != null && !oid.isBlank() && !alreadyJwt) {
                 String email = request.getHeader("X-Test-Email");
                 if (email == null || email.isBlank()) email = oid + "@e2e.test";
                 String name = request.getHeader("X-Test-Name");

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/E2eSecurityConfig.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/E2eSecurityConfig.java
@@ -1,0 +1,130 @@
+package com.pimvanleeuwen.the_harry_list_backend.config;
+
+import com.pimvanleeuwen.the_harry_list_backend.filter.RoleAuthorizationFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Security configuration used <strong>only under the {@code e2e} Spring profile</strong>.
+ *
+ * <p>Production security ({@link SecurityConfig}, gated to {@code !e2e}) validates real
+ * Azure AD JWTs, which cannot be minted in a headless test environment. This configuration
+ * instead derives the principal from simple request headers and then lets the real
+ * {@link RoleAuthorizationFilter} resolve the role from the database — so authorization,
+ * RBAC and audit-actor attribution all behave exactly as in production.</p>
+ *
+ * <p>To authenticate, an e2e request sends:</p>
+ * <ul>
+ *   <li>{@code X-Test-Oid} — the Azure object id of a (seeded) admin user (required)</li>
+ *   <li>{@code X-Test-Email}, {@code X-Test-Name} — optional display fields</li>
+ * </ul>
+ *
+ * <p>This config never loads outside {@code e2e}, so it has no effect on production.</p>
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@Profile("e2e")
+public class E2eSecurityConfig {
+
+    private final RoleAuthorizationFilter roleAuthorizationFilter;
+
+    public E2eSecurityConfig(RoleAuthorizationFilter roleAuthorizationFilter) {
+        this.roleAuthorizationFilter = roleAuthorizationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain e2eSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(e2eCorsConfigurationSource()))
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/actuator/health").permitAll()
+                .requestMatchers("/test/**").permitAll()            // e2e seed/reset helpers
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/public/reservations").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/public/reservations/recaptcha-status").permitAll()
+                .requestMatchers("/api/options/**").permitAll()
+                .requestMatchers("/api/calendar/**").permitAll()
+                .anyRequest().authenticated()
+            );
+
+        // Header-based test authentication, then the real role enrichment filter.
+        TestHeaderAuthFilter testAuthFilter = new TestHeaderAuthFilter();
+        http.addFilterBefore(testAuthFilter, AuthorizationFilter.class);
+        http.addFilterAfter(roleAuthorizationFilter, TestHeaderAuthFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource e2eCorsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    /**
+     * Authenticates a request from the {@code X-Test-Oid} header by constructing a
+     * {@link JwtAuthenticationToken} whose claims mirror an Azure AD token. The real
+     * {@link RoleAuthorizationFilter} then assigns authorities from the database.
+     */
+    static class TestHeaderAuthFilter extends OncePerRequestFilter {
+        @Override
+        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+                throws ServletException, IOException {
+            String oid = request.getHeader("X-Test-Oid");
+            if (oid != null && !oid.isBlank()
+                    && SecurityContextHolder.getContext().getAuthentication() == null) {
+                String email = request.getHeader("X-Test-Email");
+                if (email == null || email.isBlank()) email = oid + "@e2e.test";
+                String name = request.getHeader("X-Test-Name");
+                if (name == null || name.isBlank()) name = oid;
+
+                Instant now = Instant.now();
+                Jwt jwt = Jwt.withTokenValue("e2e-test-token")
+                        .header("alg", "none")
+                        .subject(oid)
+                        .claim("oid", oid)
+                        .claim("preferred_username", email)
+                        .claim("name", name)
+                        .issuedAt(now)
+                        .expiresAt(now.plusSeconds(3600))
+                        .build();
+
+                // No authorities yet — RoleAuthorizationFilter enriches from the DB role.
+                SecurityContextHolder.getContext().setAuthentication(
+                        new JwtAuthenticationToken(jwt, List.of()));
+            }
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SecurityConfig.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.pimvanleeuwen.the_harry_list_backend.filter.RoleAuthorizationFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -29,6 +30,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@Profile("!e2e")
 public class SecurityConfig {
 
     @Value("${azure.tenant-id:}")

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
@@ -9,6 +9,7 @@ import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.BlockedPeriodRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
+import com.pimvanleeuwen.the_harry_list_backend.repository.EmailTemplateRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.FormConstraintRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,19 +41,22 @@ public class TestSupportController {
     private final CalendarAppointmentRepository calendarAppointmentRepository;
     private final AuditLogRepository auditLogRepository;
     private final AdminUserRepository adminUserRepository;
+    private final EmailTemplateRepository emailTemplateRepository;
 
     public TestSupportController(ReservationRepository reservationRepository,
                                  BlockedPeriodRepository blockedPeriodRepository,
                                  FormConstraintRepository formConstraintRepository,
                                  CalendarAppointmentRepository calendarAppointmentRepository,
                                  AuditLogRepository auditLogRepository,
-                                 AdminUserRepository adminUserRepository) {
+                                 AdminUserRepository adminUserRepository,
+                                 EmailTemplateRepository emailTemplateRepository) {
         this.reservationRepository = reservationRepository;
         this.blockedPeriodRepository = blockedPeriodRepository;
         this.formConstraintRepository = formConstraintRepository;
         this.calendarAppointmentRepository = calendarAppointmentRepository;
         this.auditLogRepository = auditLogRepository;
         this.adminUserRepository = adminUserRepository;
+        this.emailTemplateRepository = emailTemplateRepository;
     }
 
     /** Wipe the mutable state an e2e test cares about, for a clean run. */
@@ -64,6 +68,8 @@ public class TestSupportController {
         formConstraintRepository.deleteAll();
         calendarAppointmentRepository.deleteAll();
         adminUserRepository.deleteAll();
+        // Clear customized templates so each test starts from the default templates.
+        emailTemplateRepository.deleteAll();
         return ResponseEntity.ok(Map.of("status", "reset"));
     }
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
@@ -3,6 +3,8 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
 import com.pimvanleeuwen.the_harry_list_backend.model.BlockedPeriod;
+import com.pimvanleeuwen.the_harry_list_backend.model.FormConstraint;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.BlockedPeriodRepository;
@@ -85,5 +87,20 @@ public class TestSupportController {
     @PostMapping("/blocked-periods")
     public ResponseEntity<BlockedPeriod> seedBlockedPeriod(@RequestBody BlockedPeriod period) {
         return ResponseEntity.ok(blockedPeriodRepository.save(period));
+    }
+
+    /** Seed a form constraint so constraint-enforcement scenarios can be exercised. */
+    @PostMapping("/constraints")
+    public ResponseEntity<FormConstraint> seedConstraint(@RequestBody FormConstraint constraint) {
+        return ResponseEntity.ok(formConstraintRepository.save(constraint));
+    }
+
+    /**
+     * Seed a reservation directly. @PrePersist fills confirmationNumber/status/timestamps,
+     * so the body only needs the business fields. Returns the saved row (with its id).
+     */
+    @PostMapping("/reservations")
+    public ResponseEntity<Reservation> seedReservation(@RequestBody Reservation reservation) {
+        return ResponseEntity.ok(reservationRepository.save(reservation));
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
@@ -1,0 +1,89 @@
+package com.pimvanleeuwen.the_harry_list_backend.controller;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
+import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
+import com.pimvanleeuwen.the_harry_list_backend.model.BlockedPeriod;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
+import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
+import com.pimvanleeuwen.the_harry_list_backend.repository.BlockedPeriodRepository;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
+import com.pimvanleeuwen.the_harry_list_backend.repository.FormConstraintRepository;
+import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * Test-only helper endpoints used by the end-to-end suite to seed and reset state
+ * without going through Azure-authenticated admin APIs.
+ *
+ * <p>Gated to the {@code e2e} Spring profile — these endpoints never exist in dev or
+ * production. {@link E2eSecurityConfig} permits {@code /test/**} only under that profile.</p>
+ */
+@RestController
+@RequestMapping("/test")
+@Profile("e2e")
+@Tag(name = "E2E Test Support", description = "Seed/reset helpers — e2e profile only")
+public class TestSupportController {
+
+    private final ReservationRepository reservationRepository;
+    private final BlockedPeriodRepository blockedPeriodRepository;
+    private final FormConstraintRepository formConstraintRepository;
+    private final CalendarAppointmentRepository calendarAppointmentRepository;
+    private final AuditLogRepository auditLogRepository;
+    private final AdminUserRepository adminUserRepository;
+
+    public TestSupportController(ReservationRepository reservationRepository,
+                                 BlockedPeriodRepository blockedPeriodRepository,
+                                 FormConstraintRepository formConstraintRepository,
+                                 CalendarAppointmentRepository calendarAppointmentRepository,
+                                 AuditLogRepository auditLogRepository,
+                                 AdminUserRepository adminUserRepository) {
+        this.reservationRepository = reservationRepository;
+        this.blockedPeriodRepository = blockedPeriodRepository;
+        this.formConstraintRepository = formConstraintRepository;
+        this.calendarAppointmentRepository = calendarAppointmentRepository;
+        this.auditLogRepository = auditLogRepository;
+        this.adminUserRepository = adminUserRepository;
+    }
+
+    /** Wipe the mutable state an e2e test cares about, for a clean run. */
+    @PostMapping("/reset")
+    public ResponseEntity<Map<String, String>> reset() {
+        auditLogRepository.deleteAll();
+        reservationRepository.deleteAll();
+        blockedPeriodRepository.deleteAll();
+        formConstraintRepository.deleteAll();
+        calendarAppointmentRepository.deleteAll();
+        adminUserRepository.deleteAll();
+        return ResponseEntity.ok(Map.of("status", "reset"));
+    }
+
+    public record SeedUser(String oid, String email, String name, String role) {
+    }
+
+    /** Create or update an admin user with a specific role, so RBAC paths can be exercised. */
+    @PostMapping("/users")
+    public ResponseEntity<AdminUser> seedUser(@RequestBody SeedUser body) {
+        AdminRole role = AdminRole.valueOf(body.role());
+        AdminUser user = adminUserRepository.findByAzureOid(body.oid())
+                .orElseGet(AdminUser::new);
+        user.setAzureOid(body.oid());
+        user.setEmail(body.email() != null ? body.email() : body.oid() + "@e2e.test");
+        user.setDisplayName(body.name() != null ? body.name() : body.oid());
+        user.setRole(role);
+        return ResponseEntity.ok(adminUserRepository.save(user));
+    }
+
+    /** Seed a blocked period directly (bypasses auth) for public-form scenarios. */
+    @PostMapping("/blocked-periods")
+    public ResponseEntity<BlockedPeriod> seedBlockedPeriod(@RequestBody BlockedPeriod period) {
+        return ResponseEntity.ok(blockedPeriodRepository.save(period));
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/SmtpEmailService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/SmtpEmailService.java
@@ -1,0 +1,227 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.EmailAttachment;
+import com.pimvanleeuwen.the_harry_list_backend.model.EmailTemplateType;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+import com.pimvanleeuwen.the_harry_list_backend.model.SpecialActivity;
+import jakarta.mail.internet.MimeMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * SMTP-based email sender used <strong>only under the {@code e2e} Spring profile</strong>.
+ *
+ * <p>Production sends email through {@link MicrosoftGraphEmailService}; this implementation
+ * exists so end-to-end tests can deliver messages to a local catcher (Mailpit) and assert
+ * on the real, rendered content. It deliberately reuses the same {@link EmailTemplateService}
+ * (the editable templates) and {@link EmailTemplates} helpers as production, so what the
+ * tests see matches what customers receive.</p>
+ *
+ * <p>It is profile-gated and never loads outside {@code e2e}, so it has no effect on prod.</p>
+ */
+@Service
+@Profile("e2e")
+public class SmtpEmailService implements EmailNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(SmtpEmailService.class);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final JavaMailSender mailSender;
+    private final EmailTemplateService emailTemplateService;
+    private final String fromEmail;
+    private final String staffEmail;
+    private final String barName;
+
+    public SmtpEmailService(JavaMailSender mailSender,
+                            EmailTemplateService emailTemplateService,
+                            @Value("${app.mail.from}") String fromEmail,
+                            @Value("${app.mail.staff}") String staffEmail,
+                            @Value("${app.bar.name:Hubble and Meteor Community Cafes}") String barName) {
+        this.mailSender = mailSender;
+        this.emailTemplateService = emailTemplateService;
+        this.fromEmail = fromEmail;
+        this.staffEmail = staffEmail;
+        this.barName = barName;
+        log.info("SMTP (e2e) email service initialized. Sending from: {}, Staff notifications to: {}",
+                fromEmail, staffEmail);
+    }
+
+    @Override
+    public void sendReservationSubmittedEmail(Reservation reservation) {
+        Map<String, String> vars = buildBaseVars(reservation);
+        deliver(reservation.getEmail(),
+                emailTemplateService.getRenderedSubject(EmailTemplateType.SUBMITTED, vars),
+                emailTemplateService.getRenderedBody(EmailTemplateType.SUBMITTED, vars));
+
+        Map<String, String> staffVars = buildStaffNotificationVars(reservation);
+        deliver(staffEmail,
+                emailTemplateService.getRenderedSubject(EmailTemplateType.STAFF_NOTIFICATION, staffVars),
+                emailTemplateService.getRenderedBody(EmailTemplateType.STAFF_NOTIFICATION, staffVars));
+    }
+
+    @Override
+    public void sendStatusChangeEmail(Reservation reservation, String customMessage) {
+        Map<String, String> vars = buildStatusChangeVars(reservation);
+        Map<String, String> rawHtmlVars = Map.of(
+                "customMessage", EmailTemplates.buildCustomMessageBlock(customMessage));
+        deliver(reservation.getEmail(),
+                emailTemplateService.getRenderedSubject(EmailTemplateType.STATUS_CHANGED, vars),
+                emailTemplateService.getRenderedBody(EmailTemplateType.STATUS_CHANGED, vars, rawHtmlVars));
+    }
+
+    @Override
+    public void sendReservationUpdatedEmail(Reservation reservation, String customMessage) {
+        Map<String, String> vars = buildBaseVars(reservation);
+        vars.put("status", reservation.getStatus().getDisplayName());
+        Map<String, String> rawHtmlVars = Map.of(
+                "customMessage", EmailTemplates.buildCustomMessageBlock(customMessage));
+        deliver(reservation.getEmail(),
+                emailTemplateService.getRenderedSubject(EmailTemplateType.UPDATED, vars),
+                emailTemplateService.getRenderedBody(EmailTemplateType.UPDATED, vars, rawHtmlVars));
+    }
+
+    @Override
+    public void sendReservationCancelledEmail(Reservation reservation) {
+        Map<String, String> vars = buildBaseVars(reservation);
+        vars.put("staffEmail", staffEmail);
+        deliver(reservation.getEmail(),
+                emailTemplateService.getRenderedSubject(EmailTemplateType.CANCELLED, vars),
+                emailTemplateService.getRenderedBody(EmailTemplateType.CANCELLED, vars));
+    }
+
+    @Override
+    public void sendCustomEmail(Reservation reservation, String subject, String message) {
+        deliver(reservation.getEmail(), subject,
+                EmailTemplates.buildCustomEmailBody(reservation, message, barName, staffEmail));
+    }
+
+    @Override
+    public void sendRawEmail(String to, String subject, String htmlBody) {
+        deliver(to, subject, htmlBody, null);
+    }
+
+    @Override
+    public void sendEmailWithAttachments(String to, String subject, String htmlBody,
+                                         List<EmailAttachment> attachments, String replyTo) {
+        // Binary attachments are not needed for e2e assertions; the message body still
+        // reaches the catcher so tests can verify subject/body and recipient.
+        deliver(to, subject, htmlBody, replyTo);
+    }
+
+    private void deliver(String to, String subject, String htmlBody) {
+        deliver(to, subject, htmlBody, null);
+    }
+
+    private void deliver(String to, String subject, String htmlBody, String replyTo) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setFrom(fromEmail);
+            helper.setTo(to);
+            if (replyTo != null && !replyTo.isBlank()) {
+                helper.setReplyTo(replyTo);
+            }
+            helper.setSubject(subject);
+            helper.setText(htmlBody, true);
+            mailSender.send(message);
+            log.info("LOGGING email.smtp_sent to='{}' subject='{}'", to, subject);
+        } catch (Exception e) {
+            log.error("Failed to send SMTP (e2e) email to: {}", to, e);
+        }
+    }
+
+    private Map<String, String> buildBaseVars(Reservation reservation) {
+        Map<String, String> vars = new HashMap<>();
+        vars.put("contactName", reservation.getContactName());
+        vars.put("confirmationNumber", reservation.getConfirmationNumber());
+        vars.put("eventTitle", reservation.getEventTitle());
+        vars.put("eventDate", reservation.getEventDate().format(DATE_FORMATTER));
+        vars.put("startTime", reservation.getStartTime().format(TIME_FORMATTER));
+        vars.put("endTime", reservation.getEndTime().format(TIME_FORMATTER));
+        vars.put("location", reservation.getLocation() != null ? reservation.getLocation().getDisplayName() : "No Preference");
+        vars.put("expectedGuests", String.valueOf(reservation.getExpectedGuests()));
+        vars.put("barName", barName);
+        return vars;
+    }
+
+    private Map<String, String> buildStatusChangeVars(Reservation reservation) {
+        Map<String, String> vars = buildBaseVars(reservation);
+        vars.put("staffEmail", staffEmail);
+        vars.put("status", reservation.getStatus().getDisplayName());
+        vars.put("statusMessage", resolveStatusMessage(reservation.getStatus()));
+        vars.put("statusColor", resolveStatusColor(reservation.getStatus()));
+        vars.put("statusSubject", resolveStatusSubject(reservation.getStatus()));
+        return vars;
+    }
+
+    private Map<String, String> buildStaffNotificationVars(Reservation reservation) {
+        Map<String, String> vars = new HashMap<>();
+        vars.put("confirmationNumber", reservation.getConfirmationNumber());
+        vars.put("contactName", reservation.getContactName());
+        vars.put("email", reservation.getEmail());
+        vars.put("phone", reservation.getPhoneNumber() != null ? reservation.getPhoneNumber() : "Not provided");
+        vars.put("organization", reservation.getOrganizationName() != null ? reservation.getOrganizationName() : "Not provided");
+        vars.put("eventTitle", reservation.getEventTitle());
+        vars.put("eventDate", reservation.getEventDate().format(DATE_FORMATTER));
+        vars.put("startTime", reservation.getStartTime().format(TIME_FORMATTER));
+        vars.put("endTime", reservation.getEndTime().format(TIME_FORMATTER));
+        vars.put("location", reservation.getLocation() != null ? reservation.getLocation().getDisplayName() : "No Preference");
+        vars.put("expectedGuests", String.valueOf(reservation.getExpectedGuests()));
+        vars.put("payment", reservation.getPaymentOption() != null ? reservation.getPaymentOption().getDisplayName() : "Not provided");
+
+        Set<SpecialActivity> activities = reservation.getSpecialActivities();
+        if (activities != null && !activities.isEmpty()) {
+            vars.put("specialActivities", activities.stream()
+                    .map(SpecialActivity::getDisplayName)
+                    .collect(Collectors.joining(", ")));
+        } else {
+            vars.put("specialActivities", "None");
+        }
+        vars.put("description", reservation.getDescription() != null ? reservation.getDescription() : "");
+        vars.put("comments", reservation.getComments() != null ? reservation.getComments() : "");
+        return vars;
+    }
+
+    private String resolveStatusMessage(ReservationStatus status) {
+        return switch (status) {
+            case CONFIRMED -> "We're pleased to confirm your reservation!";
+            case REJECTED -> "Unfortunately, we're unable to accommodate your reservation request at this time.";
+            case CANCELLED -> "Your reservation has been cancelled as requested.";
+            case COMPLETED -> "Thank you for choosing us! We hope you had a great event.";
+            default -> "Your reservation status has been updated.";
+        };
+    }
+
+    private String resolveStatusColor(ReservationStatus status) {
+        return switch (status) {
+            case CONFIRMED -> "#4CAF50";
+            case REJECTED, CANCELLED -> "#f44336";
+            case COMPLETED -> "#2196F3";
+            default -> "#FF9800";
+        };
+    }
+
+    private String resolveStatusSubject(ReservationStatus status) {
+        return switch (status) {
+            case CONFIRMED -> "Reservation Confirmed";
+            case REJECTED -> "Reservation Request Update";
+            case CANCELLED -> "Reservation Cancelled";
+            case COMPLETED -> "Thank You";
+            default -> "Reservation Update";
+        };
+    }
+}

--- a/the-harry-list-backend/src/main/resources/application-e2e.properties
+++ b/the-harry-list-backend/src/main/resources/application-e2e.properties
@@ -1,0 +1,36 @@
+# =====================================================================
+# e2e profile — used ONLY by the end-to-end test stack (docker-compose.e2e.yml).
+# Never active in dev or prod. Activated with SPRING_PROFILES_ACTIVE=e2e.
+#
+# Differences from the default profile:
+#   - Microsoft Graph email is OFF; the SmtpEmailService (@Profile("e2e")) sends
+#     via SMTP to a local Mailpit catcher so Playwright can assert real emails.
+#   - Schema is auto-managed (ddl-auto=update) against a throwaway MariaDB.
+#   - reCAPTCHA stays disabled so the public form can be driven headlessly.
+# =====================================================================
+
+# Database — overridable via env so the same image works in CI and locally.
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mariadb://localhost:3306/harrylist_e2e}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:harryuser}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:harrypass}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
+
+# Email — disable Graph, enable SMTP -> Mailpit.
+app.mail.enabled=false
+app.mail.from=noreply@hubble.cafe
+app.mail.staff=events@hubble.cafe
+app.bar.name=Hubble and Meteor Community Cafes
+spring.mail.host=${SPRING_MAIL_HOST:localhost}
+spring.mail.port=${SPRING_MAIL_PORT:1025}
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
+
+# Keep bots/recaptcha out of the way for headless runs.
+recaptcha.enabled=false
+
+# No external error reporting in tests.
+sentry.dsn=
+
+# Disable scheduled data-retention purging during tests.
+app.data.retention.days=0

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/config/E2eProfileGuardTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/config/E2eProfileGuardTest.java
@@ -1,0 +1,37 @@
+package com.pimvanleeuwen.the_harry_list_backend.config;
+
+import com.pimvanleeuwen.the_harry_list_backend.controller.TestSupportController;
+import com.pimvanleeuwen.the_harry_list_backend.service.SmtpEmailService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Profile;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Guards that test-support infrastructure (header auth, seed/reset endpoints, SMTP email)
+ * is gated to the {@code e2e} profile and can never load in dev or production, and that
+ * the production security config is correspondingly excluded from {@code e2e}.
+ *
+ * <p>If someone removes a {@code @Profile} gate, this fails loudly.</p>
+ */
+class E2eProfileGuardTest {
+
+    private String[] profilesOf(Class<?> type) {
+        Profile profile = type.getAnnotation(Profile.class);
+        assertNotNull(profile, type.getSimpleName() + " must be annotated with @Profile");
+        return profile.value();
+    }
+
+    @Test
+    void e2eOnlyBeansAreGatedToTheE2eProfile() {
+        assertArrayEquals(new String[]{"e2e"}, profilesOf(E2eSecurityConfig.class));
+        assertArrayEquals(new String[]{"e2e"}, profilesOf(TestSupportController.class));
+        assertArrayEquals(new String[]{"e2e"}, profilesOf(SmtpEmailService.class));
+    }
+
+    @Test
+    void productionSecurityIsExcludedFromTheE2eProfile() {
+        assertArrayEquals(new String[]{"!e2e"}, profilesOf(SecurityConfig.class));
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/SmtpEmailServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/SmtpEmailServiceTest.java
@@ -1,0 +1,107 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.EmailTemplateType;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SmtpEmailServiceTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private EmailTemplateService emailTemplateService;
+
+    private SmtpEmailService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SmtpEmailService(mailSender, emailTemplateService,
+                "noreply@test.cafe", "staff@test.cafe", "Test Bar");
+        // Return a real (empty session) MimeMessage so MimeMessageHelper can populate it.
+        lenient().when(mailSender.createMimeMessage())
+                .thenAnswer(inv -> new MimeMessage((Session) null));
+    }
+
+    private Reservation sampleReservation() {
+        Reservation r = new Reservation();
+        r.setContactName("Jane Smith");
+        r.setEmail("jane@example.com");
+        r.setConfirmationNumber("HM-2026-001");
+        r.setEventTitle("Test Event");
+        r.setEventDate(LocalDate.of(2026, 7, 15));
+        r.setStartTime(LocalTime.of(14, 0));
+        r.setEndTime(LocalTime.of(16, 0));
+        r.setExpectedGuests(20);
+        r.setStatus(ReservationStatus.CONFIRMED);
+        return r;
+    }
+
+    @Test
+    void sendStatusChangeEmail_rendersTemplateAndSendsToCustomer() throws Exception {
+        when(emailTemplateService.getRenderedSubject(eq(EmailTemplateType.STATUS_CHANGED), anyMap()))
+                .thenReturn("Reservation Confirmed");
+        when(emailTemplateService.getRenderedBody(eq(EmailTemplateType.STATUS_CHANGED), anyMap(), anyMap()))
+                .thenReturn("<p>Your reservation is confirmed.</p>");
+
+        service.sendStatusChangeEmail(sampleReservation(), "See you then!");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+
+        assertEquals("Reservation Confirmed", sent.getSubject());
+        assertEquals("jane@example.com", sent.getAllRecipients()[0].toString());
+        assertTrue(sent.getContent().toString().contains("Your reservation is confirmed."),
+                "The rendered template body must be sent as the email content");
+    }
+
+    @Test
+    void sendStatusChangeEmail_passesCustomMessageBlockToRenderer() {
+        when(emailTemplateService.getRenderedSubject(eq(EmailTemplateType.STATUS_CHANGED), anyMap()))
+                .thenReturn("Reservation Confirmed");
+        when(emailTemplateService.getRenderedBody(eq(EmailTemplateType.STATUS_CHANGED), anyMap(), anyMap()))
+                .thenReturn("<p>body</p>");
+
+        service.sendStatusChangeEmail(sampleReservation(), "A custom note");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<java.util.Map<String, String>> rawVars = ArgumentCaptor.forClass(java.util.Map.class);
+        verify(emailTemplateService).getRenderedBody(eq(EmailTemplateType.STATUS_CHANGED), anyMap(), rawVars.capture());
+        assertTrue(rawVars.getValue().get("customMessage").contains("A custom note"),
+                "The custom message must be embedded in the rendered email");
+    }
+
+    @Test
+    void sendReservationSubmittedEmail_sendsToCustomerAndStaff() {
+        when(emailTemplateService.getRenderedSubject(any(), anyMap())).thenReturn("Subject");
+        when(emailTemplateService.getRenderedBody(any(), anyMap())).thenReturn("<p>body</p>");
+
+        service.sendReservationSubmittedEmail(sampleReservation());
+
+        // One to the customer (SUBMITTED) + one to staff (STAFF_NOTIFICATION)
+        verify(mailSender, org.mockito.Mockito.times(2)).send(any(MimeMessage.class));
+    }
+}

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.55.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -325,7 +325,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
   // Notice rendered wherever a blocked period applies. Hard blocks show a red,
   // blocking error; soft blocks show an amber warning with an acknowledgement checkbox.
   const blockedDateNotice = !blockedDateInfo ? null : blockedDateInfo.soft ? (
-    <div className="mt-2 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 space-y-2">
+    <div data-testid="blocked-date-notice" data-soft="true" className="mt-2 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 space-y-2">
       <div className="flex items-start gap-2">
         <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
         <span>{blockedDateInfo.message}</span>
@@ -333,6 +333,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
       <label className={`flex items-start gap-2 cursor-pointer rounded-md p-1 -m-1 ${softBlockAckError ? 'ring-1 ring-red-500/60 bg-red-500/10' : ''}`}>
         <input
           type="checkbox"
+          data-testid="soft-block-ack"
           checked={softBlockAcknowledged}
           onChange={e => {
             setSoftBlockAcknowledged(e.target.checked);
@@ -343,11 +344,11 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
         <span className={softBlockAckError ? 'text-red-300' : undefined}>{blockedDateInfo.acknowledgementText}</span>
       </label>
       {softBlockAckError && (
-        <p className="text-red-300 font-medium">Please tick the box above to confirm before continuing.</p>
+        <p data-testid="soft-block-ack-error" className="text-red-300 font-medium">Please tick the box above to confirm before continuing.</p>
       )}
     </div>
   ) : (
-    <div className="mt-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
+    <div data-testid="blocked-date-notice" data-soft="false" className="mt-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 flex items-start gap-2">
       <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
       <span>{blockedDateInfo.message}</span>
     </div>
@@ -1012,6 +1013,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                   type="radio"
                   {...register('location')}
                   value="HUBBLE"
+                  data-testid="location-HUBBLE"
                   className="sr-only"
                   disabled={!!locationLocked && locationLocked !== 'HUBBLE'}
                 />
@@ -1049,6 +1051,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                   type="radio"
                   {...register('location')}
                   value="METEOR"
+                  data-testid="location-METEOR"
                   className="sr-only"
                   disabled={!!locationLocked && locationLocked !== 'METEOR'}
                 />
@@ -1086,6 +1089,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                   type="radio"
                   {...register('location')}
                   value=""
+                  data-testid="location-NO_PREFERENCE"
                   className="sr-only"
                   disabled={!!locationLocked}
                 />
@@ -1140,6 +1144,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                       type="radio"
                       {...register('seatingArea')}
                       value={area}
+                      data-testid={`seating-${area}`}
                       className="sr-only"
                       disabled={!!seatingLocked && area !== seatingLocked}
                     />
@@ -1392,6 +1397,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                 <input
                   type="checkbox"
                   {...register('termsAccepted')}
+                  data-testid="terms-accepted"
                   className="w-5 h-5 mt-0.5 rounded border-dark-600 bg-dark-700 text-hubble-500 focus:ring-hubble-500 focus:ring-offset-dark-900"
                 />
                 <div>
@@ -1445,6 +1451,7 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
           ) : (
             <button
               type="submit"
+              data-testid="submit-reservation"
               disabled={isSubmitting || !!optionsError}
               className="btn-secondary flex items-center gap-2"
             >


### PR DESCRIPTION
# Add end-to-end (Playwright) test suite

Adds a full end-to-end test layer that drives the real public and admin apps against a throwaway full stack and asserts on UI, database, and email, with screenshots, traces, and the actual delivered emails attached as evidence. It closes the gap between our fast unit/component tests and real user journeys.

## What's included

**E2E harness (`e2e/`)**
- Playwright config with `public`, `admin`, and `mobile-public` (Pixel 5) projects; boots the stack via `webServer`; trace on every run, plus screenshots and video on failure.
- Fixtures: a Mailpit client (read delivered email), `/test/*` seed and reset helpers, evidence attachers, and page objects for the reservation form and admin settings.
- 19 specs covering: full booking (happy path and a many-options/invoice variation), soft and hard blocked periods, form constraints (blocking, dynamic, and an admin to public round-trip), RBAC, status-change email with a custom message, editable email templates, the audit log, catering-only export (#280), the reservation lifecycle (submit, appears in admin, confirm, edit, remove), week overview, the calendar feed (.ics), and mobile date/time fields (#253).

**Test stack (`docker-compose.e2e.yml`)**
- MariaDB (tmpfs, clean each boot), the backend on the `e2e` Spring profile, Mailpit, and the built frontends.

**Backend test infrastructure (all gated to `@Profile("e2e")`, never loaded in dev or prod)**
- `SmtpEmailService`: sends via SMTP to Mailpit, reusing the production editable templates.
- `E2eSecurityConfig`: header-based test auth (`X-Test-*`) that reuses the real `RoleAuthorizationFilter` for genuine RBAC and audit behavior; the production `SecurityConfig` is scoped to `!e2e`.
- `TestSupportController`: `/test/reset`, `/test/users`, `/test/blocked-periods`, `/test/constraints`, `/test/reservations`.
- `E2eProfileGuardTest` fails the build if any of these gates are removed.

**App changes**
- `data-testid` hooks across the public form and admin pages (form settings, export, reservations list and detail). These are behavior-inert.
- Admin app: an env-gated e2e auth bridge (`lib/e2eAuth.ts`) that uses `X-Test-*` headers only when `E2E_AUTH_OID` is injected by the e2e stack, and is inert otherwise.
- A `spring-boot-starter-mail` dependency, used only by the e2e SMTP service and inert in production.

**CI**
- `.github/workflows/e2e.yml` runs the suite on PRs to `main` and on demand, uploads the HTML report plus traces, screenshots, and videos, and dumps backend logs on failure.

**Docs**
- A comprehensive `e2e/README.md` (architecture, evidence, maintenance playbook, regression coverage map), a Testing section in the root README, and an e2e note in CLAUDE.md.

## Safety and production impact

None. All test infrastructure is gated to the `e2e` Spring profile (verified by `E2eProfileGuardTest`) or to a runtime flag that only the e2e stack sets. Production keeps real Azure JWT auth and Microsoft Graph email. There are no database schema or API contract changes, and the new Maven dependency is inert without `spring.mail.host`.

## Testing

- Backend: 303 tests pass (including the new SMTP and profile-guard tests).
- Admin: 104 and Public: 94 component tests pass.
- E2E: 19 of 19 specs pass against the stack.

```bash
cd e2e && npm install && npx playwright install --with-deps chromium && npm test
```