### PR TITLE
Release v1.5.1

### DIFF
--- a/e2e/tests/admin/rbac.spec.ts
+++ b/e2e/tests/admin/rbac.spec.ts
@@ -48,4 +48,28 @@ test.describe('admin: RBAC is enforced by the backend', () => {
     expect(viewerWrite.status()).toBe(403); // viewers cannot mutate
     expect(editorWrite.status(), `editor create response: ${editorWriteBody}`).toBe(201); // editors can
   });
+
+  test('an EDITOR can manage catering email PDF attachments; a VIEWER cannot', async ({ request }, testInfo) => {
+    const upload = (oid: string) =>
+      request.post(`${BACKEND_URL}/api/admin/email-attachments`, {
+        headers: adminAuthHeaders(oid),
+        multipart: {
+          name: 'RBAC Catering Menu',
+          file: { name: 'menu.pdf', mimeType: 'application/pdf', buffer: Buffer.from('%PDF-1.4 rbac probe') },
+        },
+      });
+
+    const viewerUpload = await upload('e2e-viewer');
+    const editorUpload = await upload('e2e-editor');
+    const editorUploadBody = await editorUpload.text();
+
+    await attachJson(testInfo, 'rbac-attachment-results.json', {
+      viewerUpload: viewerUpload.status(),
+      editorUpload: editorUpload.status(),
+      editorUploadBody,
+    });
+
+    expect(viewerUpload.status()).toBe(403); // viewers cannot upload attachments
+    expect(editorUpload.status(), `editor upload response: ${editorUploadBody}`).toBe(200); // editors can
+  });
 });

