### PR TITLE
303 feature recurring appointments on pdf export

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -150,6 +150,7 @@ faster layers.
 | RBAC (viewer/editor/admin) | `usePermissions` | filter tests | `admin/rbac` |
 | Audit log | `AuditDiff`/`AuditService` | controller tests | `admin/audit-log` |
 | Catering-only export (#280) | — | `PdfExportServiceTest` | `admin/catering-export` |
+| Appointments on the PDF export (#303) | — | `PdfExportServiceTest`, `AppointmentRecurrenceServiceTest` | `admin/appointments-export` |
 | Week overview | `WeekOverviewPage` test | — | `admin/week-overview` |
 | Calendar feeds (iCal) | — | `ICalendarServiceTest` | `public/calendar-feed` |
 | Recurring appointments (incl. "Nth weekday", #286) | `recurrence` + `CalendarAppointmentsPage` tests | `ICalendarServiceTest` | `admin/calendar-appointments` |

--- a/e2e/fixtures/backend.ts
+++ b/e2e/fixtures/backend.ts
@@ -95,6 +95,32 @@ export async function seedReservation(
   return res.json();
 }
 
+export interface SeedAppointment {
+  title: string;
+  description?: string;
+  date: string;            // yyyy-mm-dd
+  allDay?: boolean;
+  startTime?: string;      // HH:mm (omit for all-day)
+  endTime?: string;        // HH:mm (omit for all-day)
+  location: string;        // 'HUBBLE' | 'METEOR'
+  recurrenceType?: string; // defaults to NONE
+  recurrenceInterval?: number;
+  recurrenceWeekOfMonth?: number;
+  recurrenceDayOfWeek?: string;
+  recurrenceEndDate?: string;
+  enabled?: boolean;
+}
+
+/** Seed a calendar appointment directly; returns the saved row (with its id). */
+export async function seedAppointment(
+  request: APIRequestContext,
+  appointment: SeedAppointment
+): Promise<{ id: number }> {
+  const res = await request.post(`${BACKEND_URL}/test/appointments`, { data: appointment });
+  if (!res.ok()) throw new Error(`/test/appointments failed: ${res.status()}`);
+  return res.json();
+}
+
 /** Auth headers for calling /api/admin/* as a seeded user in e2e (see E2eSecurityConfig). */
 export function adminAuthHeaders(oid: string): Record<string, string> {
   return { 'X-Test-Oid': oid };

--- a/e2e/tests/admin/appointments-export.spec.ts
+++ b/e2e/tests/admin/appointments-export.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { statSync } from 'node:fs';
+import { resetBackend, seedUser, seedAppointment } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Appointments on the PDF export (#303): a calendar appointment that falls on the
+ * exported day appears in the daily PDF, so people without portal access find it there.
+ * Verifies the UI toggle -> endpoint -> PDF download path end-to-end (the appointment
+ * selection/rendering itself is unit-tested in PdfExportServiceTest). The appointment is
+ * seeded directly so the test stays isolated from the appointments-page UI.
+ */
+test.describe('admin: appointments on the PDF export', () => {
+  const DATE = '2030-12-12';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedUser(request, { oid: 'e2e-admin', email: 'admin@e2e.test', role: 'ADMIN' });
+    // HUBBLE matches the export page's default location.
+    await seedAppointment(request, {
+      title: 'Beer delivery',
+      description: 'Crates dropped at the back door',
+      date: DATE,
+      startTime: '09:00',
+      endTime: '10:00',
+      location: 'HUBBLE',
+    });
+  });
+
+  test('downloads a daily PDF that includes the day\'s appointment', async ({ page }, testInfo) => {
+    await page.goto('/export');
+    await page.getByTestId('export-date').fill(DATE);
+    // Appointments appear regardless of the confirmed-only default, so no reservation is needed.
+    await captureScreenshot(testInfo, page, '1-export-with-appointment');
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByTestId('export-submit').click(),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+    const path = await download.path();
+    expect(statSync(path).size).toBeGreaterThan(0);
+    await testInfo.attach('daily-report-with-appointment.pdf', { path, contentType: 'application/pdf' });
+  });
+});

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -176,6 +176,10 @@ You can combine the two toggles, e.g. **Confirmed only + Catering only** for a c
 
 The PDF will automatically download to your device.
 
+## Calendar Appointments
+
+If any **calendar appointments** (from the Calendar Appointments page, including recurring ones) fall on the selected date and location, they appear on a **leading page** before the reservations — so people without portal access still see them on the printout. Appointments are always included regardless of the **Confirmed only** / **Catering only** toggles, which only filter reservations.
+
 ## When to Use This
 
 - **Before opening** — print the day's reservation list for the bar

--- a/the-harry-list-admin/src/pages/ExportPage.tsx
+++ b/the-harry-list-admin/src/pages/ExportPage.tsx
@@ -220,6 +220,7 @@ export function ExportPage() {
       <div className="bg-dark-800/50 border border-dark-700 rounded-xl p-5 max-w-xl">
         <h3 className="text-sm font-semibold text-white mb-3">What's included in the report?</h3>
         <ul className="text-sm text-dark-300 space-y-1.5">
+          <li>• A leading appointments page when calendar appointments fall on the selected date</li>
           <li>• All reservations for the selected date and location</li>
           <li>• Contact details (name, email, phone, organization)</li>
           <li>• Event details (title, time, guests, type)</li>

--- a/the-harry-list-admin/src/test/ExportPage.test.tsx
+++ b/the-harry-list-admin/src/test/ExportPage.test.tsx
@@ -53,5 +53,10 @@ describe('ExportPage', () => {
       .querySelector('input[type="checkbox"]') as HTMLInputElement;
     expect(cateringCheckbox).not.toBeChecked();
   });
+
+  it('notes that appointments appear on the report', () => {
+    renderWithRouter(<ExportPage />);
+    expect(screen.getByText(/appointments page/i)).toBeInTheDocument();
+  });
 });
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/TestSupportController.java
@@ -3,7 +3,9 @@ package com.pimvanleeuwen.the_harry_list_backend.controller;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminRole;
 import com.pimvanleeuwen.the_harry_list_backend.model.AdminUser;
 import com.pimvanleeuwen.the_harry_list_backend.model.BlockedPeriod;
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
 import com.pimvanleeuwen.the_harry_list_backend.model.FormConstraint;
+import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.repository.AdminUserRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.AuditLogRepository;
@@ -108,5 +110,25 @@ public class TestSupportController {
     @PostMapping("/reservations")
     public ResponseEntity<Reservation> seedReservation(@RequestBody Reservation reservation) {
         return ResponseEntity.ok(reservationRepository.save(reservation));
+    }
+
+    /**
+     * Seed a calendar appointment directly. @PrePersist fills timestamps. Lombok's
+     * {@code @Builder.Default} values are not applied when Jackson uses the no-args
+     * constructor, so the non-null columns (allDay/recurrenceType/enabled) are defaulted
+     * here when the caller omits them.
+     */
+    @PostMapping("/appointments")
+    public ResponseEntity<CalendarAppointment> seedAppointment(@RequestBody CalendarAppointment appointment) {
+        if (appointment.getAllDay() == null) {
+            appointment.setAllDay(false);
+        }
+        if (appointment.getRecurrenceType() == null) {
+            appointment.setRecurrenceType(RecurrenceType.NONE);
+        }
+        if (appointment.getEnabled() == null) {
+            appointment.setEnabled(true);
+        }
+        return ResponseEntity.ok(calendarAppointmentRepository.save(appointment));
     }
 }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AppointmentRecurrenceService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/AppointmentRecurrenceService.java
@@ -1,0 +1,103 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+/**
+ * Resolves whether a {@link CalendarAppointment} occurs on a concrete date.
+ *
+ * <p>This is the backend counterpart to the admin frontend's {@code recurrence.ts}
+ * expander: both interpret the same structured recurrence model (a frequency family
+ * plus an optional "every N" interval and, for {@link RecurrenceType#MONTHLY_NTH_WEEKDAY},
+ * an ordinal week + weekday). Keeping the semantics in one focused service means the PDF
+ * export and any future date-based consumers agree on what "this appointment happens on
+ * day X" means, rather than each re-deriving it.
+ */
+@Service
+public class AppointmentRecurrenceService {
+
+    /**
+     * Whether {@code appointment} has an occurrence on {@code date}, honoring its start
+     * date, optional recurrence end date, and recurrence pattern. Does not consider the
+     * {@code enabled} flag or location — callers decide visibility.
+     */
+    public boolean occursOn(CalendarAppointment appointment, LocalDate date) {
+        if (appointment == null || date == null || appointment.getDate() == null) {
+            return false;
+        }
+
+        LocalDate start = appointment.getDate();
+        if (date.isBefore(start)) {
+            return false;
+        }
+        if (appointment.getRecurrenceEndDate() != null && date.isAfter(appointment.getRecurrenceEndDate())) {
+            return false;
+        }
+
+        RecurrenceType type = appointment.getRecurrenceType() != null
+                ? appointment.getRecurrenceType()
+                : RecurrenceType.NONE;
+        int interval = effectiveInterval(appointment);
+
+        return switch (type) {
+            case NONE -> date.isEqual(start);
+            case DAILY -> daysBetween(start, date) % interval == 0;
+            case WEEKLY -> {
+                long days = daysBetween(start, date);
+                yield days % 7 == 0 && (days / 7) % interval == 0;
+            }
+            case MONTHLY -> date.getDayOfMonth() == start.getDayOfMonth()
+                    && monthsBetween(start, date) % interval == 0;
+            case YEARLY -> date.getDayOfMonth() == start.getDayOfMonth()
+                    && date.getMonthValue() == start.getMonthValue()
+                    && (date.getYear() - start.getYear()) % interval == 0;
+            case MONTHLY_NTH_WEEKDAY -> occursOnNthWeekday(appointment, start, date, interval);
+        };
+    }
+
+    private boolean occursOnNthWeekday(CalendarAppointment appointment, LocalDate start,
+                                       LocalDate date, int interval) {
+        Integer week = appointment.getRecurrenceWeekOfMonth();
+        DayOfWeek day = appointment.getRecurrenceDayOfWeek();
+        if (week == null || day == null) {
+            return false;
+        }
+        if (date.getDayOfWeek() != day) {
+            return false;
+        }
+        if (!isNthWeekdayOfMonth(date, week)) {
+            return false;
+        }
+        return monthsBetween(start, date) % interval == 0;
+    }
+
+    /**
+     * Whether {@code date} is the Nth occurrence of its own weekday within its month.
+     * {@code week} is 1–4 for first–fourth, or -1 for the last occurrence.
+     */
+    private boolean isNthWeekdayOfMonth(LocalDate date, int week) {
+        if (week == -1) {
+            // The last <weekday> of the month: one week later rolls into the next month.
+            return date.plusWeeks(1).getMonthValue() != date.getMonthValue();
+        }
+        return ((date.getDayOfMonth() - 1) / 7) + 1 == week;
+    }
+
+    /** Resolves the effective "every N" interval, defaulting to 1 when unset or invalid. */
+    private int effectiveInterval(CalendarAppointment appointment) {
+        Integer interval = appointment.getRecurrenceInterval();
+        return (interval != null && interval > 0) ? interval : 1;
+    }
+
+    private long daysBetween(LocalDate start, LocalDate date) {
+        return java.time.temporal.ChronoUnit.DAYS.between(start, date);
+    }
+
+    private long monthsBetween(LocalDate start, LocalDate date) {
+        return (long) (date.getYear() - start.getYear()) * 12 + (date.getMonthValue() - start.getMonthValue());
+    }
+}

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
@@ -3,11 +3,13 @@ package com.pimvanleeuwen.the_harry_list_backend.service;
 import org.openpdf.text.*;
 import org.openpdf.text.pdf.*;
 import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
 import com.pimvanleeuwen.the_harry_list_backend.model.InvoiceType;
 import com.pimvanleeuwen.the_harry_list_backend.model.PaymentOption;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.model.SpecialActivity;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +26,8 @@ import java.util.stream.Collectors;
 public class PdfExportService {
 
     private final ReservationRepository reservationRepository;
+    private final CalendarAppointmentRepository calendarAppointmentRepository;
+    private final AppointmentRecurrenceService appointmentRecurrenceService;
 
     // Colors for Hubble and Meteor branding
     private static final Color HUBBLE_PRIMARY = new Color(15, 77, 100);    // #0f4d64
@@ -34,8 +38,12 @@ public class PdfExportService {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("EEEE, d MMMM yyyy");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-    public PdfExportService(ReservationRepository reservationRepository) {
+    public PdfExportService(ReservationRepository reservationRepository,
+                            CalendarAppointmentRepository calendarAppointmentRepository,
+                            AppointmentRecurrenceService appointmentRecurrenceService) {
         this.reservationRepository = reservationRepository;
+        this.calendarAppointmentRepository = calendarAppointmentRepository;
+        this.appointmentRecurrenceService = appointmentRecurrenceService;
     }
 
     public byte[] generateDailyReport(LocalDate date, BarLocation location, boolean confirmedOnly, boolean cateringOnly) throws DocumentException {
@@ -45,6 +53,16 @@ public class PdfExportService {
                 .filter(r -> !confirmedOnly || r.getStatus() == ReservationStatus.CONFIRMED)
                 .filter(r -> !cateringOnly || hasCateringActivity(r))
                 .sorted(Comparator.comparing(r -> r.getStartTime() != null ? r.getStartTime() : java.time.LocalTime.MAX))
+                .toList();
+
+        // Appointments for this date/location (recurrence expanded). Shown regardless of the
+        // confirmed-only/catering-only toggles, which only apply to reservations.
+        List<CalendarAppointment> appointments = calendarAppointmentRepository.findByEnabledTrue().stream()
+                .filter(a -> a.getLocation() != null && a.getLocation().equals(location))
+                .filter(a -> appointmentRecurrenceService.occursOn(a, date))
+                .sorted(Comparator
+                        .comparing((CalendarAppointment a) -> Boolean.TRUE.equals(a.getAllDay()) ? 0 : 1)
+                        .thenComparing(a -> a.getStartTime() != null ? a.getStartTime() : java.time.LocalTime.MAX))
                 .toList();
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -65,8 +83,16 @@ public class PdfExportService {
         Font valueFont = new Font(Font.HELVETICA, 10, Font.NORMAL, Color.BLACK);
         Font smallFont = new Font(Font.HELVETICA, 9, Font.NORMAL, Color.GRAY);
 
-        // Title
         String locationName = location == BarLocation.HUBBLE ? "Hubble Community Café" : "Meteor Community Café";
+
+        // Appointments page first (if any), then continue with reservations as usual.
+        if (!appointments.isEmpty()) {
+            addAppointmentsPage(document, appointments, date, locationName,
+                    primaryColor, titleFont, subtitleFont, headerFont, labelFont, valueFont, smallFont);
+            document.newPage();
+        }
+
+        // Title
         Paragraph title = new Paragraph(locationName, titleFont);
         title.setAlignment(Element.ALIGN_CENTER);
         document.add(title);
@@ -129,6 +155,81 @@ public class PdfExportService {
 
         document.close();
         return baos.toByteArray();
+    }
+
+    /**
+     * Renders the leading "Appointments" page: a compact list of the calendar appointments
+     * that fall on the report date, so staff without portal access still see them. Each row
+     * shows the time (or "All day"), the title, and the description when present.
+     */
+    private void addAppointmentsPage(Document document, List<CalendarAppointment> appointments,
+                                     LocalDate date, String locationName, Color primaryColor,
+                                     Font titleFont, Font subtitleFont, Font headerFont,
+                                     Font labelFont, Font valueFont, Font smallFont)
+            throws DocumentException {
+
+        Paragraph title = new Paragraph(locationName, titleFont);
+        title.setAlignment(Element.ALIGN_CENTER);
+        document.add(title);
+
+        Paragraph datePara = new Paragraph("Appointments for " + date.format(DATE_FORMATTER), subtitleFont);
+        datePara.setAlignment(Element.ALIGN_CENTER);
+        datePara.setSpacingAfter(20);
+        document.add(datePara);
+
+        // Compact table: Time | Details
+        PdfPTable table = new PdfPTable(2);
+        table.setWidthPercentage(100);
+        table.setWidths(new float[]{22, 78});
+        table.setSpacingBefore(5);
+
+        // Header row
+        PdfPCell timeHeader = new PdfPCell(new Phrase("Time", headerFont));
+        timeHeader.setBackgroundColor(primaryColor);
+        timeHeader.setPadding(8);
+        timeHeader.setBorder(Rectangle.NO_BORDER);
+        table.addCell(timeHeader);
+
+        PdfPCell detailHeader = new PdfPCell(new Phrase("Appointment", headerFont));
+        detailHeader.setBackgroundColor(primaryColor);
+        detailHeader.setPadding(8);
+        detailHeader.setBorder(Rectangle.NO_BORDER);
+        table.addCell(detailHeader);
+
+        Color rowBorder = new Color(220, 220, 220);
+        for (CalendarAppointment appointment : appointments) {
+            PdfPCell timeCell = new PdfPCell(new Phrase(formatAppointmentTime(appointment), valueFont));
+            timeCell.setPadding(8);
+            timeCell.setBorderColor(rowBorder);
+            table.addCell(timeCell);
+
+            PdfPCell detailCell = new PdfPCell();
+            detailCell.setPadding(8);
+            detailCell.setBorderColor(rowBorder);
+            Paragraph detail = new Paragraph();
+            detail.add(new Chunk(appointment.getTitle() != null ? appointment.getTitle() : "Untitled", labelFont));
+            if (appointment.getDescription() != null && !appointment.getDescription().isEmpty()) {
+                detail.add(new Chunk("\n" + appointment.getDescription(), smallFont));
+            }
+            detailCell.addElement(detail);
+            table.addCell(detailCell);
+        }
+
+        document.add(table);
+    }
+
+    /** Formats an appointment's time for the list: "All day", a "HH:mm - HH:mm" range, or a single start. */
+    private String formatAppointmentTime(CalendarAppointment appointment) {
+        if (Boolean.TRUE.equals(appointment.getAllDay())) {
+            return "All day";
+        }
+        if (appointment.getStartTime() == null) {
+            return "All day";
+        }
+        if (appointment.getEndTime() != null) {
+            return appointment.getStartTime().format(TIME_FORMATTER) + " - " + appointment.getEndTime().format(TIME_FORMATTER);
+        }
+        return appointment.getStartTime().format(TIME_FORMATTER);
     }
 
     private void addReservationCard(Document document, Reservation res, int number, int total,

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AppointmentRecurrenceServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/AppointmentRecurrenceServiceTest.java
@@ -1,0 +1,167 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AppointmentRecurrenceService#occursOn}, mirroring the semantics
+ * covered by the admin frontend's recurrence expander (recurrence.ts).
+ */
+class AppointmentRecurrenceServiceTest {
+
+    private final AppointmentRecurrenceService service = new AppointmentRecurrenceService();
+
+    private CalendarAppointment.CalendarAppointmentBuilder base(LocalDate date, RecurrenceType type) {
+        return CalendarAppointment.builder()
+                .title("Test")
+                .date(date)
+                .location(BarLocation.HUBBLE)
+                .recurrenceType(type)
+                .enabled(true);
+    }
+
+    // ── NONE ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void none_occursOnlyOnItsOwnDate() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.NONE).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 6, 9)));
+    }
+
+    @Test
+    void never_occursBeforeStartDate() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.DAILY).build();
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 6, 7)));
+    }
+
+    // ── DAILY ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void daily_occursEveryDay() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.DAILY).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 9)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 7, 1)));
+    }
+
+    @Test
+    void daily_withInterval_occursEveryNthDay() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.DAILY)
+                .recurrenceInterval(3).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 6, 9)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 11))); // +3 days
+    }
+
+    // ── WEEKLY ────────────────────────────────────────────────────────────────
+
+    @Test
+    void weekly_occursOnSameWeekday() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.WEEKLY).build(); // Saturday
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 15)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 6, 14))); // Friday
+    }
+
+    @Test
+    void weekly_withInterval_skipsOddWeeks() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.WEEKLY)
+                .recurrenceInterval(2).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 6, 15))); // +1 week
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 22)));  // +2 weeks
+    }
+
+    // ── MONTHLY ───────────────────────────────────────────────────────────────
+
+    @Test
+    void monthly_occursOnSameDayOfMonth() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.MONTHLY).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 7, 8)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 7, 9)));
+    }
+
+    @Test
+    void monthly_withInterval_skipsMonths() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.MONTHLY)
+                .recurrenceInterval(2).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 8)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 7, 8)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 8, 8)));
+    }
+
+    // ── YEARLY ────────────────────────────────────────────────────────────────
+
+    @Test
+    void yearly_occursOnSameMonthAndDay() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.YEARLY).build();
+        assertTrue(service.occursOn(a, LocalDate.of(2031, 6, 8)));
+        assertFalse(service.occursOn(a, LocalDate.of(2031, 6, 9)));
+        assertFalse(service.occursOn(a, LocalDate.of(2031, 7, 8)));
+    }
+
+    // ── MONTHLY_NTH_WEEKDAY ───────────────────────────────────────────────────
+
+    @Test
+    void nthWeekday_occursOnSecondFriday() {
+        // 2030-01-11 is the 2nd Friday of January 2030.
+        CalendarAppointment a = base(LocalDate.of(2030, 1, 11), RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceWeekOfMonth(2)
+                .recurrenceDayOfWeek(DayOfWeek.FRIDAY)
+                .build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 1, 11)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 2, 8)));  // 2nd Friday of Feb 2030
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 2, 1))); // 1st Friday
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 2, 15))); // 3rd Friday
+    }
+
+    @Test
+    void nthWeekday_lastMonday() {
+        // 2030-06-24 is the last Monday of June 2030.
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 24), RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceWeekOfMonth(-1)
+                .recurrenceDayOfWeek(DayOfWeek.MONDAY)
+                .build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 24)));
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 7, 29))); // last Monday of July 2030
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 7, 22))); // 4th Monday, not last
+    }
+
+    @Test
+    void nthWeekday_incompleteConfig_neverOccurs() {
+        CalendarAppointment a = base(LocalDate.of(2030, 1, 11), RecurrenceType.MONTHLY_NTH_WEEKDAY)
+                .recurrenceWeekOfMonth(2)
+                .build(); // missing day of week
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 1, 11)));
+    }
+
+    // ── End date ──────────────────────────────────────────────────────────────
+
+    @Test
+    void recurrenceEndDate_stopsOccurrences() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.DAILY)
+                .recurrenceEndDate(LocalDate.of(2030, 6, 10))
+                .build();
+        assertTrue(service.occursOn(a, LocalDate.of(2030, 6, 10)));
+        assertFalse(service.occursOn(a, LocalDate.of(2030, 6, 11)));
+    }
+
+    // ── Null-safety ───────────────────────────────────────────────────────────
+
+    @Test
+    void nullInputs_returnFalse() {
+        CalendarAppointment a = base(LocalDate.of(2030, 6, 8), RecurrenceType.NONE).build();
+        assertFalse(service.occursOn(null, LocalDate.of(2030, 6, 8)));
+        assertFalse(service.occursOn(a, null));
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportServiceTest.java
@@ -1,16 +1,18 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
-import org.openpdf.text.DocumentException;
 import org.openpdf.text.pdf.PdfReader;
 import org.openpdf.text.pdf.parser.PdfTextExtractor;
 import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.CalendarAppointment;
+import com.pimvanleeuwen.the_harry_list_backend.model.RecurrenceType;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.model.SpecialActivity;
+import com.pimvanleeuwen.the_harry_list_backend.repository.CalendarAppointmentRepository;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -21,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 /**
@@ -33,10 +36,23 @@ class PdfExportServiceTest {
     @Mock
     private ReservationRepository reservationRepository;
 
-    @InjectMocks
+    @Mock
+    private CalendarAppointmentRepository calendarAppointmentRepository;
+
     private PdfExportService pdfExportService;
 
     private static final LocalDate REPORT_DATE = LocalDate.of(2026, 2, 15);
+
+    @BeforeEach
+    void setUp() {
+        // Uses the real recurrence resolver — its behaviour is covered by its own unit test.
+        pdfExportService = new PdfExportService(
+                reservationRepository,
+                calendarAppointmentRepository,
+                new AppointmentRecurrenceService());
+        // Most reservation-focused tests have no appointments; appointment tests override this.
+        lenient().when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of());
+    }
 
     @Test
     void generateDailyReport_cateringOnly_includesOnlyCateringReservations() throws Exception {
@@ -135,7 +151,122 @@ class PdfExportServiceTest {
         assertFalse(text.contains("Plain Drinks"));
     }
 
+    // --- appointment rendering ---
+
+    @Test
+    void generateDailyReport_includesAppointmentsForTheDateAndLocation() throws Exception {
+        // Given: a reservation and an appointment on the report date/location
+        Reservation res = reservation("Evening Drinks", LocalTime.of(20, 0),
+                ReservationStatus.CONFIRMED, Set.of(SpecialActivity.PRIVATE_EVENT));
+        when(reservationRepository.findAll()).thenReturn(List.of(res));
+        CalendarAppointment appt = appointment("Staff Meeting", "Discuss the roster",
+                LocalTime.of(9, 0), LocalTime.of(10, 0), BarLocation.HUBBLE);
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appt));
+
+        // When
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        // Then: the appointments page lists the appointment, and the reservation still appears
+        String text = extractText(pdf);
+        assertTrue(text.contains("Appointments for"), "Appointments section heading should appear");
+        assertTrue(text.contains("Staff Meeting"));
+        assertTrue(text.contains("Discuss the roster"));
+        assertTrue(text.contains("09:00 - 10:00"));
+        assertTrue(text.contains("Evening Drinks"));
+    }
+
+    @Test
+    void generateDailyReport_excludesAppointmentsForOtherLocations() throws Exception {
+        when(reservationRepository.findAll()).thenReturn(List.of());
+        CalendarAppointment meteorAppt = appointment("Meteor Only", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0), BarLocation.METEOR);
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(meteorAppt));
+
+        // When: exporting the HUBBLE report
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        // Then: the Meteor appointment is not shown and no appointments heading appears
+        String text = extractText(pdf);
+        assertFalse(text.contains("Meteor Only"));
+        assertFalse(text.contains("Appointments for"));
+    }
+
+    @Test
+    void generateDailyReport_excludesAppointmentsNotOccurringOnTheDate() throws Exception {
+        when(reservationRepository.findAll()).thenReturn(List.of());
+        // A one-off appointment on a different day
+        CalendarAppointment otherDay = appointment("Other Day", null,
+                LocalTime.of(9, 0), LocalTime.of(10, 0), BarLocation.HUBBLE);
+        otherDay.setDate(REPORT_DATE.plusDays(1));
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(otherDay));
+
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        String text = extractText(pdf);
+        assertFalse(text.contains("Other Day"));
+    }
+
+    @Test
+    void generateDailyReport_includesRecurringAppointmentOnAnOccurrence() throws Exception {
+        when(reservationRepository.findAll()).thenReturn(List.of());
+        // Weekly appointment starting two weeks before the report date — should recur onto it
+        CalendarAppointment weekly = appointment("Weekly Standup", null,
+                LocalTime.of(9, 0), LocalTime.of(9, 30), BarLocation.HUBBLE);
+        weekly.setDate(REPORT_DATE.minusWeeks(2));
+        weekly.setRecurrenceType(RecurrenceType.WEEKLY);
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(weekly));
+
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        String text = extractText(pdf);
+        assertTrue(text.contains("Weekly Standup"));
+    }
+
+    @Test
+    void generateDailyReport_showsAppointmentsEvenWithConfirmedAndCateringOnlyFilters() throws Exception {
+        // Given: no reservations match, but an appointment exists. The filters only apply to
+        // reservations, so the appointment must still appear.
+        when(reservationRepository.findAll()).thenReturn(List.of());
+        CalendarAppointment appt = appointment("Always Visible", null,
+                LocalTime.of(8, 0), null, BarLocation.HUBBLE);
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appt));
+
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, true, true);
+
+        String text = extractText(pdf);
+        assertTrue(text.contains("Always Visible"));
+    }
+
+    @Test
+    void generateDailyReport_rendersAllDayAppointmentTime() throws Exception {
+        when(reservationRepository.findAll()).thenReturn(List.of());
+        CalendarAppointment allDay = appointment("Closed for Holiday", null, null, null, BarLocation.HUBBLE);
+        allDay.setAllDay(true);
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(allDay));
+
+        byte[] pdf = pdfExportService.generateDailyReport(REPORT_DATE, BarLocation.HUBBLE, false, false);
+
+        String text = extractText(pdf);
+        assertTrue(text.contains("Closed for Holiday"));
+        assertTrue(text.contains("All day"));
+    }
+
     // --- helpers ---
+
+    private CalendarAppointment appointment(String title, String description, LocalTime start,
+                                            LocalTime end, BarLocation location) {
+        return CalendarAppointment.builder()
+                .title(title)
+                .description(description)
+                .date(REPORT_DATE)
+                .startTime(start)
+                .endTime(end)
+                .allDay(false)
+                .location(location)
+                .recurrenceType(RecurrenceType.NONE)
+                .enabled(true)
+                .build();
+    }
 
     private Reservation reservation(String title, LocalTime start, ReservationStatus status,
                                     Set<SpecialActivity> activities) {


### PR DESCRIPTION
## Appointments on the PDF export (#303)

Staff asked for calendar appointments to show up in the daily PDF export so people without portal access can still find them. This adds a leading "Appointments" page to the daily report: when calendar appointments fall on the exported date and location, they render first as a compact list (time or "All day", title, and description), then the reservations follow exactly as before. When there are no appointments on the day, the export is unchanged.

### Behavior
Appointments are matched to the report's location, consistent with the ICS calendar feed. Recurring appointments are expanded so any occurrence landing on the report date is included. Appointments always appear regardless of the "Confirmed only" and "Catering only" toggles, since those filters only apply to reservations.

### Changes
Backend: new `AppointmentRecurrenceService.occursOn(appointment, date)` that mirrors the admin `recurrence.ts` semantics (DAILY/WEEKLY/MONTHLY/YEARLY intervals, MONTHLY_NTH_WEEKDAY, start and end-date bounds). `PdfExportService` now pulls enabled appointments, filters by location and occurrence, and renders the leading appointments page. Added an e2e-only `POST /test/appointments` seed endpoint.

Admin: documented the new behavior on the Export page "What's included" list and in its HelpGuide.

E2E: `seedAppointment` fixture plus an `admin/appointments-export` spec that seeds an appointment and asserts the daily PDF downloads, with a coverage-map row.

### Testing
Backend 331 passing (14 new recurrence tests, 6 new PDF rendering tests). Admin 137 passing. Admin production build clean. New e2e spec passing against a freshly rebuilt stack.