### PR TITLE
302 feature go from rejected back to pending

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -144,6 +144,7 @@ faster layers.
 | Form constraints (all types) | form tests | `ConstraintValidationServiceTest` | `public/constraints-blocking`, `public/constraints-dynamic`, `admin/constraints-roundtrip` |
 | Confirm a reservation (appears in admin) | `ReservationsPage`/detail tests | controller tests | `admin/reservation-lifecycle` #1 |
 | Edit / remove a reservation | `ReservationDetailPage` test | `Update`/`DeleteReservationServiceTest` | `admin/reservation-lifecycle` #2 |
+| Reopen a rejected reservation to pending | `ReservationDetailPage` test | `AdminReservationControllerTest` | `admin/reservation-lifecycle` #3 |
 | Status-change email + custom message | — | `AdminReservationControllerTest` | `admin/status-email` |
 | Editable email templates | — | `EmailTemplateServiceTest` | `admin/email-template` |
 | RBAC (viewer/editor/admin) | `usePermissions` | filter tests | `admin/rbac` |

--- a/e2e/tests/admin/reservation-lifecycle.spec.ts
+++ b/e2e/tests/admin/reservation-lifecycle.spec.ts
@@ -108,4 +108,43 @@ test.describe('admin: reservation lifecycle', () => {
     await expect(page.getByTestId('reservation-row').filter({ hasText: 'Editable Booking' })).toHaveCount(0);
     await captureScreenshot(testInfo, page, '2-removed');
   });
+
+  test('a rejected reservation can be moved back to pending and confirmed', async ({ page, request }, testInfo) => {
+    // A rejected event whose date/location changed — staff reopen it rather than
+    // asking the customer to re-submit everything.
+    await seedReservation(request, {
+      contactName: 'Reopen Guest',
+      email: 'reopen.guest@example.com',
+      eventTitle: 'Reopenable Booking',
+      description: 'Rejected, then revived',
+      eventDate: '2030-12-05',
+      startTime: '18:00',
+      endTime: '20:00',
+      expectedGuests: 20,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INDIVIDUAL',
+      status: 'REJECTED',
+    });
+
+    await page.goto('/reservations');
+    await page.getByPlaceholder(/Search by name/).fill('Reopenable Booking');
+    const row = page.getByTestId('reservation-row').filter({ hasText: 'Reopenable Booking' });
+    await expect(row).toHaveCount(1);
+    await row.click();
+    await expect(page.getByTestId('reservation-status')).toContainText('REJECTED');
+    await captureScreenshot(testInfo, page, '1-rejected');
+
+    // Move it back to pending (email stays off — internal correction).
+    await page.getByTestId('reopen-reservation').click();
+    await page.getByTestId('reopen-dialog-submit').click();
+    await expect(page.getByTestId('reservation-status')).toContainText('PENDING');
+    await captureScreenshot(testInfo, page, '2-back-to-pending');
+
+    // Now pending, it offers confirm/reject again and can be confirmed straight away.
+    await page.getByTestId('confirm-reservation').click();
+    await page.getByTestId('confirm-dialog-submit').click();
+    await expect(page.getByTestId('reservation-status')).toContainText('CONFIRMED');
+    await captureScreenshot(testInfo, page, '3-confirmed-after-reopen');
+  });
 });

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -434,12 +434,16 @@ The available actions depend on the current status:
 - **Complete** — mark as completed after the event has taken place
 - **Cancel** — cancel the reservation (e.g. customer called to cancel)
 
+### Rejected Reservations
+- **Move back to Pending** — reopen a rejected reservation. Use this when the event is going ahead after all (e.g. a different date or location frees up) so you can edit the existing details instead of asking the customer to fill everything in again. The reservation returns to **Pending**, ready to confirm or reject. The customer email is **off** by default for this action — tick the box only if you want to let them know it's being reconsidered.
+- **Remove** — permanently delete the rejected reservation (with confirmation dialog)
+
 ### All Reservations
 - **Edit** — open the edit form to change any field
 - **Delete** — permanently remove (with confirmation dialog)
 
 ### Email Notifications