--- a/e2e/tests/admin/reservation-lifecycle.spec.ts
+++ b/e2e/tests/admin/reservation-lifecycle.spec.ts
@@ -83,6 +83,11 @@ test.describe('admin: reservation lifecycle', () => {
 
     // Edit the guest count.
     await page.getByTestId('edit-reservation').click();
+    // The "send update email" notification defaults to OFF — editing should be silent
+    // unless the editor explicitly opts in.
+    await expect(
+      page.getByRole('checkbox', { name: /send email notification about changes/i })
+    ).not.toBeChecked();
     await page.getByTestId('edit-guests').fill('137');
     await page.getByTestId('edit-save').click();
     await expect(page.getByTestId('edit-save')).toHaveCount(0); // edit mode closed

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@azure/msal-browser": "^5.11.0",
         "@azure/msal-react": "^5.4.2",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/components/Layout.tsx
+++ b/the-harry-list-admin/src/components/Layout.tsx
@@ -15,7 +15,7 @@ export function Layout() {
   const { instance, accounts } = useMsal();
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { canEditEmailTemplates, canEditFormSettings, canViewAuditLog } = usePermissions();
+  const { canEditEmailTemplates, canManageAttachments, canEditFormSettings, canViewAuditLog } = usePermissions();
   const { role } = useRole();
 
   const user = accounts[0];
@@ -37,7 +37,7 @@ export function Layout() {
     { to: '/export', icon: FileDown, label: 'Export' },
     { to: '/calendar', icon: CalendarSync, label: 'Calendar Feeds' },
     { to: '/calendar-appointments', icon: CalendarPlus, label: 'Appointments' },
-    ...(canEditEmailTemplates ? [{ to: '/email-templates', icon: Mail, label: 'Email Templates' }] : []),
+    ...((canEditEmailTemplates || canManageAttachments) ? [{ to: '/email-templates', icon: Mail, label: canEditEmailTemplates ? 'Email Templates' : 'Email Attachments' }] : []),
     ...(canViewAuditLog ? [{ to: '/audit', icon: History, label: 'Audit Log' }] : []),
     ...(canEditFormSettings ? [{ to: '/settings', icon: Settings, label: 'Settings' }] : []),
   ];

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -439,7 +439,7 @@ The available actions depend on the current status:
 - **Delete** — permanently remove (with confirmation dialog)
 
 ### Email Notifications
-Each status change dialog (and the edit form) has a **"Send email notification"** checkbox. Keep this checked to automatically notify the customer. Uncheck it only if you've already communicated with them directly.
+Each status change dialog (and the edit form) has a **"Send email notification"** checkbox. For status changes it is **on** by default — uncheck it only if you've already communicated with the customer directly. For the **edit form** it is **off** by default, since most edits are internal tweaks; tick it when a change is worth notifying the customer about.
 
 ### Adding a Message to the Email
 When the email notification is on, every status dialog and the edit form shows an optional **"Add a message to the email"** box. Anything you type here appears as a highlighted note in that email — use it to clarify things the standard template doesn't cover, e.g. *"We read your special request and will keep a shaded spot for you."* For **Reject**, this box is pre-filled with a default reason that you can edit, replace, or clear before sending.`,

--- a/the-harry-list-admin/src/pages/EmailTemplatesPage.tsx
+++ b/the-harry-list-admin/src/pages/EmailTemplatesPage.tsx
@@ -4,6 +4,7 @@ import { fetchWithAuth, fetchEmailAttachments, uploadEmailAttachment, deleteEmai
 import type { EmailAttachment } from '../types/reservation';
 import { HelpGuide } from '../components/HelpGuide';
 import { emailTemplatesGuide } from '../lib/guideContent';
+import { usePermissions } from '../lib/usePermissions';
 
 interface EmailTemplateDto {
   templateType: string;
@@ -17,8 +18,12 @@ interface EmailTemplateDto {
 }
 
 export function EmailTemplatesPage() {
+  // Editors may manage PDF attachments but only admins can edit the templates
+  // themselves (the template PUT/DELETE/test endpoints require ADMIN).
+  const { canEditEmailTemplates, canManageAttachments } = usePermissions();
+
   const [templates, setTemplates] = useState<EmailTemplateDto[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(canEditEmailTemplates);
   const [error, setError] = useState<string | null>(null);
   const [expandedType, setExpandedType] = useState<string | null>(null);
   const [editSubject, setEditSubject] = useState('');
@@ -39,9 +44,10 @@ export function EmailTemplatesPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    loadTemplates();
-    loadAttachments();
-  }, []);
+    // Only admins load/see the templates; editors get the attachments only.
+    if (canEditEmailTemplates) loadTemplates();
+    if (canManageAttachments) loadAttachments();
+  }, [canEditEmailTemplates, canManageAttachments]);
 
   async function loadTemplates() {
     try {
@@ -205,20 +211,27 @@ export function EmailTemplatesPage() {
       <div className="flex items-start justify-between">
         <div>
           <h1 className="text-2xl font-title font-bold text-white">Email Templates</h1>
-          <p className="text-dark-400 font-light">Customise the emails sent to customers and staff</p>
+          <p className="text-dark-400 font-light">
+            {canEditEmailTemplates
+              ? 'Customise the emails sent to customers and staff'
+              : 'Manage the PDF attachments used in catering option emails'}
+          </p>
         </div>
-        <HelpGuide title="Email Templates Guide" sections={emailTemplatesGuide} />
+        {canEditEmailTemplates && <HelpGuide title="Email Templates Guide" sections={emailTemplatesGuide} />}
       </div>
 
       {/* Info card */}
+      {canEditEmailTemplates && (
       <div className="bg-dark-900 border border-dark-800 rounded-2xl p-5">
         <p className="text-sm text-dark-300">
           Use <code className="bg-dark-800 text-hubble-400 px-1.5 py-0.5 rounded font-mono text-xs">{'{{variable}}'}</code> placeholders in your templates.
           Available variables are listed per template. Templates not yet customised use the built-in default.
         </p>
       </div>
+      )}
 
       {/* Template cards */}
+      {canEditEmailTemplates && (
       <div className="space-y-3">
         {templates.map((template) => {
           const isExpanded = expandedType === template.templateType;
@@ -374,8 +387,10 @@ export function EmailTemplatesPage() {
           );
         })}
       </div>
+      )}
 
       {/* PDF Attachments section */}
+      {canManageAttachments && (
       <div>
         <h2 className="text-xl font-title font-bold text-white mb-1">PDF Attachments</h2>
         <p className="text-dark-400 font-light text-sm mb-4">Manage PDF files that can be attached to catering option emails</p>
@@ -460,6 +475,7 @@ export function EmailTemplatesPage() {
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -74,7 +74,7 @@ export function ReservationDetailPage() {
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [editData, setEditData] = useState<Partial<Reservation>>({});
-  const [sendEditEmail, setSendEditEmail] = useState(true);
+  const [sendEditEmail, setSendEditEmail] = useState(false);
   // Optional free-text message added to the "reservation updated" email.
   const [editMessage, setEditMessage] = useState('');
 

--- a/the-harry-list-admin/src/test/EmailTemplatesPage.test.tsx
+++ b/the-harry-list-admin/src/test/EmailTemplatesPage.test.tsx
@@ -5,13 +5,15 @@ import { EmailTemplatesPage } from '../pages/EmailTemplatesPage';
 
 // Hoist mocks so vi.mock factory can access them
 const { mockFetchWithAuth, mockFetchEmailAttachments, mockUploadEmailAttachment,
-  mockDeleteEmailAttachment, mockToggleEmailAttachmentActive } = vi.hoisted(() => {
+  mockDeleteEmailAttachment, mockToggleEmailAttachmentActive, mockPermissions } = vi.hoisted(() => {
   return {
     mockFetchWithAuth: vi.fn(),
     mockFetchEmailAttachments: vi.fn(),
     mockUploadEmailAttachment: vi.fn(),
     mockDeleteEmailAttachment: vi.fn(),
     mockToggleEmailAttachmentActive: vi.fn(),
+    // Defaults to admin (both true); individual tests override for the editor view.
+    mockPermissions: { canEditEmailTemplates: true, canManageAttachments: true },
   };
 });
 
@@ -21,6 +23,10 @@ vi.mock('../lib/api', () => ({
   uploadEmailAttachment: mockUploadEmailAttachment,
   deleteEmailAttachment: mockDeleteEmailAttachment,
   toggleEmailAttachmentActive: mockToggleEmailAttachmentActive,
+}));
+
+vi.mock('../lib/usePermissions', () => ({
+  usePermissions: () => mockPermissions,
 }));
 
 const sampleTemplates = [
@@ -52,6 +58,9 @@ function renderPage() {
 describe('EmailTemplatesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset to the admin view; editor-specific tests override below.
+    mockPermissions.canEditEmailTemplates = true;
+    mockPermissions.canManageAttachments = true;
     mockFetchWithAuth.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(sampleTemplates),
@@ -156,6 +165,27 @@ describe('EmailTemplatesPage', () => {
     renderPage();
     await waitFor(() => {
       expect(screen.getByText('Reservation Submitted')).toBeDefined();
+    });
+  });
+
+  describe('editor (attachments only)', () => {
+    beforeEach(() => {
+      mockPermissions.canEditEmailTemplates = false;
+      mockPermissions.canManageAttachments = true;
+    });
+
+    it('lets editors manage PDF attachments without loading the templates', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('PDF Attachments')).toBeDefined();
+        expect(screen.getByText('Catering Menu')).toBeDefined();
+      });
+
+      // The template-editing UI is hidden and never fetched for editors.
+      expect(screen.queryByText('Reservation Submitted')).toBeNull();
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+      expect(mockFetchEmailAttachments).toHaveBeenCalledOnce();
     });
   });
 });

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -57,7 +57,7 @@ vi.mock('../lib/api', () => ({
   sendCateringEmail: vi.fn(),
 }));
 
-import { fetchReservationAuditLog, fetchReservation, updateReservationStatus } from '../lib/api';
+import { fetchReservationAuditLog, fetchReservation, updateReservationStatus, updateReservation } from '../lib/api';
 
 const DEFAULT_REJECTION_MESSAGE =
   'Unfortunately we cannot host you since we do not have any places left at this time';
@@ -160,5 +160,37 @@ describe('ReservationDetailPage — custom email message', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }));
 
     expect(screen.queryByPlaceholderText(/shaded spot/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('ReservationDetailPage — edit email default', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults the "send update email" checkbox to off when editing', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('edit-reservation')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByTestId('edit-reservation'));
+
+    const sendEmailCheckbox = await screen.findByRole('checkbox', {
+      name: /send email notification about changes/i,
+    });
+    expect(sendEmailCheckbox).not.toBeChecked();
+  });
+
+  it('saves an edit with sendEmail=false unless the box is ticked', async () => {
+    vi.mocked(updateReservation).mockResolvedValueOnce(sampleReservation);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('edit-reservation')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByTestId('edit-reservation'));
+    await screen.findByTestId('edit-save');
+    fireEvent.click(screen.getByTestId('edit-save'));
+
+    await waitFor(() =>
+      expect(updateReservation).toHaveBeenCalledWith(1, expect.any(Object), false, undefined));
   });
 });

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.5.0</version>
+	<version>1.5.1</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.55.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v1.5.1

Patch release with two small fixes to the admin portal.

### Edit reservation: update email now defaults to off

When editing a reservation, the "Send email notification about changes" checkbox previously started checked, so routine internal edits emailed thecustomer unless you remembered to untick it. It now starts unchecked. Tick it explicitly when a change is worth notifying the customer about.

Status changes (confirm, reject, cancel) and deletion are unaffected and keep their email-on default.

### Editors can manage catering email PDF attachments

The PDF Attachments manager lived on the admin-only Email Templates page, so editors could not reach it even though the backend already authorised them to upload attachments.

Editors now see an "Email Attachments" entry in the navigation that opens the same page showing only the PDF Attachments section. The template editing UI stays admin-only. Admins continue to see the full Email Templates page as before.

All existing tests pass, lint is clean, and the admin build succeeds.