### PR TITLE
feat: more recurring date options

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -151,6 +151,7 @@ faster layers.
 | Catering-only export (#280) | — | `PdfExportServiceTest` | `admin/catering-export` |
 | Week overview | `WeekOverviewPage` test | — | `admin/week-overview` |
 | Calendar feeds (iCal) | — | `ICalendarServiceTest` | `public/calendar-feed` |
+| Recurring appointments (incl. "Nth weekday", #286) | `recurrence` + `CalendarAppointmentsPage` tests | `ICalendarServiceTest` | `admin/calendar-appointments` |
 | Mobile date/time fields (#253) | — | — | `mobile-public/datetime` |
 
 ## CI

--- a/e2e/pages/CalendarAppointmentsPage.ts
+++ b/e2e/pages/CalendarAppointmentsPage.ts
@@ -1,0 +1,60 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page object for the admin Calendar Appointments page (custom calendar entries
+ * that appear in the ICS feeds). Centralizes selectors for the guided recurrence
+ * builder so feature changes touch this file, not every spec.
+ */
+export class CalendarAppointmentsPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/calendar-appointments');
+    // Heading specifically — the text also appears in the nav.
+    await expect(this.page.getByRole('heading', { name: 'Calendar Appointments' })).toBeVisible();
+  }
+
+  rows(): Locator {
+    return this.page.getByTestId('appointment-row');
+  }
+
+  recurrenceBadge(): Locator {
+    return this.page.getByTestId('appointment-recurrence');
+  }
+
+  /**
+   * Create an all-day appointment that recurs on the Nth weekday of the month
+   * (e.g. "every 2nd Friday") through the guided builder.
+   */
+  async createNthWeekdayAppointment(opts: {
+    title: string;
+    date: string;       // yyyy-mm-dd, should fall on the chosen weekday
+    week: number;       // 1–4, or -1 for "last"
+    weekday: string;    // DayOfWeek name, e.g. 'FRIDAY'
+    interval?: number;  // every N months (default 1)
+    endDate?: string;   // optional recurrence end
+  }): Promise<void> {
+    await this.page.getByTestId('add-appointment').click();
+    await expect(this.page.getByText('New Appointment')).toBeVisible();
+
+    await this.page.getByTestId('appointment-title').fill(opts.title);
+    await this.page.getByTestId('appointment-date').fill(opts.date);
+    // All-day, so start/end times are not required to enable the save button.
+    await this.page.getByTestId('appointment-allday-toggle').click();
+
+    await this.page.getByTestId('appointment-frequency').selectOption('MONTHLY');
+    await this.page.getByTestId('monthly-mode-nth').check();
+    await this.page.getByLabel('Week of month').selectOption(String(opts.week));
+    await this.page.getByLabel('Day of week').selectOption(opts.weekday);
+
+    if (opts.interval && opts.interval > 1) {
+      await this.page.getByLabel('Repeat interval').fill(String(opts.interval));
+    }
+    if (opts.endDate) {
+      // The recurrence end date is the second date input in the modal.
+      await this.page.locator('input[type="date"]').nth(1).fill(opts.endDate);
+    }
+
+    await this.page.getByTestId('save-appointment').click();
+  }
+}

--- a/e2e/tests/admin/calendar-appointments.spec.ts
+++ b/e2e/tests/admin/calendar-appointments.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { CalendarAppointmentsPage } from '../../pages/CalendarAppointmentsPage';
+import { resetBackend, seedUser } from '../../fixtures/backend';
+import { attachText, captureScreenshot } from '../../fixtures/evidence';
+import { BACKEND_URL } from '../../playwright.config';
+
+/**
+ * Admin can configure a generic recurring appointment — "every 2nd Friday of the
+ * month" (#286) — through the guided builder, and the backend emits the correct
+ * RFC 5545 RRULE (BYDAY=2FR) in the public iCal feed. This exercises the wiring
+ * from the new UI through persistence to ICS generation in one journey.
+ */
+const FEED_TOKEN = 'e2e-feed-token';
+
+test.describe('admin: recurring calendar appointments', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', email: 'admin@e2e.test', role: 'ADMIN' });
+  });
+
+  test('creates an "every 2nd Friday" appointment and emits BYDAY=2FR in the feed', async ({ page, request }, testInfo) => {
+    const appointments = new CalendarAppointmentsPage(page);
+    await appointments.goto();
+
+    await appointments.createNthWeekdayAppointment({
+      title: 'Second Friday Drinks',
+      date: '2030-01-11', // the 2nd Friday of January 2030
+      week: 2,
+      weekday: 'FRIDAY',
+    });
+
+    // Appears in the list with a descriptive recurrence summary badge.
+    await expect(appointments.rows()).toHaveCount(1);
+    await expect(appointments.recurrenceBadge()).toHaveText('Every 2nd Friday');
+    await captureScreenshot(testInfo, page, '1-nth-weekday-created');
+
+    // End-to-end wiring: the backend renders the right RRULE in the public iCal feed.
+    const feed = await request.get(`${BACKEND_URL}/api/calendar/feed.ics?token=${FEED_TOKEN}`);
+    expect(feed.status()).toBe(200);
+    const ics = await feed.text();
+    await attachText(testInfo, 'feed.ics', ics);
+    expect(ics).toContain('Second Friday Drinks');
+    expect(ics).toContain('RRULE:FREQ=MONTHLY;BYDAY=2FR');
+  });
+});

--- a/the-harry-list-admin/src/lib/recurrence.ts
+++ b/the-harry-list-admin/src/lib/recurrence.ts
@@ -88,6 +88,18 @@ export function nthWeekdayOfMonth(
   return result.getMonth() === monthIndex ? result : null;
 }
 