-Each status change dialog (and the edit form) has a **"Send email notification"** checkbox. For status changes it is **on** by default — uncheck it only if you've already communicated with the customer directly. For the **edit form** it is **off** by default, since most edits are internal tweaks; tick it when a change is worth notifying the customer about.
+Each status change dialog (and the edit form) has a **"Send email notification"** checkbox. For most status changes it is **on** by default — uncheck it only if you've already communicated with the customer directly. For the **edit form** and the **Move back to Pending** action it is **off** by default, since those are usually internal corrections; tick it when the change is worth notifying the customer about.
 
 ### Adding a Message to the Email
 When the email notification is on, every status dialog and the edit form shows an optional **"Add a message to the email"** box. Anything you type here appears as a highlighted note in that email — use it to clarify things the standard template doesn't cover, e.g. *"We read your special request and will keep a shaded spot for you."* For **Reject**, this box is pre-filled with a default reason that you can edit, replace, or clear before sending.`,

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -5,7 +5,7 @@ import {
   ArrowLeft, Calendar, Clock, MapPin, Users, Mail, Phone,
   Building2, CreditCard, UtensilsCrossed, MessageSquare,
   CheckCircle, XCircle, Loader2, AlertCircle, Trash2,
-  Send, Edit, X, FileText, Paperclip, History
+  Send, Edit, X, FileText, Paperclip, History, RotateCcw
 } from 'lucide-react';
 import {
   fetchReservation, updateReservationStatus, deleteReservation, updateReservation,
@@ -67,6 +67,7 @@ export function ReservationDetailPage() {
   const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [showCompleteDialog, setShowCompleteDialog] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showReopenDialog, setShowReopenDialog] = useState(false);
   const [sendEmail, setSendEmail] = useState(true);
   // Optional free-text message added to the status-change email (pre-filled for rejections).
   const [actionMessage, setActionMessage] = useState('');
@@ -382,6 +383,21 @@ export function ReservationDetailPage() {
             </button>
           )}
 
