### PR TITLE
fix(admin): show inside/outside seating area on reservation details

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -144,6 +144,7 @@ faster layers.
 | Form constraints (all types) | form tests | `ConstraintValidationServiceTest` | `public/constraints-blocking`, `public/constraints-dynamic`, `admin/constraints-roundtrip` |
 | Confirm a reservation (appears in admin) | `ReservationsPage`/detail tests | controller tests | `admin/reservation-lifecycle` #1 |
 | Edit / remove a reservation | `ReservationDetailPage` test | `Update`/`DeleteReservationServiceTest` | `admin/reservation-lifecycle` #2 |
+| Seating area (inside/outside) shown in detail (#292) | `ReservationDetailPage` test | — | `admin/reservation-lifecycle` #2 |
 | Reopen a rejected reservation to pending | `ReservationDetailPage` test | `AdminReservationControllerTest` | `admin/reservation-lifecycle` #3 |
 | Status-change email + custom message | — | `AdminReservationControllerTest` | `admin/status-email` |
 | Editable email templates | — | `EmailTemplateServiceTest` | `admin/email-template` |

--- a/e2e/tests/admin/reservation-lifecycle.spec.ts
+++ b/e2e/tests/admin/reservation-lifecycle.spec.ts
@@ -81,6 +81,10 @@ test.describe('admin: reservation lifecycle', () => {
     await row.click();
     await expect(page.getByTestId('reservation-status')).toContainText('PENDING');
 
+    // The inside/outside seating area is visible in read mode (#292) — staff no longer
+    // have to open the editor to find out where the reservation is seated.
+    await expect(page.getByTestId('seating-area-badge')).toContainText('Inside');
+
     // Edit the guest count.
     await page.getByTestId('edit-reservation').click();
     // The "send update email" notification defaults to OFF — editing should be silent

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -416,7 +416,7 @@ export const reservationDetailGuide: GuideSection[] = [
 ## Information Sections
 
 - **Contact Information** — name, email, phone number
-- **Event Details** — title, date, start/end time, location, guest count
+- **Event Details** — title, date, start/end time, location, seating area (Inside / Outside), guest count
 - **Activities** — selected special activities (catering, à la carte, etc.)
 - **Additional Notes** — any comments the customer added
 - **Payment** — payment option and invoice details (if applicable)

--- a/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
+++ b/the-harry-list-admin/src/pages/ReservationDetailPage.tsx
@@ -5,7 +5,8 @@ import {
   ArrowLeft, Calendar, Clock, MapPin, Users, Mail, Phone,
   Building2, CreditCard, UtensilsCrossed, MessageSquare,
   CheckCircle, XCircle, Loader2, AlertCircle, Trash2,
-  Send, Edit, X, FileText, Paperclip, History, RotateCcw
+  Send, Edit, X, FileText, Paperclip, History, RotateCcw,
+  Home, Sun
 } from 'lucide-react';
 import {
   fetchReservation, updateReservationStatus, deleteReservation, updateReservation,
@@ -616,6 +617,18 @@ export function ReservationDetailPage() {
             <InfoRow icon={Calendar} label="Date" value={new Date(reservation.eventDate).toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })} />
             <InfoRow icon={Clock} label="Time" value={`${reservation.startTime.slice(0, 5)} - ${reservation.endTime.slice(0, 5)}`} />
             <InfoRow icon={MapPin} label="Location" value={reservation.location} />
+            {/* Inside/outside is set on booking and editable, but was previously only visible
+                in edit mode — surface it here so staff can see it at a glance. */}
+            {(reservation.seatingArea === 'INSIDE' || reservation.seatingArea === 'OUTSIDE') && (
+              <div className="flex items-start gap-3">
+                <div className="pl-7">
+                  <div className="text-xs text-dark-500">Seating Area</div>
+                  <div className="mt-1">
+                    <SeatingAreaBadge area={reservation.seatingArea} />
+                  </div>
+                </div>
+              </div>
+            )}
             <InfoRow icon={Users} label="Expected Guests" value={reservation.expectedGuests.toString()} />
             <div className="flex items-start gap-3">
               <div className="pl-7">
@@ -1266,6 +1279,26 @@ function InfoRow({ icon: Icon, label, value }: { icon?: typeof Users; label: str
         <div className="text-white">{value}</div>
       </div>
     </div>
+  );
+}
+
+// Surfaces the inside/outside seating area as a colored badge so staff can see it at a
+// glance, without having to open the editor.
+function SeatingAreaBadge({ area }: { area: string }) {
+  const isInside = area === 'INSIDE';
+  const Icon = isInside ? Home : Sun;
+  return (
+    <span
+      data-testid="seating-area-badge"
+      className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border ${
+        isInside
+          ? 'bg-green-500/20 text-green-400 border-green-500/30'
+          : 'bg-amber-500/20 text-amber-400 border-amber-500/30'
+      }`}
+    >
+      <Icon className="w-3 h-3" />
+      {isInside ? 'Inside' : 'Outside'}
+    </span>
   );
 }
 

--- a/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
+++ b/the-harry-list-admin/src/test/ReservationDetailPage.test.tsx
@@ -250,6 +250,39 @@ describe('ReservationDetailPage — reopen rejected reservation', () => {
   });
 });
 
+describe('ReservationDetailPage — seating area indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an "Inside" badge in read mode without opening the editor', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, seatingArea: 'INSIDE' });
+
+    renderPage();
+
+    const badge = await screen.findByTestId('seating-area-badge', {}, { timeout: 3000 });
+    expect(badge).toHaveTextContent('Inside');
+  });
+
+  it('shows an "Outside" badge in read mode', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, seatingArea: 'OUTSIDE' });
+
+    renderPage();
+
+    const badge = await screen.findByTestId('seating-area-badge', {}, { timeout: 3000 });
+    expect(badge).toHaveTextContent('Outside');
+  });
+
+  it('hides the badge when no seating area is stored', async () => {
+    vi.mocked(fetchReservation).mockResolvedValueOnce({ ...sampleReservation, seatingArea: undefined });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Birthday Party')).toBeInTheDocument(), { timeout: 3000 });
+
+    expect(screen.queryByTestId('seating-area-badge')).not.toBeInTheDocument();
+  });
+});
+
 describe('ReservationDetailPage — edit email default', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Problem
The seating area (inside/outside) was captured at booking and editable in the edit modal, but the read-only Event Details card never displayed it. Staff had to open the editor just to see whether a reservation was inside or outside.

## Fix
Added a colored Inside/Outside badge to the Event Details card on the reservation detail page. The badge is hidden when no seating area is stored, so older incomplete records stay clean.

## Tests & docs
Added three ReservationDetailPage unit tests (Inside badge, Outside badge, hidden-when-absent), extended the admin/reservation-lifecycle e2e spec to assert the badge is visible in read mode, and updated the in-app help guide plus the e2e coverage map.

Verification: admin unit tests 15/15 pass, admin build passes, lint clean, e2e typecheck passes.