+/**
+ * Derives a sensible "Nth weekday" default from a concrete date, e.g. 2026-06-12
+ * (the 2nd Friday) → { week: 2, day: 'FRIDAY' }. A 5th occurrence collapses to
+ * "last" (-1). Used to pre-fill the guided builder when switching to that mode.
+ */
+export function nthWeekdayFromDate(dateStr: string): { week: number; day: DayOfWeek } {
+  const d = parseDate(dateStr);
+  const week = Math.ceil(d.getDate() / 7);
+  const day = WEEKDAYS.find(w => w.jsDay === d.getDay())!.value;
+  return { week: week > 4 ? -1 : week, day };
+}
+
 /** Resolves the effective "every N" interval, defaulting to 1. */
 export function effectiveInterval(appointment: CalendarAppointment): number {
   const i = appointment.recurrenceInterval;

--- a/the-harry-list-admin/src/lib/recurrence.ts
+++ b/the-harry-list-admin/src/lib/recurrence.ts
@@ -38,8 +38,8 @@ export const WEEK_OF_MONTH_OPTIONS: { value: number; label: string; ordinal: str
   { value: -1, label: 'Last', ordinal: 'last' },
 ];
 
-// Frequency picker for the guided builder. Note BIWEEKLY is intentionally absent:
-// it is represented as WEEKLY with interval 2 (see normalizeForEditing).
+// Frequency picker for the guided builder. "Every 2 weeks" is expressed as
+// WEEKLY with interval 2 rather than a dedicated option.
 export const FREQUENCY_OPTIONS: { value: RecurrenceType; label: string; unitLabel: string }[] = [
   { value: 'NONE', label: 'Does not repeat', unitLabel: '' },
   { value: 'DAILY', label: 'Daily', unitLabel: 'day' },
@@ -151,13 +151,10 @@ function expandInterval(
   const interval = effectiveInterval(appointment);
   const type = appointment.recurrenceType;
 
-  // BIWEEKLY is the legacy shorthand for "every 2 weeks"; its 14-day step bakes
-  // that in, so a stored interval (typically 1) is not double-counted.
   const advance = (d: Date) => {
     switch (type) {
       case 'DAILY': d.setDate(d.getDate() + interval); break;
       case 'WEEKLY': d.setDate(d.getDate() + 7 * interval); break;
-      case 'BIWEEKLY': d.setDate(d.getDate() + 14 * interval); break;
       case 'MONTHLY': d.setMonth(d.getMonth() + interval); break;
       case 'YEARLY': d.setFullYear(d.getFullYear() + interval); break;
     }
@@ -225,7 +222,7 @@ function expandNthWeekday(
 
 /**
  * Human-readable summary of an appointment's recurrence, e.g. "Every 2nd Friday",
- * "Every 3 weeks", "Weekly", "Bi-weekly". Used for list/calendar badges.
+ * "Every 3 weeks", "Weekly". Used for list/calendar badges.
  */
 export function recurrenceSummary(appointment: CalendarAppointment): string {
   const type = appointment.recurrenceType;
@@ -239,8 +236,6 @@ export function recurrenceSummary(appointment: CalendarAppointment): string {
     const base = `${ordinalFor(week)} ${weekdayLabel(day)}`;
     return interval > 1 ? `Every ${interval} months on the ${base}` : `Every ${base}`;
   }
-
-  if (type === 'BIWEEKLY') return 'Bi-weekly';
 
   const unit = FREQUENCY_OPTIONS.find(o => o.value === type)?.unitLabel ?? '';
   if (interval > 1) return `Every ${interval} ${unit}s`;

--- a/the-harry-list-admin/src/lib/recurrence.ts
+++ b/the-harry-list-admin/src/lib/recurrence.ts
@@ -1,0 +1,243 @@
+import type { CalendarAppointment, DayOfWeek, RecurrenceType } from '../types/reservation';
+
+/**
+ * Single source of truth for recurrence semantics on the admin frontend.
+ *
+ * Mirrors the backend's structured recurrence model (see RecurrenceType.java /
+ * ICalendarService.buildRecurrenceRule): a frequency family plus optional
+ * "every N" interval and, for MONTHLY_NTH_WEEKDAY, an ordinal week + weekday.
+ *
+ * New recurrence patterns should be added here (option metadata + expander)
+ * and in the backend RRULE mapper — not scattered across pages.
+ */
+
+// ── Weekday metadata ──────────────────────────────────────────────────────────
+// DayOfWeek values match the backend (java.time.DayOfWeek names). jsDay is the
+// index returned by Date.getDay() (0 = Sunday … 6 = Saturday).
+export const WEEKDAYS: { value: DayOfWeek; label: string; jsDay: number }[] = [
+  { value: 'MONDAY', label: 'Monday', jsDay: 1 },
+  { value: 'TUESDAY', label: 'Tuesday', jsDay: 2 },
+  { value: 'WEDNESDAY', label: 'Wednesday', jsDay: 3 },
+  { value: 'THURSDAY', label: 'Thursday', jsDay: 4 },
+  { value: 'FRIDAY', label: 'Friday', jsDay: 5 },
+  { value: 'SATURDAY', label: 'Saturday', jsDay: 6 },
+  { value: 'SUNDAY', label: 'Sunday', jsDay: 0 },
+];
+
+const JS_DAY_BY_WEEKDAY: Record<DayOfWeek, number> = WEEKDAYS.reduce(
+  (acc, w) => ({ ...acc, [w.value]: w.jsDay }),
+  {} as Record<DayOfWeek, number>,
+);
+
+// Ordinal options for "on the Nth <weekday>" (-1 = last).
+export const WEEK_OF_MONTH_OPTIONS: { value: number; label: string; ordinal: string }[] = [
+  { value: 1, label: 'First', ordinal: '1st' },
+  { value: 2, label: 'Second', ordinal: '2nd' },
+  { value: 3, label: 'Third', ordinal: '3rd' },
+  { value: 4, label: 'Fourth', ordinal: '4th' },
+  { value: -1, label: 'Last', ordinal: 'last' },
+];
+
+// Frequency picker for the guided builder. Note BIWEEKLY is intentionally absent:
+// it is represented as WEEKLY with interval 2 (see normalizeForEditing).
+export const FREQUENCY_OPTIONS: { value: RecurrenceType; label: string; unitLabel: string }[] = [
+  { value: 'NONE', label: 'Does not repeat', unitLabel: '' },
+  { value: 'DAILY', label: 'Daily', unitLabel: 'day' },
+  { value: 'WEEKLY', label: 'Weekly', unitLabel: 'week' },
+  { value: 'MONTHLY', label: 'Monthly', unitLabel: 'month' },
+  { value: 'YEARLY', label: 'Yearly', unitLabel: 'year' },
+];
+
+// ── Date helpers (local-time, yyyy-mm-dd) ─────────────────────────────────────
+export function toDateString(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+export function parseDate(dateStr: string): Date {
+  return new Date(dateStr + 'T00:00:00');
+}
+
+const ordinalFor = (week: number) =>
+  WEEK_OF_MONTH_OPTIONS.find(o => o.value === week)?.ordinal ?? `${week}`;
+
+const weekdayLabel = (day: DayOfWeek) =>
+  WEEKDAYS.find(w => w.value === day)?.label ?? day;
+
+/**
+ * Computes the date of the Nth weekday of a given month, e.g. the 2nd Friday.
+ * Returns null when the occurrence does not exist (e.g. a 5th Friday in a month
+ * that only has four). week: 1–4 = first–fourth, -1 = last.
+ */
+export function nthWeekdayOfMonth(
+  year: number,
+  monthIndex: number, // 0-based
+  week: number,
+  jsDay: number,
+): Date | null {
+  if (week === -1) {
+    const lastDay = new Date(year, monthIndex + 1, 0); // last day of month
+    const offset = (lastDay.getDay() - jsDay + 7) % 7;
+    lastDay.setDate(lastDay.getDate() - offset);
+    return lastDay;
+  }
+  const first = new Date(year, monthIndex, 1);
+  const firstOffset = (jsDay - first.getDay() + 7) % 7;
+  const day = 1 + firstOffset + (week - 1) * 7;
+  const result = new Date(year, monthIndex, day);
+  // If we overflowed into the next month, the Nth weekday doesn't exist.
+  return result.getMonth() === monthIndex ? result : null;
+}
+
+/** Resolves the effective "every N" interval, defaulting to 1. */
+export function effectiveInterval(appointment: CalendarAppointment): number {
+  const i = appointment.recurrenceInterval;
+  return i != null && i > 0 ? i : 1;
+}
+
+/**
+ * Expands an appointment into the concrete dates (yyyy-mm-dd) it occurs on within
+ * the inclusive [rangeStart, rangeEnd] window. Honors the appointment's start date
+ * and optional recurrenceEndDate. Does NOT filter on `enabled`/location — callers
+ * decide visibility. Returns sorted, unique date strings.
+ */
+export function expandOccurrences(
+  appointment: CalendarAppointment,
+  rangeStart: string,
+  rangeEnd: string,
+): string[] {
+  const start = parseDate(appointment.date);
+  const windowStart = parseDate(rangeStart);
+  const windowEnd = parseDate(rangeEnd);
+  const end = appointment.recurrenceEndDate ? parseDate(appointment.recurrenceEndDate) : null;
+
+  // The latest date worth considering is the earlier of the window end and the
+  // recurrence end date.
+  const hardEnd = end && end < windowEnd ? end : windowEnd;
+  if (hardEnd < start) return [];
+
+  const type = appointment.recurrenceType;
+
+  if (type === 'NONE') {
+    return start >= windowStart && start <= hardEnd ? [appointment.date] : [];
+  }
+
+  if (type === 'MONTHLY_NTH_WEEKDAY') {
+    return expandNthWeekday(appointment, start, windowStart, hardEnd);
+  }
+
+  return expandInterval(appointment, start, windowStart, hardEnd);
+}
+
+const MAX_ITERATIONS = 1000;
+
+function expandInterval(
+  appointment: CalendarAppointment,
+  start: Date,
+  windowStart: Date,
+  hardEnd: Date,
+): string[] {
+  const interval = effectiveInterval(appointment);
+  const type = appointment.recurrenceType;
+
+  // BIWEEKLY is the legacy shorthand for "every 2 weeks"; its 14-day step bakes
+  // that in, so a stored interval (typically 1) is not double-counted.
+  const advance = (d: Date) => {
+    switch (type) {
+      case 'DAILY': d.setDate(d.getDate() + interval); break;
+      case 'WEEKLY': d.setDate(d.getDate() + 7 * interval); break;
+      case 'BIWEEKLY': d.setDate(d.getDate() + 14 * interval); break;
+      case 'MONTHLY': d.setMonth(d.getMonth() + interval); break;
+      case 'YEARLY': d.setFullYear(d.getFullYear() + interval); break;
+    }
+  };
+
+  const dates: string[] = [];
+  const current = new Date(start);
+  let iterations = 0;
+
+  // Fast-forward up to the window start.
+  while (current < windowStart && iterations < MAX_ITERATIONS) {
+    advance(current);
+    iterations++;
+  }
+
+  while (current <= hardEnd && iterations < MAX_ITERATIONS) {
+    if (current >= start && current >= windowStart) {
+      dates.push(toDateString(current));
+    }
+    advance(current);
+    iterations++;
+  }
+
+  return dates;
+}
+
+function expandNthWeekday(
+  appointment: CalendarAppointment,
+  start: Date,
+  windowStart: Date,
+  hardEnd: Date,
+): string[] {
+  const week = appointment.recurrenceWeekOfMonth;
+  const day = appointment.recurrenceDayOfWeek;
+  if (week == null || day == null) return [];
+  const jsDay = JS_DAY_BY_WEEKDAY[day];
+  const interval = effectiveInterval(appointment);
+
+  const dates: string[] = [];
+  // Walk months from the start month. Interval applies to month count since start.
+  let year = start.getFullYear();
+  let month = start.getMonth();
+  let monthsSinceStart = 0;
+  let iterations = 0;
+
+  while (iterations < MAX_ITERATIONS) {
+    const cursorMonthStart = new Date(year, month, 1);
+    if (cursorMonthStart > hardEnd) break;
+
+    if (monthsSinceStart % interval === 0) {
+      const occurrence = nthWeekdayOfMonth(year, month, week, jsDay);
+      if (occurrence && occurrence >= start && occurrence >= windowStart && occurrence <= hardEnd) {
+        dates.push(toDateString(occurrence));
+      }
+    }
+
+    month++;
+    if (month > 11) { month = 0; year++; }
+    monthsSinceStart++;
+    iterations++;
+  }
+
+  return dates;
+}
+
+/**
+ * Human-readable summary of an appointment's recurrence, e.g. "Every 2nd Friday",
+ * "Every 3 weeks", "Weekly", "Bi-weekly". Used for list/calendar badges.
+ */
+export function recurrenceSummary(appointment: CalendarAppointment): string {
+  const type = appointment.recurrenceType;
+  if (type === 'NONE') return '';
+  const interval = effectiveInterval(appointment);
+
+  if (type === 'MONTHLY_NTH_WEEKDAY') {
+    const week = appointment.recurrenceWeekOfMonth;
+    const day = appointment.recurrenceDayOfWeek;
+    if (week == null || day == null) return 'Monthly';
+    const base = `${ordinalFor(week)} ${weekdayLabel(day)}`;
+    return interval > 1 ? `Every ${interval} months on the ${base}` : `Every ${base}`;
+  }
+
+  if (type === 'BIWEEKLY') return 'Bi-weekly';
+
+  const unit = FREQUENCY_OPTIONS.find(o => o.value === type)?.unitLabel ?? '';
+  if (interval > 1) return `Every ${interval} ${unit}s`;
+  // interval === 1 → use the friendly frequency name
+  switch (type) {
+    case 'DAILY': return 'Daily';
+    case 'WEEKLY': return 'Weekly';
+    case 'MONTHLY': return 'Monthly';
+    case 'YEARLY': return 'Yearly';
+    default: return type;
+  }
+}

--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -7,26 +7,46 @@ import {
   fetchCalendarAppointments, createCalendarAppointment, updateCalendarAppointment,
   toggleCalendarAppointment, deleteCalendarAppointment,
 } from '../lib/api';
-import type { CalendarAppointment, RecurrenceType } from '../types/reservation';
+import type { CalendarAppointment, RecurrenceType, DayOfWeek } from '../types/reservation';
 import { usePermissions } from '../lib/usePermissions';
 import { ConfirmDialog } from '../components/ConfirmDialog';
+import {
+  FREQUENCY_OPTIONS, WEEK_OF_MONTH_OPTIONS, WEEKDAYS,
+  recurrenceSummary, nthWeekdayFromDate,
+} from '../lib/recurrence';
 
-const RECURRENCE_OPTIONS: { value: RecurrenceType; label: string }[] = [
-  { value: 'NONE', label: 'None' },
-  { value: 'DAILY', label: 'Daily' },
-  { value: 'WEEKLY', label: 'Weekly' },
-  { value: 'BIWEEKLY', label: 'Bi-weekly' },
-  { value: 'MONTHLY', label: 'Monthly' },
-  { value: 'YEARLY', label: 'Yearly' },
-];
+/** The frequency family shown in the builder (BIWEEKLY/nth-weekday are derived detail). */
+type Frequency = 'NONE' | 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
 
-const RECURRENCE_LABELS: Record<string, string> = {
-  DAILY: 'Daily',
-  WEEKLY: 'Weekly',
-  BIWEEKLY: 'Bi-weekly',
-  MONTHLY: 'Monthly',
-  YEARLY: 'Yearly',
-};
+/** Maps a stored recurrence type to the frequency option the builder displays. */
+function frequencyOf(type: RecurrenceType): Frequency {
+  switch (type) {
+    case 'DAILY': return 'DAILY';
+    case 'WEEKLY':
+    case 'BIWEEKLY': return 'WEEKLY';
+    case 'MONTHLY':
+    case 'MONTHLY_NTH_WEEKDAY': return 'MONTHLY';
+    case 'YEARLY': return 'YEARLY';
+    default: return 'NONE';
+  }
+}
+
+/** Singular noun for the interval unit of a frequency. */
+function unitNoun(freq: Frequency): string {
+  return FREQUENCY_OPTIONS.find(o => o.value === freq)?.unitLabel ?? '';
+}
+
+/**
+ * Normalizes an appointment for editing in the guided builder. Legacy BIWEEKLY
+ * records are presented as "Weekly, every 2 weeks" — an equivalent representation
+ * that round-trips to the same RRULE — and the interval defaults to 1.
+ */
+function normalizeForEditing(a: CalendarAppointment): CalendarAppointment {
+  if (a.recurrenceType === 'BIWEEKLY') {
+    return { ...a, recurrenceType: 'WEEKLY', recurrenceInterval: 2 };
+  }
+  return { ...a, recurrenceInterval: a.recurrenceInterval ?? 1 };
+}
 
 const emptyAppointment: CalendarAppointment = {
   title: '',
@@ -37,6 +57,7 @@ const emptyAppointment: CalendarAppointment = {
   endTime: '',
   location: 'HUBBLE',
   recurrenceType: 'NONE',
+  recurrenceInterval: 1,
   recurrenceEndDate: '',
   enabled: true,
 };
@@ -63,13 +84,20 @@ export function CalendarAppointmentsPage() {
     setSaving(true);
     setError(null);
 
-    // Clean empty strings to null for optional fields
+    const isRecurring = editing.recurrenceType !== 'NONE';
+    const isNthWeekday = editing.recurrenceType === 'MONTHLY_NTH_WEEKDAY';
+
+    // Clean empty strings to null and drop recurrence detail that doesn't apply
+    // to the selected pattern, so the payload stays consistent.
     const cleaned = {
       ...editing,
       description: editing.description || undefined,
       startTime: editing.allDay ? undefined : editing.startTime || undefined,
       endTime: editing.allDay ? undefined : editing.endTime || undefined,
-      recurrenceEndDate: editing.recurrenceType === 'NONE' ? undefined : editing.recurrenceEndDate || undefined,
+      recurrenceInterval: isRecurring ? (editing.recurrenceInterval ?? 1) : undefined,
+      recurrenceWeekOfMonth: isNthWeekday ? editing.recurrenceWeekOfMonth : undefined,
+      recurrenceDayOfWeek: isNthWeekday ? editing.recurrenceDayOfWeek : undefined,
+      recurrenceEndDate: isRecurring ? editing.recurrenceEndDate || undefined : undefined,
     };
 
     try {
@@ -108,6 +136,37 @@ export function CalendarAppointmentsPage() {
       setError(err instanceof Error ? err.message : 'Failed to delete appointment');
     } finally {
       setDeleting(false);
+    }
+  };
+
+  // Switch the recurrence frequency, mapping it to a concrete stored type and
+  // preserving the nth-weekday sub-mode when staying on Monthly.
+  const handleFrequencyChange = (freq: Frequency) => {
+    if (!editing) return;
+    let recurrenceType: RecurrenceType = freq;
+    if (freq === 'MONTHLY' && editing.recurrenceType === 'MONTHLY_NTH_WEEKDAY') {
+      recurrenceType = 'MONTHLY_NTH_WEEKDAY';
+    }
+    setEditing({
+      ...editing,
+      recurrenceType,
+      recurrenceInterval: freq === 'NONE' ? undefined : editing.recurrenceInterval ?? 1,
+    });
+  };
+
+  // Toggle between "on day N of the month" and "on the Nth weekday".
+  const setMonthlyMode = (mode: 'dayOfMonth' | 'nthWeekday') => {
+    if (!editing) return;
+    if (mode === 'dayOfMonth') {
+      setEditing({ ...editing, recurrenceType: 'MONTHLY', recurrenceWeekOfMonth: undefined, recurrenceDayOfWeek: undefined });
+    } else {
+      const def = editing.date ? nthWeekdayFromDate(editing.date) : { week: 1, day: 'MONDAY' as DayOfWeek };
+      setEditing({
+        ...editing,
+        recurrenceType: 'MONTHLY_NTH_WEEKDAY',
+        recurrenceWeekOfMonth: editing.recurrenceWeekOfMonth ?? def.week,
+        recurrenceDayOfWeek: editing.recurrenceDayOfWeek ?? def.day,
+      });
     }
   };
 
@@ -191,7 +250,7 @@ export function CalendarAppointmentsPage() {
                   {appointment.recurrenceType !== 'NONE' && (
                     <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 flex items-center gap-1">
                       <Repeat className="w-3 h-3" />
-                      {RECURRENCE_LABELS[appointment.recurrenceType] || appointment.recurrenceType}
+                      {recurrenceSummary(appointment)}
                     </span>
                   )}
                 </div>
@@ -208,7 +267,7 @@ export function CalendarAppointmentsPage() {
               {canManageAppointments && (
               <div className="flex items-center gap-2 shrink-0">
                 <button
-                  onClick={() => setEditing({ ...appointment })}
+                  onClick={() => setEditing(normalizeForEditing(appointment))}
                   className="p-1.5 rounded-lg text-dark-400 hover:text-white hover:bg-dark-800"
                   title="Edit"
                 >
@@ -339,32 +398,112 @@ export function CalendarAppointmentsPage() {
                 </select>
               </div>
 
-              {/* Recurrence */}
+              {/* Recurrence — guided builder */}
               <div>
                 <label className="label">Recurrence</label>
                 <select
-                  value={editing.recurrenceType}
-                  onChange={e => setEditing({ ...editing, recurrenceType: e.target.value as RecurrenceType })}
+                  value={frequencyOf(editing.recurrenceType)}
+                  onChange={e => handleFrequencyChange(e.target.value as Frequency)}
                   className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                 >
-                  {RECURRENCE_OPTIONS.map(opt => (
+                  {FREQUENCY_OPTIONS.map(opt => (
                     <option key={opt.value} value={opt.value}>{opt.label}</option>
                   ))}
                 </select>
               </div>
 
-              {/* Recurrence end date (shown when recurrence != NONE) */}
               {editing.recurrenceType !== 'NONE' && (
-                <div>
-                  <label className="label">Recurrence End Date</label>
-                  <input
-                    type="date"
-                    value={editing.recurrenceEndDate || ''}
-                    onChange={e => setEditing({ ...editing, recurrenceEndDate: e.target.value })}
-                    className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
-                  />
-                  <p className="text-xs text-dark-500 mt-1">Leave empty for indefinite recurrence</p>
-                </div>
+                <>
+                  {/* Interval — "repeat every N units" */}
+                  <div className="flex items-end gap-2">
+                    <div>
+                      <label className="label">Repeat every</label>
+                      <input
+                        type="number"
+                        min={1}
+                        aria-label="Repeat interval"
+                        value={editing.recurrenceInterval ?? 1}
+                        onChange={e => setEditing({
+                          ...editing,
+                          recurrenceInterval: Math.max(1, parseInt(e.target.value, 10) || 1),
+                        })}
+                        className="w-20 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                      />
+                    </div>
+                    <span className="text-sm text-dark-300 pb-2">
+                      {unitNoun(frequencyOf(editing.recurrenceType))}
+                      {(editing.recurrenceInterval ?? 1) > 1 ? 's' : ''}
+                    </span>
+                  </div>
+
+                  {/* Monthly pattern: day-of-month vs Nth weekday */}
+                  {frequencyOf(editing.recurrenceType) === 'MONTHLY' && (
+                    <div className="space-y-2">
+                      <label className="label">Monthly pattern</label>
+                      <label className="flex items-center gap-2 text-sm text-dark-300">
+                        <input
+                          type="radio"
+                          name="monthlyMode"
+                          checked={editing.recurrenceType === 'MONTHLY'}
+                          onChange={() => setMonthlyMode('dayOfMonth')}
+                        />
+                        On day {editing.date ? new Date(editing.date + 'T00:00:00').getDate() : '—'} of the month
+                      </label>
+                      <label className="flex items-center gap-2 text-sm text-dark-300 flex-wrap">
+                        <input
+                          type="radio"
+                          name="monthlyMode"
+                          checked={editing.recurrenceType === 'MONTHLY_NTH_WEEKDAY'}
+                          onChange={() => setMonthlyMode('nthWeekday')}
+                        />
+                        On the
+                        <select
+                          aria-label="Week of month"
+                          value={editing.recurrenceWeekOfMonth ?? 1}
+                          onChange={e => setEditing({
+                            ...editing,
+                            recurrenceType: 'MONTHLY_NTH_WEEKDAY',
+                            recurrenceWeekOfMonth: parseInt(e.target.value, 10),
+                            recurrenceDayOfWeek: editing.recurrenceDayOfWeek
+                              ?? (editing.date ? nthWeekdayFromDate(editing.date).day : 'MONDAY'),
+                          })}
+                          className="bg-dark-800 border border-dark-700 rounded-lg px-2 py-1 text-white text-sm"
+                        >
+                          {WEEK_OF_MONTH_OPTIONS.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
+                        </select>
+                        <select
+                          aria-label="Day of week"
+                          value={editing.recurrenceDayOfWeek ?? 'MONDAY'}
+                          onChange={e => setEditing({
+                            ...editing,
+                            recurrenceType: 'MONTHLY_NTH_WEEKDAY',
+                            recurrenceWeekOfMonth: editing.recurrenceWeekOfMonth ?? 1,
+                            recurrenceDayOfWeek: e.target.value as DayOfWeek,
+                          })}
+                          className="bg-dark-800 border border-dark-700 rounded-lg px-2 py-1 text-white text-sm"
+                        >
+                          {WEEKDAYS.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+                  )}
+
+                  {/* Recurrence end date */}
+                  <div>
+                    <label className="label">Recurrence End Date</label>
+                    <input
+                      type="date"
+                      value={editing.recurrenceEndDate || ''}
+                      onChange={e => setEditing({ ...editing, recurrenceEndDate: e.target.value })}
+                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                    />
+                    <p className="text-xs text-dark-500 mt-1">Leave empty for indefinite recurrence</p>
+                  </div>
+                </>
               )}
 
               {/* Actions */}

--- a/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
+++ b/the-harry-list-admin/src/pages/CalendarAppointmentsPage.tsx
@@ -15,15 +15,14 @@ import {
   recurrenceSummary, nthWeekdayFromDate,
 } from '../lib/recurrence';
 
-/** The frequency family shown in the builder (BIWEEKLY/nth-weekday are derived detail). */
+/** The frequency family shown in the builder (the nth-weekday mode is derived detail). */
 type Frequency = 'NONE' | 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
 
 /** Maps a stored recurrence type to the frequency option the builder displays. */
 function frequencyOf(type: RecurrenceType): Frequency {
   switch (type) {
     case 'DAILY': return 'DAILY';
-    case 'WEEKLY':
-    case 'BIWEEKLY': return 'WEEKLY';
+    case 'WEEKLY': return 'WEEKLY';
     case 'MONTHLY':
     case 'MONTHLY_NTH_WEEKDAY': return 'MONTHLY';
     case 'YEARLY': return 'YEARLY';
@@ -36,15 +35,8 @@ function unitNoun(freq: Frequency): string {
   return FREQUENCY_OPTIONS.find(o => o.value === freq)?.unitLabel ?? '';
 }
 
-/**
- * Normalizes an appointment for editing in the guided builder. Legacy BIWEEKLY
- * records are presented as "Weekly, every 2 weeks" — an equivalent representation
- * that round-trips to the same RRULE — and the interval defaults to 1.
- */
+/** Normalizes an appointment for editing in the guided builder (interval defaults to 1). */
 function normalizeForEditing(a: CalendarAppointment): CalendarAppointment {
-  if (a.recurrenceType === 'BIWEEKLY') {
-    return { ...a, recurrenceType: 'WEEKLY', recurrenceInterval: 2 };
-  }
   return { ...a, recurrenceInterval: a.recurrenceInterval ?? 1 };
 }
 
@@ -190,6 +182,7 @@ export function CalendarAppointmentsPage() {
         <button
           onClick={() => setEditing({ ...emptyAppointment })}
           className="btn-primary flex items-center gap-2 shrink-0"
+          data-testid="add-appointment"
         >
           <Plus className="w-4 h-4" />
           Add Appointment
@@ -219,6 +212,7 @@ export function CalendarAppointmentsPage() {
           {appointments.map(appointment => (
             <div
               key={appointment.id}
+              data-testid="appointment-row"
               className={`bg-dark-900 border rounded-xl p-4 flex items-start gap-4 ${
                 appointment.enabled ? 'border-dark-800' : 'border-dark-800/50 opacity-60'
               }`}
@@ -248,7 +242,10 @@ export function CalendarAppointmentsPage() {
                   ) : null}
                   {/* Recurrence badge */}
                   {appointment.recurrenceType !== 'NONE' && (
-                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 flex items-center gap-1">
+                    <span
+                      data-testid="appointment-recurrence"
+                      className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 flex items-center gap-1"
+                    >
                       <Repeat className="w-3 h-3" />
                       {recurrenceSummary(appointment)}
                     </span>
@@ -320,6 +317,7 @@ export function CalendarAppointmentsPage() {
                   onChange={e => setEditing({ ...editing, title: e.target.value })}
                   className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                   placeholder="e.g. Staff Meeting, Holiday Closure"
+                  data-testid="appointment-title"
                 />
               </div>
 
@@ -343,6 +341,7 @@ export function CalendarAppointmentsPage() {
                   value={editing.date}
                   onChange={e => setEditing({ ...editing, date: e.target.value })}
                   className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                  data-testid="appointment-date"
                 />
               </div>
 
@@ -352,6 +351,7 @@ export function CalendarAppointmentsPage() {
                   type="button"
                   onClick={() => setEditing({ ...editing, allDay: !editing.allDay })}
                   className="shrink-0"
+                  data-testid="appointment-allday-toggle"
                 >
                   {editing.allDay
                     ? <ToggleRight className="w-6 h-6 text-amber-400" />
@@ -405,6 +405,7 @@ export function CalendarAppointmentsPage() {
                   value={frequencyOf(editing.recurrenceType)}
                   onChange={e => handleFrequencyChange(e.target.value as Frequency)}
                   className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                  data-testid="appointment-frequency"
                 >
                   {FREQUENCY_OPTIONS.map(opt => (
                     <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -444,6 +445,7 @@ export function CalendarAppointmentsPage() {
                         <input
                           type="radio"
                           name="monthlyMode"
+                          data-testid="monthly-mode-day"
                           checked={editing.recurrenceType === 'MONTHLY'}
                           onChange={() => setMonthlyMode('dayOfMonth')}
                         />
@@ -453,6 +455,7 @@ export function CalendarAppointmentsPage() {
                         <input
                           type="radio"
                           name="monthlyMode"
+                          data-testid="monthly-mode-nth"
                           checked={editing.recurrenceType === 'MONTHLY_NTH_WEEKDAY'}
                           onChange={() => setMonthlyMode('nthWeekday')}
                         />
@@ -518,6 +521,7 @@ export function CalendarAppointmentsPage() {
                   onClick={handleSave}
                   disabled={saving || !editing.title || !editing.date || (!editing.allDay && (!editing.startTime || !editing.endTime))}
                   className="btn-primary flex items-center gap-2"
+                  data-testid="save-appointment"
                 >
                   {saving && <Loader2 className="w-4 h-4 animate-spin" />}
                   {editing.id ? 'Save Changes' : 'Create Appointment'}

--- a/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
+++ b/the-harry-list-admin/src/pages/WeekOverviewPage.tsx
@@ -9,6 +9,7 @@ import type { Reservation, CalendarAppointment } from '../types/reservation';
 import { usePermissions } from '../lib/usePermissions';
 import { HelpGuide } from '../components/HelpGuide';
 import { weekOverviewGuide } from '../lib/guideContent';
+import { expandOccurrences } from '../lib/recurrence';
 
 const CATERING_ACTIVITIES = ['EAT_A_LA_CARTE', 'EAT_CATERING', 'CATERING_CORONA_ROOM'];
 
@@ -52,68 +53,6 @@ const STATUS_BADGE: Record<string, string> = {
   CANCELLED: 'bg-dark-500/20 text-dark-400',
   COMPLETED: 'bg-blue-500/20 text-blue-400',
 };
-
-/** Expand a recurring appointment into occurrence dates within a given week. */
-function expandAppointmentOccurrences(appointment: CalendarAppointment, weekDateStrings: string[]): string[] {
-  if (!appointment.enabled) return [];
-  const startDate = new Date(appointment.date + 'T00:00:00');
-  const weekStart = new Date(weekDateStrings[0] + 'T00:00:00');
-  const weekEnd = new Date(weekDateStrings[6] + 'T00:00:00');
-
-  if (appointment.recurrenceType === 'NONE') {
-    return weekDateStrings.includes(appointment.date) ? [appointment.date] : [];
-  }
-
-  const endDate = appointment.recurrenceEndDate
-    ? new Date(appointment.recurrenceEndDate + 'T00:00:00')
-    : new Date(weekEnd.getTime() + 365 * 86400000); // reasonable horizon
-
-  const dates: string[] = [];
-  const current = new Date(startDate);
-
-  const advanceDate = (d: Date) => {
-    switch (appointment.recurrenceType) {
-      case 'DAILY': d.setDate(d.getDate() + 1); break;
-      case 'WEEKLY': d.setDate(d.getDate() + 7); break;
-      case 'BIWEEKLY': d.setDate(d.getDate() + 14); break;
-      case 'MONTHLY': d.setMonth(d.getMonth() + 1); break;
-      case 'YEARLY': d.setFullYear(d.getFullYear() + 1); break;
-    }
-  };
-
-  // Fast-forward to near the week if far in the past
-  while (current < weekStart) {
-    advanceDate(current);
-  }
-  // Also check one step back in case we overshot
-  const stepBack = new Date(current);
-  switch (appointment.recurrenceType) {
-    case 'DAILY': stepBack.setDate(stepBack.getDate() - 1); break;
-    case 'WEEKLY': stepBack.setDate(stepBack.getDate() - 7); break;
-    case 'BIWEEKLY': stepBack.setDate(stepBack.getDate() - 14); break;
-    case 'MONTHLY': stepBack.setMonth(stepBack.getMonth() - 1); break;
-    case 'YEARLY': stepBack.setFullYear(stepBack.getFullYear() - 1); break;
-  }
-  if (stepBack >= weekStart && stepBack >= startDate) {
-    current.setTime(stepBack.getTime());
-  }
-
-  // Collect occurrences within the week
-  const maxIterations = 400;
-  let iterations = 0;
-  while (current <= weekEnd && current <= endDate && iterations < maxIterations) {
-    if (current >= startDate) {
-      const dateStr = toLocalDateString(current);
-      if (weekDateStrings.includes(dateStr)) {
-        dates.push(dateStr);
-      }
-    }
-    advanceDate(current);
-    iterations++;
-  }
-
-  return dates;
-}
 
 export function WeekOverviewPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -167,7 +106,7 @@ export function WeekOverviewPage() {
   for (const appt of appointments) {
     if (!appt.enabled) continue;
     if (locationFilter !== 'ALL' && appt.location !== locationFilter) continue;
-    const occurrences = expandAppointmentOccurrences(appt, weekDateStrings);
+    const occurrences = expandOccurrences(appt, weekDateStrings[0], weekDateStrings[6]);
     for (const dateStr of occurrences) {
       weekAppointments[dateStr]?.push(appt);
     }

--- a/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
+++ b/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
@@ -288,21 +288,17 @@ describe('CalendarAppointmentsPage', () => {
     expect(screen.getByText('Every 2nd Friday')).toBeInTheDocument();
   });
 
-  it('opens a legacy BIWEEKLY appointment as "Weekly, every 2 weeks" and saves it equivalently', async () => {
+  it('edits a Weekly appointment to "every 2 weeks" and saves the interval', async () => {
     mockFetch.mockResolvedValue([
-      { id: 8, title: 'Legacy Biweekly', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'BIWEEKLY', enabled: true },
+      { id: 8, title: 'Fortnightly Sync', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'WEEKLY', recurrenceInterval: 1, enabled: true },
     ]);
-    mockUpdate.mockResolvedValue({ id: 8, title: 'Legacy Biweekly', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'WEEKLY', recurrenceInterval: 2, enabled: true });
+    mockUpdate.mockResolvedValue({ id: 8, title: 'Fortnightly Sync', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'WEEKLY', recurrenceInterval: 2, enabled: true });
     renderPage();
-    await waitFor(() => expect(screen.getByText('Legacy Biweekly')).toBeInTheDocument());
-
-    // List badge still reads the legacy label
-    expect(screen.getByText('Bi-weekly')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Fortnightly Sync')).toBeInTheDocument());
 
     fireEvent.click(screen.getByTitle('Edit'));
-    // Presented as Weekly with interval 2
     expect(screen.getByDisplayValue('Weekly')).toBeInTheDocument();
-    expect(screen.getByLabelText('Repeat interval')).toHaveValue(2);
+    fireEvent.change(screen.getByLabelText('Repeat interval'), { target: { value: '2' } });
 
     fireEvent.click(screen.getByText('Save Changes'));
     await waitFor(() => expect(mockUpdate).toHaveBeenCalled());

--- a/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
+++ b/the-harry-list-admin/src/test/CalendarAppointmentsPage.test.tsx
@@ -189,7 +189,7 @@ describe('CalendarAppointmentsPage', () => {
     expect(screen.queryByText('Recurrence End Date')).not.toBeInTheDocument();
 
     // Change recurrence to Weekly
-    const recurrenceSelect = screen.getByDisplayValue('None');
+    const recurrenceSelect = screen.getByDisplayValue('Does not repeat');
     fireEvent.change(recurrenceSelect, { target: { value: 'WEEKLY' } });
 
     expect(screen.getByText('Recurrence End Date')).toBeInTheDocument();
@@ -226,6 +226,90 @@ describe('CalendarAppointmentsPage', () => {
     await waitFor(() => {
       expect(mockDelete).toHaveBeenCalledWith(1);
     });
+  });
+
+  // ── Guided recurrence builder ───────────────────────────────────────────────
+
+  const dateInputs = () => Array.from(document.querySelectorAll('input[type="date"]')) as HTMLInputElement[];
+
+  const startNewAllDayAppointment = (title: string, date: string) => {
+    fireEvent.click(screen.getByText('Add Appointment'));
+    fireEvent.change(screen.getByPlaceholderText(/Staff Meeting/), { target: { value: title } });
+    fireEvent.change(dateInputs()[0], { target: { value: date } });
+    // all-day so we don't need start/end times to enable the submit button
+    fireEvent.click(screen.getByText('All-day event').previousElementSibling as HTMLElement);
+  };
+
+  it('saves an "every N weeks" interval', async () => {
+    mockCreate.mockResolvedValue({ id: 9, title: 'Sprint Sync', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'WEEKLY', recurrenceInterval: 3, enabled: true });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Staff Meeting')).toBeInTheDocument());
+
+    startNewAllDayAppointment('Sprint Sync', '2026-06-01');
+    fireEvent.change(screen.getByDisplayValue('Does not repeat'), { target: { value: 'WEEKLY' } });
+    fireEvent.change(screen.getByLabelText('Repeat interval'), { target: { value: '3' } });
+    fireEvent.click(screen.getByText('Create Appointment'));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.recurrenceType).toBe('WEEKLY');
+    expect(payload.recurrenceInterval).toBe(3);
+  });
+
+  it('saves a "monthly on the Nth weekday" pattern', async () => {
+    mockCreate.mockResolvedValue({ id: 10, title: '2nd Friday Drinks', date: '2026-06-12', allDay: true, location: 'HUBBLE', recurrenceType: 'MONTHLY_NTH_WEEKDAY', recurrenceWeekOfMonth: 2, recurrenceDayOfWeek: 'FRIDAY', enabled: true });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Staff Meeting')).toBeInTheDocument());
+
+    startNewAllDayAppointment('2nd Friday Drinks', '2026-06-12');
+    fireEvent.change(screen.getByDisplayValue('Does not repeat'), { target: { value: 'MONTHLY' } });
+
+    // Switch to the "on the Nth weekday" mode
+    const radios = screen.getAllByRole('radio');
+    fireEvent.click(radios[1]);
+    fireEvent.change(screen.getByLabelText('Week of month'), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText('Day of week'), { target: { value: 'FRIDAY' } });
+
+    fireEvent.click(screen.getByText('Create Appointment'));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload.recurrenceType).toBe('MONTHLY_NTH_WEEKDAY');
+    expect(payload.recurrenceWeekOfMonth).toBe(2);
+    expect(payload.recurrenceDayOfWeek).toBe('FRIDAY');
+  });
+
+  it('renders a descriptive badge for nth-weekday recurrence', async () => {
+    mockFetch.mockResolvedValue([
+      { id: 7, title: 'Board Meeting', date: '2026-06-12', allDay: true, location: 'HUBBLE', recurrenceType: 'MONTHLY_NTH_WEEKDAY', recurrenceWeekOfMonth: 2, recurrenceDayOfWeek: 'FRIDAY', enabled: true },
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Board Meeting')).toBeInTheDocument());
+    expect(screen.getByText('Every 2nd Friday')).toBeInTheDocument();
+  });
+
+  it('opens a legacy BIWEEKLY appointment as "Weekly, every 2 weeks" and saves it equivalently', async () => {
+    mockFetch.mockResolvedValue([
+      { id: 8, title: 'Legacy Biweekly', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'BIWEEKLY', enabled: true },
+    ]);
+    mockUpdate.mockResolvedValue({ id: 8, title: 'Legacy Biweekly', date: '2026-06-01', allDay: true, location: 'HUBBLE', recurrenceType: 'WEEKLY', recurrenceInterval: 2, enabled: true });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Legacy Biweekly')).toBeInTheDocument());
+
+    // List badge still reads the legacy label
+    expect(screen.getByText('Bi-weekly')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Edit'));
+    // Presented as Weekly with interval 2
+    expect(screen.getByDisplayValue('Weekly')).toBeInTheDocument();
+    expect(screen.getByLabelText('Repeat interval')).toHaveValue(2);
+
+    fireEvent.click(screen.getByText('Save Changes'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    const [id, payload] = mockUpdate.mock.calls[0];
+    expect(id).toBe(8);
+    expect(payload.recurrenceType).toBe('WEEKLY');
+    expect(payload.recurrenceInterval).toBe(2);
   });
 });
 

--- a/the-harry-list-admin/src/test/recurrence.test.ts
+++ b/the-harry-list-admin/src/test/recurrence.test.ts
@@ -61,14 +61,7 @@ describe('expandOccurrences — interval frequencies', () => {
     expect(expandOccurrences(a, '2026-06-01', '2026-06-14')).toEqual(['2026-06-01', '2026-06-08']);
   });
 
-  it('BIWEEKLY (legacy every-2-weeks)', () => {
-    const a = appt({ date: '2026-06-01', recurrenceType: 'BIWEEKLY' });
-    expect(expandOccurrences(a, '2026-06-01', '2026-07-01')).toEqual([
-      '2026-06-01', '2026-06-15', '2026-06-29',
-    ]);
-  });
-
-  it('WEEKLY interval 2 matches BIWEEKLY semantics', () => {
+  it('WEEKLY interval 2 ("every 2 weeks")', () => {
     const a = appt({ date: '2026-06-01', recurrenceType: 'WEEKLY', recurrenceInterval: 2 });
     expect(expandOccurrences(a, '2026-06-01', '2026-07-01')).toEqual([
       '2026-06-01', '2026-06-15', '2026-06-29',
@@ -146,7 +139,7 @@ describe('recurrenceSummary', () => {
   it('labels simple frequencies', () => {
     expect(recurrenceSummary(appt({ recurrenceType: 'NONE' }))).toBe('');
     expect(recurrenceSummary(appt({ recurrenceType: 'WEEKLY' }))).toBe('Weekly');
-    expect(recurrenceSummary(appt({ recurrenceType: 'BIWEEKLY' }))).toBe('Bi-weekly');
+    expect(recurrenceSummary(appt({ recurrenceType: 'WEEKLY', recurrenceInterval: 2 }))).toBe('Every 2 weeks');
     expect(recurrenceSummary(appt({ recurrenceType: 'MONTHLY' }))).toBe('Monthly');
   });
 

--- a/the-harry-list-admin/src/test/recurrence.test.ts
+++ b/the-harry-list-admin/src/test/recurrence.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  nthWeekdayOfMonth,
+  expandOccurrences,
+  recurrenceSummary,
+  effectiveInterval,
+} from '../lib/recurrence';
+import type { CalendarAppointment } from '../types/reservation';
+
+function appt(overrides: Partial<CalendarAppointment>): CalendarAppointment {
+  return {
+    title: 'Test',
+    date: '2026-06-01',
+    allDay: true,
+    location: 'HUBBLE',
+    recurrenceType: 'NONE',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe('nthWeekdayOfMonth', () => {
+  it('finds the 2nd Friday of June 2026', () => {
+    const d = nthWeekdayOfMonth(2026, 5, 2, 5); // June, 2nd, Friday(jsDay 5)
+    expect(d && `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`).toBe('2026-6-12');
+  });
+
+  it('finds the last Monday of June 2026', () => {
+    const d = nthWeekdayOfMonth(2026, 5, -1, 1); // June, last, Monday(jsDay 1)
+    expect(d && d.getDate()).toBe(29);
+  });
+
+  it('returns null when the requested occurrence overflows the month', () => {
+    const fourth = nthWeekdayOfMonth(2026, 5, 4, 5); // 4th Friday of June exists (26th)
+    expect(fourth && fourth.getDate()).toBe(26);
+    // June 2026 has no 5th Friday → overflow into July → null
+    const fifth = nthWeekdayOfMonth(2026, 5, 5, 5);
+    expect(fifth).toBeNull();
+  });
+});
+
+describe('expandOccurrences — NONE', () => {
+  it('returns the single date when in range', () => {
+    expect(expandOccurrences(appt({ date: '2026-06-03' }), '2026-06-01', '2026-06-07')).toEqual(['2026-06-03']);
+  });
+  it('returns empty when out of range', () => {
+    expect(expandOccurrences(appt({ date: '2026-06-20' }), '2026-06-01', '2026-06-07')).toEqual([]);
+  });
+});
+
+describe('expandOccurrences — interval frequencies', () => {
+  it('DAILY every 3 days', () => {
+    const a = appt({ date: '2026-06-01', recurrenceType: 'DAILY', recurrenceInterval: 3 });
+    expect(expandOccurrences(a, '2026-06-01', '2026-06-10')).toEqual([
+      '2026-06-01', '2026-06-04', '2026-06-07', '2026-06-10',
+    ]);
+  });
+
+  it('WEEKLY every week', () => {
+    const a = appt({ date: '2026-06-01', recurrenceType: 'WEEKLY' });
+    expect(expandOccurrences(a, '2026-06-01', '2026-06-14')).toEqual(['2026-06-01', '2026-06-08']);
+  });
+
+  it('BIWEEKLY (legacy every-2-weeks)', () => {
+    const a = appt({ date: '2026-06-01', recurrenceType: 'BIWEEKLY' });
+    expect(expandOccurrences(a, '2026-06-01', '2026-07-01')).toEqual([
+      '2026-06-01', '2026-06-15', '2026-06-29',
+    ]);
+  });
+
+  it('WEEKLY interval 2 matches BIWEEKLY semantics', () => {
+    const a = appt({ date: '2026-06-01', recurrenceType: 'WEEKLY', recurrenceInterval: 2 });
+    expect(expandOccurrences(a, '2026-06-01', '2026-07-01')).toEqual([
+      '2026-06-01', '2026-06-15', '2026-06-29',
+    ]);
+  });
+
+  it('MONTHLY on the same day-of-month', () => {
+    const a = appt({ date: '2026-01-15', recurrenceType: 'MONTHLY' });
+    expect(expandOccurrences(a, '2026-03-01', '2026-03-31')).toEqual(['2026-03-15']);
+  });
+
+  it('YEARLY on the anniversary', () => {
+    const a = appt({ date: '2026-01-15', recurrenceType: 'YEARLY' });
+    expect(expandOccurrences(a, '2028-01-01', '2028-12-31')).toEqual(['2028-01-15']);
+  });
+
+  it('never returns dates before the start date', () => {
+    const a = appt({ date: '2026-06-10', recurrenceType: 'DAILY' });
+    expect(expandOccurrences(a, '2026-06-01', '2026-06-12')).toEqual([
+      '2026-06-10', '2026-06-11', '2026-06-12',
+    ]);
+  });
+
+  it('respects recurrenceEndDate', () => {
+    const a = appt({ date: '2026-06-01', recurrenceType: 'WEEKLY', recurrenceEndDate: '2026-06-08' });
+    expect(expandOccurrences(a, '2026-06-01', '2026-06-30')).toEqual(['2026-06-01', '2026-06-08']);
+  });
+});
+
+describe('expandOccurrences — MONTHLY_NTH_WEEKDAY', () => {
+  it('expands "2nd Friday of the month" across months', () => {
+    const a = appt({
+      date: '2026-06-12',
+      recurrenceType: 'MONTHLY_NTH_WEEKDAY',
+      recurrenceWeekOfMonth: 2,
+      recurrenceDayOfWeek: 'FRIDAY',
+    });
+    expect(expandOccurrences(a, '2026-06-01', '2026-08-31')).toEqual([
+      '2026-06-12', '2026-07-10', '2026-08-14',
+    ]);
+  });
+
+  it('expands "last Monday of the month"', () => {
+    const a = appt({
+      date: '2026-06-29',
+      recurrenceType: 'MONTHLY_NTH_WEEKDAY',
+      recurrenceWeekOfMonth: -1,
+      recurrenceDayOfWeek: 'MONDAY',
+    });
+    expect(expandOccurrences(a, '2026-06-01', '2026-07-31')).toEqual([
+      '2026-06-29', '2026-07-27',
+    ]);
+  });
+
+  it('honors a month interval (every other month, first Tuesday)', () => {
+    const a = appt({
+      date: '2026-06-02',
+      recurrenceType: 'MONTHLY_NTH_WEEKDAY',
+      recurrenceInterval: 2,
+      recurrenceWeekOfMonth: 1,
+      recurrenceDayOfWeek: 'TUESDAY',
+    });
+    expect(expandOccurrences(a, '2026-06-01', '2026-09-30')).toEqual([
+      '2026-06-02', '2026-08-04',
+    ]);
+  });
+
+  it('returns empty for incomplete config', () => {
+    const a = appt({ date: '2026-06-12', recurrenceType: 'MONTHLY_NTH_WEEKDAY', recurrenceWeekOfMonth: 2 });
+    expect(expandOccurrences(a, '2026-06-01', '2026-08-31')).toEqual([]);
+  });
+});
+
+describe('recurrenceSummary', () => {
+  it('labels simple frequencies', () => {
+    expect(recurrenceSummary(appt({ recurrenceType: 'NONE' }))).toBe('');
+    expect(recurrenceSummary(appt({ recurrenceType: 'WEEKLY' }))).toBe('Weekly');
+    expect(recurrenceSummary(appt({ recurrenceType: 'BIWEEKLY' }))).toBe('Bi-weekly');
+    expect(recurrenceSummary(appt({ recurrenceType: 'MONTHLY' }))).toBe('Monthly');
+  });
+
+  it('labels intervals', () => {
+    expect(recurrenceSummary(appt({ recurrenceType: 'WEEKLY', recurrenceInterval: 3 }))).toBe('Every 3 weeks');
+    expect(recurrenceSummary(appt({ recurrenceType: 'DAILY', recurrenceInterval: 2 }))).toBe('Every 2 days');
+  });
+
+  it('labels nth-weekday patterns', () => {
+    expect(recurrenceSummary(appt({
+      recurrenceType: 'MONTHLY_NTH_WEEKDAY', recurrenceWeekOfMonth: 2, recurrenceDayOfWeek: 'FRIDAY',
+    }))).toBe('Every 2nd Friday');
+    expect(recurrenceSummary(appt({
+      recurrenceType: 'MONTHLY_NTH_WEEKDAY', recurrenceWeekOfMonth: -1, recurrenceDayOfWeek: 'MONDAY',
+    }))).toBe('Every last Monday');
+  });
+});
+
+describe('effectiveInterval', () => {
+  it('defaults to 1', () => {
+    expect(effectiveInterval(appt({}))).toBe(1);
+    expect(effectiveInterval(appt({ recurrenceInterval: 0 }))).toBe(1);
+    expect(effectiveInterval(appt({ recurrenceInterval: 4 }))).toBe(4);
+  });
+});

--- a/the-harry-list-admin/src/types/reservation.ts
+++ b/the-harry-list-admin/src/types/reservation.ts
@@ -60,7 +60,24 @@ export interface CateringEmailRequest {
   replyTo?: string;
 }
 
-export type RecurrenceType = 'NONE' | 'DAILY' | 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY' | 'YEARLY';
+export type RecurrenceType =
+  | 'NONE'
+  | 'DAILY'
+  | 'WEEKLY'
+  | 'BIWEEKLY'
+  | 'MONTHLY'
+  | 'YEARLY'
+  | 'MONTHLY_NTH_WEEKDAY';
+
+/** Weekday encoding shared with the backend (java.time.DayOfWeek names). */
+export type DayOfWeek =
+  | 'MONDAY'
+  | 'TUESDAY'
+  | 'WEDNESDAY'
+  | 'THURSDAY'
+  | 'FRIDAY'
+  | 'SATURDAY'
+  | 'SUNDAY';
 
 export interface CalendarAppointment {
   id?: number;
@@ -72,6 +89,12 @@ export interface CalendarAppointment {
   endTime?: string;
   location: string;
   recurrenceType: RecurrenceType;
+  /** "Every N" multiplier (RRULE INTERVAL). Null/1 means every period. */
+  recurrenceInterval?: number;
+  /** For MONTHLY_NTH_WEEKDAY: 1–4 for first–fourth, or -1 for last. */
+  recurrenceWeekOfMonth?: number;
+  /** For MONTHLY_NTH_WEEKDAY: which weekday, e.g. FRIDAY for "2nd Friday". */
+  recurrenceDayOfWeek?: DayOfWeek;
   recurrenceEndDate?: string;
   enabled: boolean;
   createdAt?: string;

--- a/the-harry-list-admin/src/types/reservation.ts
+++ b/the-harry-list-admin/src/types/reservation.ts
@@ -64,7 +64,6 @@ export type RecurrenceType =
   | 'NONE'
   | 'DAILY'
   | 'WEEKLY'
-  | 'BIWEEKLY'
   | 'MONTHLY'
   | 'YEARLY'
   | 'MONTHLY_NTH_WEEKDAY';

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentController.java
@@ -74,6 +74,9 @@ public class AdminCalendarAppointmentController {
                     existing.setEndTime(appointment.getEndTime());
                     existing.setLocation(appointment.getLocation());
                     existing.setRecurrenceType(appointment.getRecurrenceType());
+                    existing.setRecurrenceInterval(appointment.getRecurrenceInterval());
+                    existing.setRecurrenceWeekOfMonth(appointment.getRecurrenceWeekOfMonth());
+                    existing.setRecurrenceDayOfWeek(appointment.getRecurrenceDayOfWeek());
                     existing.setRecurrenceEndDate(appointment.getRecurrenceEndDate());
                     existing.setEnabled(appointment.getEnabled());
                     CalendarAppointment saved = repository.save(existing);

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/CalendarAppointment.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/CalendarAppointment.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -53,6 +54,27 @@ public class CalendarAppointment {
     @Column(name = "recurrence_type", length = 20, nullable = false)
     @Builder.Default
     private RecurrenceType recurrenceType = RecurrenceType.NONE;
+
+    /**
+     * "Every N" multiplier for the recurrence (RRULE INTERVAL). Null or 1 means every period.
+     * Applies to DAILY/WEEKLY/MONTHLY/YEARLY/MONTHLY_NTH_WEEKDAY.
+     */
+    @Column(name = "recurrence_interval")
+    private Integer recurrenceInterval;
+
+    /**
+     * Which week of the month for {@link RecurrenceType#MONTHLY_NTH_WEEKDAY}:
+     * 1–4 for first–fourth, or -1 for the last occurrence (RRULE BYSETPOS/BYDAY ordinal).
+     */
+    @Column(name = "recurrence_week_of_month")
+    private Integer recurrenceWeekOfMonth;
+
+    /**
+     * Which weekday for {@link RecurrenceType#MONTHLY_NTH_WEEKDAY}, e.g. FRIDAY for "2nd Friday".
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recurrence_day_of_week", length = 10)
+    private DayOfWeek recurrenceDayOfWeek;
 
     @Column(name = "recurrence_end_date")
     private LocalDate recurrenceEndDate;

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/RecurrenceType.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/RecurrenceType.java
@@ -14,9 +14,6 @@ public enum RecurrenceType {
     NONE,
     DAILY,
     WEEKLY,
-    /** Legacy shorthand for "every 2 weeks". Retained for backward compatibility;
-     *  new appointments express this as WEEKLY with {@code recurrenceInterval = 2}. */
-    BIWEEKLY,
     MONTHLY,
     YEARLY,
     /** Monthly on the Nth weekday, e.g. "every 2nd Friday" or "the last Monday".

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/RecurrenceType.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/RecurrenceType.java
@@ -2,12 +2,25 @@ package com.pimvanleeuwen.the_harry_list_backend.model;
 
 /**
  * Recurrence pattern for calendar appointments.
+ *
+ * <p>The frequency family is captured by this enum; the finer detail (how often,
+ * and — for {@link #MONTHLY_NTH_WEEKDAY} — which weekday of which week) lives in
+ * the structured {@code recurrenceInterval}, {@code recurrenceWeekOfMonth} and
+ * {@code recurrenceDayOfWeek} fields on {@code CalendarAppointment}. This keeps the
+ * model generic: new patterns are added by extending this enum plus the single
+ * RRULE mapper in {@code ICalendarService}, rather than touching many call sites.
  */
 public enum RecurrenceType {
     NONE,
     DAILY,
     WEEKLY,
+    /** Legacy shorthand for "every 2 weeks". Retained for backward compatibility;
+     *  new appointments express this as WEEKLY with {@code recurrenceInterval = 2}. */
     BIWEEKLY,
     MONTHLY,
-    YEARLY
+    YEARLY,
+    /** Monthly on the Nth weekday, e.g. "every 2nd Friday" or "the last Monday".
+     *  Driven by {@code recurrenceWeekOfMonth} (1–4, or -1 for last) and
+     *  {@code recurrenceDayOfWeek}. */
+    MONTHLY_NTH_WEEKDAY
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
@@ -417,21 +417,52 @@ public class ICalendarService {
         return event.toString();
     }
 
+    /**
+     * Builds the RFC 5545 RRULE line for an appointment's recurrence.
+     *
+     * <p>This is the single mapping from our structured recurrence model to iCal.
+     * Frequency comes from {@link RecurrenceType}; "every N" from
+     * {@code recurrenceInterval}; and the nth-weekday detail from
+     * {@code recurrenceWeekOfMonth} + {@code recurrenceDayOfWeek}. New recurrence
+     * patterns should be expressed here rather than scattered across the codebase.
+     */
     private String buildRecurrenceRule(CalendarAppointment appointment) {
-        if (appointment.getRecurrenceType() == null || appointment.getRecurrenceType() == RecurrenceType.NONE) {
+        RecurrenceType type = appointment.getRecurrenceType();
+        if (type == null || type == RecurrenceType.NONE) {
             return "";
         }
 
-        StringBuilder rrule = new StringBuilder("RRULE:FREQ=");
-        switch (appointment.getRecurrenceType()) {
-            case DAILY -> rrule.append("DAILY");
-            case WEEKLY -> rrule.append("WEEKLY");
-            case BIWEEKLY -> rrule.append("WEEKLY;INTERVAL=2");
-            case MONTHLY -> rrule.append("MONTHLY");
-            case YEARLY -> rrule.append("YEARLY");
+        String freq;
+        String byDay = null;
+        int interval = effectiveInterval(appointment);
+
+        switch (type) {
+            case DAILY -> freq = "DAILY";
+            case WEEKLY -> freq = "WEEKLY";
+            case BIWEEKLY -> {
+                freq = "WEEKLY";
+                interval = Math.max(interval, 2); // legacy shorthand for every 2 weeks
+            }
+            case MONTHLY -> freq = "MONTHLY";
+            case YEARLY -> freq = "YEARLY";
+            case MONTHLY_NTH_WEEKDAY -> {
+                byDay = formatNthWeekday(appointment);
+                if (byDay == null) {
+                    return ""; // incomplete config — emit no RRULE rather than an invalid one
+                }
+                freq = "MONTHLY";
+            }
             default -> { return ""; }
         }
 
+        StringBuilder rrule = new StringBuilder("RRULE:FREQ=").append(freq);
+
+        if (interval > 1) {
+            rrule.append(";INTERVAL=").append(interval);
+        }
+        if (byDay != null) {
+            rrule.append(";BYDAY=").append(byDay);
+        }
         if (appointment.getRecurrenceEndDate() != null) {
             rrule.append(";UNTIL=").append(
                     appointment.getRecurrenceEndDate().atTime(23, 59, 59).format(ICS_DATE_FORMAT));
@@ -439,6 +470,39 @@ public class ICalendarService {
 
         rrule.append("\r\n");
         return rrule.toString();
+    }
+
+    /** Resolves the effective "every N" interval, defaulting to 1 when unset or invalid. */
+    private int effectiveInterval(CalendarAppointment appointment) {
+        Integer interval = appointment.getRecurrenceInterval();
+        return (interval != null && interval > 0) ? interval : 1;
+    }
+
+    /**
+     * Formats the BYDAY token for a monthly nth-weekday rule, e.g. {@code 2FR} for the
+     * 2nd Friday or {@code -1MO} for the last Monday. Returns null if either the week
+     * ordinal or the weekday is missing.
+     */
+    private String formatNthWeekday(CalendarAppointment appointment) {
+        Integer week = appointment.getRecurrenceWeekOfMonth();
+        java.time.DayOfWeek day = appointment.getRecurrenceDayOfWeek();
+        if (week == null || day == null) {
+            return null;
+        }
+        return week + icsWeekdayCode(day);
+    }
+
+    /** Two-letter RRULE weekday code (MO, TU, … SU) for a java.time DayOfWeek. */
+    private String icsWeekdayCode(java.time.DayOfWeek day) {
+        return switch (day) {
+            case MONDAY -> "MO";
+            case TUESDAY -> "TU";
+            case WEDNESDAY -> "WE";
+            case THURSDAY -> "TH";
+            case FRIDAY -> "FR";
+            case SATURDAY -> "SA";
+            case SUNDAY -> "SU";
+        };
     }
 
     private String escapeIcsText(String text) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
@@ -439,10 +439,6 @@ public class ICalendarService {
         switch (type) {
             case DAILY -> freq = "DAILY";
             case WEEKLY -> freq = "WEEKLY";
-            case BIWEEKLY -> {
-                freq = "WEEKLY";
-                interval = Math.max(interval, 2); // legacy shorthand for every 2 weeks
-            }
             case MONTHLY -> freq = "MONTHLY";
             case YEARLY -> freq = "YEARLY";
             case MONTHLY_NTH_WEEKDAY -> {

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarAppointmentControllerTest.java
@@ -155,6 +155,64 @@ class AdminCalendarAppointmentControllerTest {
 
     @Test
     @WithMockUser(roles = "EDITOR")
+    void create_nthWeekday_shouldPersistStructuredFields() throws Exception {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(3L)
+                .title("Second Friday Meetup")
+                .date(LocalDate.of(2026, 6, 12))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceInterval(1)
+                .recurrenceWeekOfMonth(2)
+                .recurrenceDayOfWeek(java.time.DayOfWeek.FRIDAY)
+                .enabled(true)
+                .build();
+        when(repository.save(any())).thenReturn(appointment);
+
+        mockMvc.perform(post("/api/admin/calendar-appointments")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(appointment)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.recurrenceType").value("MONTHLY_NTH_WEEKDAY"))
+                .andExpect(jsonPath("$.recurrenceWeekOfMonth").value(2))
+                .andExpect(jsonPath("$.recurrenceDayOfWeek").value("FRIDAY"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void update_shouldCopyStructuredRecurrenceFields() throws Exception {
+        CalendarAppointment existing = sampleAppointment();
+        when(repository.findById(1L)).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        CalendarAppointment payload = CalendarAppointment.builder()
+                .id(1L)
+                .title("Updated Meetup")
+                .date(LocalDate.of(2026, 6, 12))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceInterval(2)
+                .recurrenceWeekOfMonth(-1)
+                .recurrenceDayOfWeek(java.time.DayOfWeek.MONDAY)
+                .enabled(true)
+                .build();
+
+        mockMvc.perform(put("/api/admin/calendar-appointments/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.recurrenceType").value("MONTHLY_NTH_WEEKDAY"))
+                .andExpect(jsonPath("$.recurrenceInterval").value(2))
+                .andExpect(jsonPath("$.recurrenceWeekOfMonth").value(-1))
+                .andExpect(jsonPath("$.recurrenceDayOfWeek").value("MONDAY"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
     void toggle_shouldFlipEnabledState() throws Exception {
         CalendarAppointment appointment = sampleAppointment();
         appointment.setEnabled(true);

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
@@ -294,6 +294,118 @@ class ICalendarServiceTest {
     }
 
     @Test
+    void generateCalendarFeed_shouldIncludeIntervalForEveryNWeeks() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(7L)
+                .title("Every Three Weeks")
+                .date(LocalDate.of(2026, 6, 1))
+                .allDay(false)
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(10, 0))
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.WEEKLY)
+                .recurrenceInterval(3)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=WEEKLY;INTERVAL=3"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeRruleForNthWeekdayOfMonth() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(8L)
+                .title("Second Friday Meetup")
+                .date(LocalDate.of(2026, 6, 12)) // a 2nd Friday
+                .allDay(false)
+                .startTime(LocalTime.of(18, 0))
+                .endTime(LocalTime.of(20, 0))
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceWeekOfMonth(2)
+                .recurrenceDayOfWeek(java.time.DayOfWeek.FRIDAY)
+                .recurrenceEndDate(LocalDate.of(2026, 12, 31))
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=MONTHLY;BYDAY=2FR;UNTIL=20261231T235959"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldRenderLastWeekdayOfMonth() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(9L)
+                .title("Last Monday Cleanup")
+                .date(LocalDate.of(2026, 6, 29))
+                .allDay(true)
+                .location(BarLocation.METEOR)
+                .recurrenceType(RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceWeekOfMonth(-1)
+                .recurrenceDayOfWeek(java.time.DayOfWeek.MONDAY)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=MONTHLY;BYDAY=-1MO"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldHonourIntervalForNthWeekday() {
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(10L)
+                .title("Every Other Month, First Tuesday")
+                .date(LocalDate.of(2026, 6, 2))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceInterval(2)
+                .recurrenceWeekOfMonth(1)
+                .recurrenceDayOfWeek(java.time.DayOfWeek.TUESDAY)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("RRULE:FREQ=MONTHLY;INTERVAL=2;BYDAY=1TU"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldOmitRruleForIncompleteNthWeekday() {
+        // Missing day-of-week => no valid BYDAY can be built; emit no RRULE rather than invalid iCal
+        CalendarAppointment appointment = CalendarAppointment.builder()
+                .id(11L)
+                .title("Incomplete Nth Weekday")
+                .date(LocalDate.of(2026, 6, 1))
+                .allDay(true)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceWeekOfMonth(2)
+                .enabled(true)
+                .build();
+        when(reservationRepository.findAll()).thenReturn(Collections.emptyList());
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false);
+
+        assertTrue(ics.contains("SUMMARY:Incomplete Nth Weekday"));
+        // VTIMEZONE legitimately contains RRULE lines, so assert no *event* monthly rule was emitted
+        assertFalse(ics.contains("RRULE:FREQ=MONTHLY"));
+    }
+
+    @Test
     void generateCalendarFeed_shouldExcludeDisabledAppointments() {
         // findByEnabledTrue() already filters, so an empty result means disabled ones are excluded
         when(reservationRepository.findAll()).thenReturn(Collections.emptyList());

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
@@ -273,16 +273,18 @@ class ICalendarServiceTest {
     }
 
     @Test
-    void generateCalendarFeed_shouldIncludeRruleForBiweekly() {
+    void generateCalendarFeed_shouldIncludeRruleForEveryTwoWeeks() {
+        // "Every 2 weeks" is now expressed as WEEKLY with interval 2 (BIWEEKLY retired).
         CalendarAppointment appointment = CalendarAppointment.builder()
                 .id(4L)
-                .title("Biweekly Sync")
+                .title("Fortnightly Sync")
                 .date(LocalDate.of(2026, 6, 1))
                 .allDay(false)
                 .startTime(LocalTime.of(9, 0))
                 .endTime(LocalTime.of(10, 0))
                 .location(BarLocation.HUBBLE)
-                .recurrenceType(RecurrenceType.BIWEEKLY)
+                .recurrenceType(RecurrenceType.WEEKLY)
+                .recurrenceInterval(2)
                 .enabled(true)
                 .build();
         when(reservationRepository.findAll()).thenReturn(Collections.emptyList());


### PR DESCRIPTION
## What & why

Calendar appointments could only recur on a fixed set of frequencies (daily/weekly/monthly/…). This adds a **generic, extensible recurrence model** so
patterns like **"every 2nd Friday of the month"** — and future ones — are supported
without re-plumbing every layer.

Rather than hard-coding the one example, recurrence is now a frequency *family* plus
structured detail (interval + nth-weekday), mapping 1:1 to iCal RRULE. Adding a new
pattern later = extend the enum + one RRULE mapper (backend) and one expander
(frontend); nothing scattered across pages.

## How it works

- **Model**: a new `MONTHLY_NTH_WEEKDAY` type plus three nullable fields on `CalendarAppointment`, `recurrenceInterval` (every N), `recurrenceWeekOfMonth`
  (1–4 or -1=last), `recurrenceDayOfWeek`.
- **Backend**: `ICalendarService` has one generic RRULE builder emitting `INTERVAL=N` and `BYDAY=2FR` / `BYDAY=-1MO`, and safely omits the rule for
  incomplete config.
- **Admin shared logic**: new `lib/recurrence.ts` is the single source of truth (occurrence expander + summaries), reused by the Week Overview.
- **Admin UI**: a guided builder — frequency + "repeat every N" + a monthly "on the [1st…last] [weekday]" option, with smart defaults from the chosen date.
- **Cleanup**: retired the redundant `BIWEEKLY` type ("every 2 weeks" is now `WEEKLY` + interval 2). Prod has no BIWEEKLY rows, so no data migration.

## Testing

- Backend: **310** unit/integration tests (incl. new RRULE cases: interval, 2nd Friday, last Monday, interval+nth, incomplete).
- Admin: **131** component/unit tests (new `recurrence.ts` suite + guided-builder).
- E2E (Playwright, real stack): new `admin/calendar-appointments` spec creates an "every 2nd Friday" appointment through the UI and asserts `RRULE:FREQ=MONTHLY;BYDAY=2FR` reaches the public iCal feed. `week-overview` and `calendar-feed` specs re-run green.

## Deployment — DB change required

Three **nullable** columns must exist on `calendar_appointments` before the new backend starts (prod runs `ddl-auto=validate`).

## Commits
1. `feat(backend): generic recurrence model for calendar appointments`
2. `feat(admin): shared recurrence module with generic occurrence expander`
3. `feat(admin): guided recurrence builder for calendar appointments`
4. `test(e2e): cover recurring "Nth weekday" appointments end-to-end`
5. `refactor: retire redundant BIWEEKLY recurrence type`