+          {/* A rejected event is often only rejected because the date or location needs to
+              change. Reopening it puts it back to PENDING so staff can edit the existing
+              details instead of asking the customer to submit everything again. */}
+          {reservation.status === 'REJECTED' && (
+            <button
+              onClick={() => { setActionMessage(''); setSendEmail(false); setShowReopenDialog(true); }}
+              data-testid="reopen-reservation"
+              disabled={isUpdating}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 transition-colors"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Move back to Pending
+            </button>
+          )}
+
           {(reservation.status === 'CANCELLED' || reservation.status === 'REJECTED') && (
             <button
               onClick={() => setShowDeleteConfirm(true)}
@@ -521,6 +537,38 @@ export function ReservationDetailPage() {
               </button>
               <button
                 onClick={() => setShowCancelDialog(false)}
+                className="px-4 py-2 rounded-lg border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors"
+              >
+                Go Back
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Reopen (Reject -> Pending) Dialog */}
+        {showReopenDialog && (
+          <div className="mt-4 p-4 rounded-xl bg-yellow-500/10 border border-yellow-500/50">
+            <p className="text-yellow-400 mb-3">
+              Move this rejected reservation back to <strong>Pending</strong>? You'll be able to
+              edit the date, location and other details, then confirm or reject it again.
+              {sendEmail && ' A status-update email will be sent to the customer.'}
+            </p>
+            <EmailMessageField value={actionMessage} onChange={setActionMessage} show={sendEmail} />
+            <div className="flex gap-3 mt-3">
+              <button
+                onClick={() => {
+                  handleStatusChange('PENDING');
+                  setShowReopenDialog(false);
+                }}
+                data-testid="reopen-dialog-submit"
+                disabled={isUpdating}
+                className="px-4 py-2 rounded-lg bg-yellow-500 text-white hover:bg-yellow-600 transition-colors flex items-center gap-2"
+              >
+                {isUpdating ? <Loader2 className="w-4 h-4 animate-spin" /> : <RotateCcw className="w-4 h-4" />}
+                Yes, Move to Pending
+              </button>
+              <button
+                onClick={() => setShowReopenDialog(false)}
                 className="px-4 py-2 rounded-lg border border-dark-700 text-dark-300 hover:bg-dark-800 transition-colors"
               >
                 Go Back

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -326,7 +326,7 @@ export function ReservationDetailPage() {
             Edit Details
           </button>
 
-          {hasCateringActivity && (
+          {hasCateringActivity && reservation.status !== 'REJECTED' && (
             <button
               onClick={openCateringEmailDialog}
               disabled={isUpdating}

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -163,6 +163,73 @@ describe('ReservationDetailPage — custom email message', () => {
   });
 });
 
+describe('ReservationDetailPage — reopen rejected reservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a "Move back to Pending" action only for rejected reservations', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'REJECTED' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    expect(screen.getByTestId('reopen-reservation')).toBeInTheDocument();
+    // A rejected reservation has no confirm/reject/cancel actions.
+    expect(screen.queryByTestId('confirm-reservation')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('cancel-reservation')).not.toBeInTheDocument();
+  });
+
+  it('does not show the reopen action for non-rejected reservations', async () => {
+    // sampleReservation defaults to CONFIRMED.
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    expect(screen.queryByTestId('reopen-reservation')).not.toBeInTheDocument();
+  });
+
+  it('moves a rejected reservation back to PENDING without emailing by default', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'REJECTED' });
+    vi.mocked(updateReservationStatus).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByTestId('reopen-reservation'));
+    // Email is opt-in for this action, so the message field stays hidden.
+    expect(screen.queryByPlaceholderText(/shaded spot/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('reopen-dialog-submit'));
+
+    await waitFor(() =>
+      expect(updateReservationStatus).toHaveBeenCalledWith(1, 'PENDING', 'Staff Member', false, undefined));
+
+    // The badge reflects the new status.
+    await waitFor(() => expect(screen.getByTestId('reservation-status')).toHaveTextContent('PENDING'));
+  });
+
+  it('sends a status email and message when the editor opts in', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, status: 'REJECTED' });
+    vi.mocked(updateReservationStatus).mockResolvedValueOnce({ ...sampleReservation, status: 'PENDING' });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByTestId('reopen-reservation'));
+    // Opt back in to the email.
+    fireEvent.click(screen.getByRole('checkbox', { name: /send email notification to customer/i }));
+
+    const textarea = await screen.findByPlaceholderText(/shaded spot/i);
+    fireEvent.change(textarea, { target: { value: 'Good news — a slot opened up!' } });
+
+    fireEvent.click(screen.getByTestId('reopen-dialog-submit'));
+
+    await waitFor(() =>
+      expect(updateReservationStatus).toHaveBeenCalledWith(
+        1, 'PENDING', 'Staff Member', true, 'Good news — a slot opened up!'));
+  });
+});
+
 describe('ReservationDetailPage — edit email default', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -180,6 +180,26 @@ describe('ReservationDetailPage — reopen rejected reservation', () => {
     expect(screen.queryByTestId('cancel-reservation')).not.toBeInTheDocument();
   });
 
+  it('hides the "Send Catering Options" action for rejected reservations', async () => {
+    const cateringActivities = ['EAT_CATERING'];
+    // A catering reservation that is still pending offers the catering email...
+    vi.mocked(fetchReservation).mockResolvedValueOnce({
+      ...sampleReservation, status: 'PENDING', specialActivities: cateringActivities,
+    });
+    const { unmount } = renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+    expect(screen.getByRole('button', { name: /Send Catering Options/i })).toBeInTheDocument();
+    unmount();
+
+    // ...but once rejected, there's nothing left to cater, so the action is gone.
+    vi.mocked(fetchReservation).mockResolvedValueOnce({
+      ...sampleReservation, status: 'REJECTED', specialActivities: cateringActivities,
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Actions')).toBeInTheDocument(), { timeout: 3000 });
+    expect(screen.queryByRole('button', { name: /Send Catering Options/i })).not.toBeInTheDocument();
+  });
+
   it('does not show the reopen action for non-rejected reservations', async () => {
     // sampleReservation defaults to CONFIRMED.
     renderPage();

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -155,6 +155,30 @@ class AdminReservationControllerTest {
 
     @Test
     @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldReopenRejectedReservationToPending() throws Exception {
+        // Given a previously rejected reservation
+        sampleReservation.setStatus(ReservationStatus.REJECTED);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        // When it is moved back to pending (e.g. to change date/location without re-submission)
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "PENDING")
+                .param("sendEmail", "false"))
+            .andExpect(status().isOk());
+
+        // Then the reservation is persisted as PENDING again...
+        verify(reservationRepository).save(argThat(res ->
+            res.getStatus() == ReservationStatus.PENDING
+        ));
+        // ...and no customer email is sent for this internal correction.
+        verify(emailNotificationService, never()).sendStatusChangeEmail(any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
     void updateStatus_shouldCancelReservation() throws Exception {
         // Given
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));


### PR DESCRIPTION
## Move a rejected reservation back to pending

Sometimes a reservation is rejected only because the date or location needs to change, and the event is still going ahead. Until now the only action available on a rejected reservation was Remove, which forced staff to ask the customer to submit everything again. This adds a "Move back to Pending" action so staff can reopen a rejected reservation and edit the existing details instead.

### What changed
- Admin reservation detail page now shows a "Move back to Pending" action on rejected reservations, with a confirmation dialog that returns the reservation to PENDING so it can be edited and then confirmed or rejected again.
- The customer email is off by default for this action since it is usually an internal correction. Staff can opt in, and when they do they can add a message to the email.
- Updated the in-app help guide (Status Actions) to document the new action and its email default.

### Backend
No production change was needed. The status endpoint already accepted any target status, so the gap was purely the missing UI action. Added a controller test to lock in the REJECTED to PENDING transition and confirm no email is sent when sendEmail is false.

### Tests
- Admin unit tests covering the action visibility (rejected only), the default no-email path, and the opt-in email path.
- Backend controller test for the reject to pending transition.
- Playwright e2e journey: seed a rejected reservation, move it back to pending, then confirm it, plus a new row in the regression coverage map.

All admin unit tests, the backend controller test, lint, and build pass.