### PR TITLE
309 feature filter calendar on catering or non catering

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,14 @@ Subscribe to reservations from any calendar app (Google Calendar, Outlook, Apple
 |-----------|-------------|
 | `status` | Filter by status: `PENDING`, `CONFIRMED`, `REJECTED`, `CANCELLED` (comma-separated) |
 | `location` | Filter by location: `HUBBLE` or `METEOR` |
+| `catering` | `true` for catering events only, `false` for non-catering only (omit for all). Custom calendar appointments count as non-catering |
 | `upcomingOnly` | Set to `true` for future events only |
+
+Filters can be combined freely. Omitting a parameter leaves that dimension unfiltered, so existing feed URLs keep working unchanged.
 
 **Examples:**
 - All confirmed: `?token=XXX&status=CONFIRMED`
 - Hubble upcoming: `?token=XXX&location=HUBBLE&upcomingOnly=true`
+- Hubble catering only: `?token=XXX&location=HUBBLE&catering=true`
+- Non-catering events: `?token=XXX&catering=false`
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -154,7 +154,7 @@ faster layers.
 | Catering-only export (#280) | — | `PdfExportServiceTest` | `admin/catering-export` |
 | Appointments on the PDF export (#303) | — | `PdfExportServiceTest`, `AppointmentRecurrenceServiceTest` | `admin/appointments-export` |
 | Week overview | `WeekOverviewPage` test | — | `admin/week-overview` |
-| Calendar feeds (iCal) | — | `ICalendarServiceTest` | `public/calendar-feed` |
+| Calendar feeds (iCal) incl. catering filter (#309) | — | `ICalendarServiceTest`, `ReservationTest` | `public/calendar-feed` |
 | Recurring appointments (incl. "Nth weekday", #286) | `recurrence` + `CalendarAppointmentsPage` tests | `ICalendarServiceTest` | `admin/calendar-appointments` |
 | Mobile date/time fields (#253) | — | — | `mobile-public/datetime` |
 

--- a/e2e/tests/public/calendar-feed.spec.ts
+++ b/e2e/tests/public/calendar-feed.spec.ts
@@ -44,4 +44,65 @@ test.describe('calendar feed (iCal)', () => {
     expect(ics).toContain('BEGIN:VEVENT');
     expect(ics).toContain('Calendar Feed Event');
   });
+
+  test('filters by catering and concatenates with location', async ({ request }, testInfo) => {
+    // The beforeEach seeded a non-catering Hubble event ("Calendar Feed Event").
+    // Add a Hubble catering event and a Meteor catering event.
+    await seedReservation(request, {
+      contactName: 'Catering Guest',
+      email: 'catering@example.com',
+      eventTitle: 'Hubble Catering Event',
+      description: 'Has catering',
+      eventDate: '2030-10-21',
+      startTime: '12:00',
+      endTime: '14:00',
+      expectedGuests: 30,
+      location: 'HUBBLE',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INVOICE',
+      status: 'CONFIRMED',
+      specialActivities: ['EAT_CATERING'],
+    });
+    await seedReservation(request, {
+      contactName: 'Meteor Guest',
+      email: 'meteor@example.com',
+      eventTitle: 'Meteor Catering Event',
+      description: 'Meteor catering',
+      eventDate: '2030-10-22',
+      startTime: '12:00',
+      endTime: '14:00',
+      expectedGuests: 15,
+      location: 'METEOR',
+      seatingArea: 'INSIDE',
+      paymentOption: 'INVOICE',
+      status: 'CONFIRMED',
+      specialActivities: ['EAT_CATERING'],
+    });
+
+    // catering=true → only catering events, the non-catering one is gone.
+    const cateringOnly = await request.get(`${BACKEND_URL}/api/calendar/feed.ics?token=${FEED_TOKEN}&catering=true`);
+    expect(cateringOnly.status()).toBe(200);
+    const cateringIcs = await cateringOnly.text();
+    await attachText(testInfo, 'catering-true.ics', cateringIcs);
+    expect(cateringIcs).toContain('Hubble Catering Event');
+    expect(cateringIcs).toContain('Meteor Catering Event');
+    expect(cateringIcs).not.toContain('Calendar Feed Event');
+
+    // catering=false → only non-catering events.
+    const nonCatering = await request.get(`${BACKEND_URL}/api/calendar/feed.ics?token=${FEED_TOKEN}&catering=false`);
+    expect(nonCatering.status()).toBe(200);
+    const nonCateringIcs = await nonCatering.text();
+    await attachText(testInfo, 'catering-false.ics', nonCateringIcs);
+    expect(nonCateringIcs).toContain('Calendar Feed Event');
+    expect(nonCateringIcs).not.toContain('Hubble Catering Event');
+
+    // location=HUBBLE&catering=true → concatenated: only the Hubble catering event.
+    const combined = await request.get(`${BACKEND_URL}/api/calendar/feed.ics?token=${FEED_TOKEN}&location=HUBBLE&catering=true`);
+    expect(combined.status()).toBe(200);
+    const combinedIcs = await combined.text();
+    await attachText(testInfo, 'hubble-catering.ics', combinedIcs);
+    expect(combinedIcs).toContain('Hubble Catering Event');
+    expect(combinedIcs).not.toContain('Meteor Catering Event');
+    expect(combinedIcs).not.toContain('Calendar Feed Event');
+  });
 });

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -222,7 +222,18 @@ Click the **"Add to Google Calendar"** link to open Google Calendar with the fee
 ### Important
 Calendar feeds update automatically — new and changed reservations appear within a few hours. You only need to subscribe once.
 
-Staff feed URLs contain a security token. **Do not share staff feed URLs** with people outside the team.`,
+Staff feed URLs contain a security token. **Do not share staff feed URLs** with people outside the team.
+
+## Filtering a Feed
+
+Each feed URL already includes a **location** filter. You can append extra parameters from the **Additional URL Parameters** section to narrow it further, and combine them:
+
+- \`&catering=true\` — only events that include catering (eat à la carte, eat catering, or Catering Corona Room)
+- \`&catering=false\` — only events **without** catering (custom calendar appointments count as non-catering)
+- \`&status=CONFIRMED\` — only a specific status
+- \`&upcomingOnly=true\` — hide past events
+
+For example, appending \`&catering=true\` to the Hubble staff feed gives a calendar of just the Hubble catering events. Leaving a parameter off keeps everything for that dimension, so any link you've already subscribed to keeps working unchanged.`,
   },
 ];
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarController.java
@@ -162,6 +162,12 @@ public class AdminCalendarController {
         status.example = "&status=CONFIRMED";
         params.add(status);
 
+        ParameterInfo catering = new ParameterInfo();
+        catering.name = "catering";
+        catering.description = "Show only catering events (true) or only non-catering events (false). Omit to show all. Combines with the other filters.";
+        catering.example = "&catering=true";
+        params.add(catering);
+
         ParameterInfo upcomingOnly = new ParameterInfo();
         upcomingOnly.name = "upcomingOnly";
         upcomingOnly.description = "Only show future events";

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/open/CalendarFeedController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/open/CalendarFeedController.java
@@ -50,6 +50,7 @@ public class CalendarFeedController {
             @RequestParam(required = false) String token,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String location,
+            @RequestParam(required = false) Boolean catering,
             @RequestParam(required = false, defaultValue = "false") boolean upcomingOnly) {
 
         // Validate token if configured (constant-time comparison to prevent timing attacks)
@@ -59,7 +60,7 @@ public class CalendarFeedController {
             }
         }
 
-        return generateFeed(status, location, upcomingOnly, false, "reservations.ics");
+        return generateFeed(status, location, catering, upcomingOnly, false, "reservations.ics");
     }
 
     @GetMapping(value = "/staff-feed.ics", produces = "text/calendar")
@@ -73,6 +74,7 @@ public class CalendarFeedController {
             @RequestParam(required = false) String token,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String location,
+            @RequestParam(required = false) Boolean catering,
             @RequestParam(required = false, defaultValue = "false") boolean upcomingOnly) {
 
         // Validate staff token (required, must be different from public token)
@@ -83,10 +85,10 @@ public class CalendarFeedController {
             return ResponseEntity.status(401).body("Invalid or missing staff token");
         }
 
-        return generateFeed(status, location, upcomingOnly, true, "staff-reservations.ics");
+        return generateFeed(status, location, catering, upcomingOnly, true, "staff-reservations.ics");
     }
 
-    private ResponseEntity<String> generateFeed(String status, String location, boolean upcomingOnly,
+    private ResponseEntity<String> generateFeed(String status, String location, Boolean catering, boolean upcomingOnly,
                                                   boolean includeConfidential, String filename) {
         // Parse status filter
         List<ReservationStatus> statusFilter = null;
@@ -105,9 +107,9 @@ public class CalendarFeedController {
         // Generate calendar
         String icsContent;
         if (upcomingOnly) {
-            icsContent = iCalendarService.generateUpcomingCalendarFeed(statusFilter, location, includeConfidential);
+            icsContent = iCalendarService.generateUpcomingCalendarFeed(statusFilter, location, catering, includeConfidential);
         } else {
-            icsContent = iCalendarService.generateCalendarFeed(statusFilter, location, includeConfidential);
+            icsContent = iCalendarService.generateCalendarFeed(statusFilter, location, catering, includeConfidential);
         }
 
         HttpHeaders headers = new HttpHeaders();
@@ -147,6 +149,7 @@ public class CalendarFeedController {
         info.parameters.token = "Required authentication token";
         info.parameters.status = "Optional: Filter by status (comma-separated: PENDING,CONFIRMED,REJECTED,CANCELLED)";
         info.parameters.location = "Optional: Filter by location (HUBBLE or METEOR)";
+        info.parameters.catering = "Optional: Set to true for catering events only, false for non-catering only (omit for all). Combine with other filters, e.g. location=HUBBLE&catering=true";
         info.parameters.upcomingOnly = "Optional: Set to true to only show upcoming events";
 
         info.instructions = new CalendarInfo.Instructions();
@@ -174,6 +177,7 @@ public class CalendarFeedController {
             public String token;
             public String status;
             public String location;
+            public String catering;
             public String upcomingOnly;
         }
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/Reservation.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/Reservation.java
@@ -215,6 +215,23 @@ public class Reservation {
         updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * Whether this reservation includes catering, i.e. it has one of the
+     * catering-related special activities ({@link SpecialActivity#EAT_A_LA_CARTE},
+     * {@link SpecialActivity#EAT_CATERING} or {@link SpecialActivity#CATERING_CORONA_ROOM}).
+     *
+     * <p>This is the single source of truth for "is this a catering event?" and is
+     * shared by the PDF day-report export, the ICS calendar feeds and the staff
+     * feed description. Note it reflects the <em>requested</em> activities, not the
+     * {@link #cateringArranged} follow-up flag.
+     */
+    public boolean hasCateringActivity() {
+        return specialActivities != null && specialActivities.stream()
+                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE
+                        || a == SpecialActivity.EAT_CATERING
+                        || a == SpecialActivity.CATERING_CORONA_ROOM);
+    }
+
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     /**

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
@@ -37,6 +37,20 @@ public class ICalendarService {
     }
 
     public String generateCalendarFeed(List<ReservationStatus> includeStatuses, String location, boolean includeConfidentialDetails) {
+        return generateCalendarFeed(includeStatuses, location, null, includeConfidentialDetails);
+    }
+
+    /**
+     * Generates the full ICS feed, optionally filtered by catering.
+     *
+     * @param catering {@code null} = all events (default, backward compatible);
+     *                 {@code true} = only catering reservations;
+     *                 {@code false} = only non-catering events. Custom calendar
+     *                 appointments carry no catering attribute and are treated as
+     *                 non-catering: included when {@code catering} is null/false,
+     *                 excluded when {@code catering} is true.
+     */
+    public String generateCalendarFeed(List<ReservationStatus> includeStatuses, String location, Boolean catering, boolean includeConfidentialDetails) {
         List<Reservation> reservations = reservationRepository.findAll();
 
         if (includeStatuses != null && !includeStatuses.isEmpty()) {
@@ -51,12 +65,23 @@ public class ICalendarService {
                     .toList();
         }
 
-        List<CalendarAppointment> appointments = getFilteredAppointments(location);
+        reservations = filterByCatering(reservations, catering);
+
+        List<CalendarAppointment> appointments = getFilteredAppointments(location, catering);
 
         return buildIcsCalendar(reservations, appointments, includeConfidentialDetails);
     }
 
     public String generateUpcomingCalendarFeed(List<ReservationStatus> includeStatuses, String location, boolean includeConfidentialDetails) {
+        return generateUpcomingCalendarFeed(includeStatuses, location, null, includeConfidentialDetails);
+    }
+
+    /**
+     * Generates the upcoming-only ICS feed, optionally filtered by catering.
+     * See {@link #generateCalendarFeed(List, String, Boolean, boolean)} for the
+     * catering filter semantics.
+     */
+    public String generateUpcomingCalendarFeed(List<ReservationStatus> includeStatuses, String location, Boolean catering, boolean includeConfidentialDetails) {
         LocalDate today = LocalDate.now();
         List<Reservation> reservations = reservationRepository.findAll().stream()
                 .filter(r -> r.getEventDate() != null && !r.getEventDate().isBefore(today))
@@ -74,7 +99,9 @@ public class ICalendarService {
                     .toList();
         }
 
-        List<CalendarAppointment> appointments = getFilteredAppointments(location).stream()
+        reservations = filterByCatering(reservations, catering);
+
+        List<CalendarAppointment> appointments = getFilteredAppointments(location, catering).stream()
                 .filter(a -> {
                     if (a.getRecurrenceType() != RecurrenceType.NONE) {
                         // Recurring: include if no end date or end date is in the future
@@ -88,7 +115,23 @@ public class ICalendarService {
         return buildIcsCalendar(reservations, appointments, includeConfidentialDetails);
     }
 
-    private List<CalendarAppointment> getFilteredAppointments(String location) {
+    /** Filters reservations to catering-only or non-catering-only; no-op when {@code catering} is null. */
+    private List<Reservation> filterByCatering(List<Reservation> reservations, Boolean catering) {
+        if (catering == null) {
+            return reservations;
+        }
+        return reservations.stream()
+                .filter(r -> r.hasCateringActivity() == catering)
+                .toList();
+    }
+
+    private List<CalendarAppointment> getFilteredAppointments(String location, Boolean catering) {
+        // Appointments carry no catering attribute, so they count as non-catering:
+        // when the feed is restricted to catering events, drop them entirely.
+        if (Boolean.TRUE.equals(catering)) {
+            return List.of();
+        }
+
         List<CalendarAppointment> appointments = calendarAppointmentRepository.findByEnabledTrue();
 
         if (location != null && !location.isEmpty()) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarService.java
@@ -264,9 +264,7 @@ public class ICalendarService {
         }
 
         // Catering
-        boolean hasCateringActivity = activities != null && activities.stream()
-                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE || a == SpecialActivity.EAT_CATERING || a == SpecialActivity.CATERING_CORONA_ROOM);
-        if (hasCateringActivity) {
+        if (reservation.hasCateringActivity()) {
             sb.append("\nCatering Arranged: ").append(reservation.isCateringArranged() ? "Yes ✓" : "Not yet").append("\n");
         }
         if (reservation.getCateringDietaryNotes() != null && !reservation.getCateringDietaryNotes().isEmpty()) {

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/PdfExportService.java
@@ -51,7 +51,7 @@ public class PdfExportService {
                 .filter(r -> r.getEventDate() != null && r.getEventDate().equals(date))
                 .filter(r -> r.getLocation() != null && r.getLocation().equals(location))
                 .filter(r -> !confirmedOnly || r.getStatus() == ReservationStatus.CONFIRMED)
-                .filter(r -> !cateringOnly || hasCateringActivity(r))
+                .filter(r -> !cateringOnly || r.hasCateringActivity())
                 .sorted(Comparator.comparing(r -> r.getStartTime() != null ? r.getStartTime() : java.time.LocalTime.MAX))
                 .toList();
 
@@ -329,7 +329,7 @@ public class PdfExportService {
         contentCell.addElement(content);
 
         // Add catering info if present
-        if (hasCateringActivity(res)) {
+        if (res.hasCateringActivity()) {
             Paragraph cateringStatusPara = new Paragraph();
             cateringStatusPara.setSpacingBefore(10);
             cateringStatusPara.add(new Chunk("Catering Arranged: ", labelFont));
@@ -568,18 +568,6 @@ public class PdfExportService {
         cell.setHorizontalAlignment(alignment);
         cell.setPaddingTop(5);
         table.addCell(cell);
-    }
-
-    /**
-     * Whether a reservation includes catering, i.e. has one of the catering-related
-     * special activities. Used both to filter the report (cateringOnly) and to decide
-     * whether to render the catering info block on a reservation card.
-     */
-    private boolean hasCateringActivity(Reservation res) {
-        return res.getSpecialActivities() != null && res.getSpecialActivities().stream()
-                .anyMatch(a -> a == SpecialActivity.EAT_A_LA_CARTE
-                        || a == SpecialActivity.EAT_CATERING
-                        || a == SpecialActivity.CATERING_CORONA_ROOM);
     }
 
     private void addField(Paragraph para, String label, String value, Font labelFont, Font valueFont) {

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminCalendarControllerTest.java
@@ -86,6 +86,7 @@ class AdminCalendarControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.parameters", hasSize(greaterThan(0))))
             .andExpect(jsonPath("$.parameters[?(@.name=='status')]").exists())
+            .andExpect(jsonPath("$.parameters[?(@.name=='catering')]").exists())
             .andExpect(jsonPath("$.parameters[?(@.name=='upcomingOnly')]").exists());
     }
 

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/ReservationTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/model/ReservationTest.java
@@ -160,4 +160,52 @@ class ReservationTest {
         // Then
         assertEquals("Large graduation ceremony with dinner", reservation.getLongReservationReason());
     }
+
+    @Test
+    void hasCateringActivity_shouldBeFalseWhenNoActivities() {
+        assertFalse(reservation.hasCateringActivity());
+
+        reservation.setSpecialActivities(Set.of());
+        assertFalse(reservation.hasCateringActivity());
+    }
+
+    @Test
+    void hasCateringActivity_shouldBeFalseForNonCateringActivities() {
+        // Given - only non-catering activities
+        reservation.setSpecialActivities(Set.of(SpecialActivity.GRADUATION, SpecialActivity.PRIVATE_EVENT));
+
+        // Then
+        assertFalse(reservation.hasCateringActivity());
+    }
+
+    @Test
+    void hasCateringActivity_shouldBeTrueForEachCateringActivity() {
+        for (SpecialActivity catering : new SpecialActivity[]{
+                SpecialActivity.EAT_A_LA_CARTE,
+                SpecialActivity.EAT_CATERING,
+                SpecialActivity.CATERING_CORONA_ROOM}) {
+            Reservation r = new Reservation();
+            r.setSpecialActivities(Set.of(catering));
+            assertTrue(r.hasCateringActivity(), () -> catering + " should count as catering");
+        }
+    }
+
+    @Test
+    void hasCateringActivity_shouldBeTrueWhenMixedWithNonCatering() {
+        // Given - a catering activity alongside a non-catering one
+        reservation.setSpecialActivities(Set.of(SpecialActivity.GRADUATION, SpecialActivity.EAT_CATERING));
+
+        // Then
+        assertTrue(reservation.hasCateringActivity());
+    }
+
+    @Test
+    void hasCateringActivity_shouldNotDependOnCateringArrangedFlag() {
+        // Given - catering requested but not yet arranged
+        reservation.setSpecialActivities(Set.of(SpecialActivity.EAT_CATERING));
+        reservation.setCateringArranged(false);
+
+        // Then - still counts as a catering event (reflects requested activities)
+        assertTrue(reservation.hasCateringActivity());
+    }
 }

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ICalendarServiceTest.java
@@ -39,8 +39,9 @@ class ICalendarServiceTest {
     @BeforeEach
     void setUp() {
         sampleReservation = createSampleReservation();
-        // Default: no appointments (existing tests should not be affected)
-        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(Collections.emptyList());
+        // Default: no appointments (existing tests should not be affected). Lenient because the
+        // catering-only path short-circuits and never queries the appointment repository.
+        lenient().when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(Collections.emptyList());
     }
 
     @Test
@@ -167,6 +168,113 @@ class ICalendarServiceTest {
         // Then
         assertTrue(ics.contains("Future Event"));
         assertFalse(ics.contains("Past Event"));
+    }
+
+    // ===== Catering Filter Tests =====
+
+    @Test
+    void generateCalendarFeed_shouldDefaultToAllWhenCateringNull() {
+        Reservation cateringReservation = createCateringReservation();
+        when(reservationRepository.findAll()).thenReturn(Arrays.asList(sampleReservation, cateringReservation));
+
+        // catering = null => no catering filtering (backward compatible)
+        String ics = iCalendarService.generateCalendarFeed(null, null, null, false);
+
+        assertTrue(ics.contains("Test Event"));
+        assertTrue(ics.contains("Catering Event"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldFilterCateringOnly() {
+        Reservation cateringReservation = createCateringReservation();
+        when(reservationRepository.findAll()).thenReturn(Arrays.asList(sampleReservation, cateringReservation));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, true, false);
+
+        assertTrue(ics.contains("Catering Event"));
+        assertFalse(ics.contains("Test Event"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldFilterNonCateringOnly() {
+        Reservation cateringReservation = createCateringReservation();
+        when(reservationRepository.findAll()).thenReturn(Arrays.asList(sampleReservation, cateringReservation));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false, false);
+
+        assertTrue(ics.contains("Test Event"));
+        assertFalse(ics.contains("Catering Event"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldExcludeAppointmentsWhenCateringOnly() {
+        // Appointments have no catering attribute => treated as non-catering => dropped from a catering-only feed
+        Reservation cateringReservation = createCateringReservation();
+        CalendarAppointment appointment = createSampleAppointment();
+        when(reservationRepository.findAll()).thenReturn(List.of(cateringReservation));
+        // Lenient: catering-only short-circuits before the appointment repo is queried — that
+        // early exit is precisely the behaviour under test (appointments never reach the feed).
+        lenient().when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, true, false);
+
+        assertTrue(ics.contains("Catering Event"));
+        assertFalse(ics.contains("Staff Meeting"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldIncludeAppointmentsWhenNonCateringOnly() {
+        // Appointments count as non-catering, so they stay in a non-catering feed
+        Reservation cateringReservation = createCateringReservation();
+        CalendarAppointment appointment = createSampleAppointment();
+        when(reservationRepository.findAll()).thenReturn(Arrays.asList(sampleReservation, cateringReservation));
+        when(calendarAppointmentRepository.findByEnabledTrue()).thenReturn(List.of(appointment));
+
+        String ics = iCalendarService.generateCalendarFeed(null, null, false, false);
+
+        assertTrue(ics.contains("Test Event"));
+        assertTrue(ics.contains("Staff Meeting"));
+        assertFalse(ics.contains("Catering Event"));
+    }
+
+    @Test
+    void generateCalendarFeed_shouldCombineLocationAndCateringFilters() {
+        // Hubble catering (should match), Meteor catering (wrong location), Hubble non-catering (wrong catering)
+        Reservation hubbleCatering = createCateringReservation();
+        hubbleCatering.setLocation(BarLocation.HUBBLE);
+
+        Reservation meteorCatering = createCateringReservation();
+        meteorCatering.setLocation(BarLocation.METEOR);
+        meteorCatering.setEventTitle("Meteor Catering Event");
+
+        Reservation hubbleNonCatering = createSampleReservation();
+        hubbleNonCatering.setLocation(BarLocation.HUBBLE);
+        hubbleNonCatering.setEventTitle("Hubble Plain Event");
+
+        when(reservationRepository.findAll()).thenReturn(Arrays.asList(hubbleCatering, meteorCatering, hubbleNonCatering));
+
+        String ics = iCalendarService.generateCalendarFeed(null, "HUBBLE", true, false);
+
+        assertTrue(ics.contains("Catering Event"));
+        assertFalse(ics.contains("Meteor Catering Event"));
+        assertFalse(ics.contains("Hubble Plain Event"));
+    }
+
+    @Test
+    void generateUpcomingCalendarFeed_shouldApplyCateringFilter() {
+        Reservation futureCatering = createCateringReservation();
+        futureCatering.setEventDate(LocalDate.now().plusDays(5));
+
+        Reservation futurePlain = createSampleReservation();
+        futurePlain.setEventDate(LocalDate.now().plusDays(5));
+        futurePlain.setEventTitle("Future Plain Event");
+
+        when(reservationRepository.findAll()).thenReturn(Arrays.asList(futureCatering, futurePlain));
+
+        String ics = iCalendarService.generateUpcomingCalendarFeed(null, null, true, false);
+
+        assertTrue(ics.contains("Catering Event"));
+        assertFalse(ics.contains("Future Plain Event"));
     }
 
     // ===== Calendar Appointment Tests =====
@@ -500,6 +608,14 @@ class ICalendarServiceTest {
         reservation.setExpectedGuests(20);
         reservation.setStatus(ReservationStatus.CONFIRMED);
         reservation.setConfirmationNumber("ABC123");
+        return reservation;
+    }
+
+    private Reservation createCateringReservation() {
+        Reservation reservation = createSampleReservation();
+        reservation.setId(2L);
+        reservation.setEventTitle("Catering Event");
+        reservation.setSpecialActivities(java.util.Set.of(SpecialActivity.EAT_CATERING));
         return reservation;
     }
 }

--- a/the-harry-list-public/src/index.css
+++ b/the-harry-list-public/src/index.css
@@ -369,6 +369,12 @@ body {
   background-color: rgba(3, 15, 20, 0.04);
 }
 
+.light .bg-meteor-950\/50 {
+  /* meteor-950 is a near-black gray; in light mode use a faint meteor-green tint
+     to match the hubble-950/50 notice instead of rendering a dark grey block */
+  background-color: rgba(5, 56, 38, 0.05);
+}
+
 .light .bg-meteor-500\/10 {
   background-color: rgba(5, 56, 38, 0.06);
 }
@@ -408,6 +414,10 @@ body {
 
 .light .border-meteor-500\/30 {
   border-color: rgba(5, 56, 38, 0.2);
+}
+
+.light .border-meteor-800\/50 {
+  border-color: rgba(2, 22, 16, 0.12);
 }
 
 .light .border-red-500\/20 {


### PR DESCRIPTION
## Summary

Adds a `catering` filter to the ICS calendar feeds so staff can subscribe to a calendar of just catering events, just non-catering events, or all events. The filter concatenates with the existing `location`, `status`, and `upcomingOnly` filters (for example `?location=HUBBLE&catering=true`). Existing feed links that do not include the parameter are unchanged and keep working exactly as before.

Also includes a separate light-mode styling fix for the post-booking spam-folder notice that was rendering with a dark background.

Closes #309

## What changed

**Catering filter (backend)**
- Extracted the catering definition onto the `Reservation` domain model as `hasCateringActivity()` (catering means one of `EAT_A_LA_CARTE`, `EAT_CATERING`, `CATERING_CORONA_ROOM`), replacing the duplicated checks in `PdfExportService` and the ICS staff-feed description. No behaviour change.
- Added `Boolean catering` overloads to `ICalendarService`. The previous three-argument signatures now delegate with `catering=null`, so all existing callers are untouched. Reservations filter on `hasCateringActivity() == catering`. Custom calendar appointments have no catering attribute and are treated as non-catering: shown in the non-catering feed, hidden from the catering feed.
- Wired the `catering` request parameter through both `/api/calendar/feed.ics` and `/api/calendar/staff-feed.ics`, documented it on the `/info` endpoint, and surfaced it in the admin Calendar Feeds page parameter list.

**Docs and tests**
- Updated the README feed filter table and the in-app Calendar Feeds help guide.
- Added unit tests for `Reservation.hasCateringActivity()`, catering-only, non-catering-only, appointment handling, and location plus catering concatenation, plus an admin controller assertion.
- Added a Playwright spec proving catering-only, non-catering-only, and combined location plus catering feeds, and updated the e2e coverage map.

**Light-mode fix (public)**
- The post-booking spam-folder notice used `bg-meteor-950/50` and `border-meteor-800/50`, which had no light-mode overrides (unlike the hubble-based Important Notice box), so `meteor-950` (#343436) rendered as a dark grey block with low-contrast text. Added the matching `.light` overrides with a faint meteor-green tint.

## Backward compatibility

Omitting `catering` leaves that dimension unfiltered, so previously subscribed feed URLs behave identically. The audit log and editable email-template features are unaffected.

## Testing

- Backend: 343 of 343 tests pass.
- Public and admin typecheck clean, public production build succeeds, `SuccessMessage` test passes.
- e2e spec compiles and is ready to run against the docker stack via `cd e2e && npm test`.