### PR TITLE
Constraint notice

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -143,6 +143,7 @@ faster layers.
 | Sender / spam-folder notice on confirmation (#310) | `SuccessMessage` test | — | `public/happy-path` |
 | Soft / hard blocked periods | `blockedPeriods` + form tests | `ConstraintValidationServiceTest` | `public/soft-block`, `public/hard-block`, `admin/blocked-periods` |
 | Form constraints (all types) | form tests | `ConstraintValidationServiceTest` | `public/constraints-blocking`, `public/constraints-dynamic`, `admin/constraints-roundtrip` |
+| Activity notice (advisory, non-blocking) | `ReservationForm` + `FormSettingsPage` tests | `ConstraintValidationServiceTest` | `public/activity-notice` |
 | Confirm a reservation (appears in admin) | `ReservationsPage`/detail tests | controller tests | `admin/reservation-lifecycle` #1 |
 | Edit / remove a reservation | `ReservationDetailPage` test | `Update`/`DeleteReservationServiceTest` | `admin/reservation-lifecycle` #2 |
 | Seating area (inside/outside) shown in detail (#292) | `ReservationDetailPage` test | — | `admin/reservation-lifecycle` #2 |

--- a/e2e/pages/ReservationFormPage.ts
+++ b/e2e/pages/ReservationFormPage.ts
@@ -73,6 +73,11 @@ export class ReservationFormPage {
     await this.page.getByText(label, { exact: true }).click();
   }
 
+  /** Advisory notices (ACTIVITY_NOTICE) shown when a triggering activity is selected. */
+  activityNotices(): Locator {
+    return this.page.getByTestId('activity-notice');
+  }
+
   // ---- Blocked-period notice (soft or hard) ----
   blockedNotice(): Locator {
     return this.page.getByTestId('blocked-date-notice');

--- a/e2e/tests/public/activity-notice.spec.ts
+++ b/e2e/tests/public/activity-notice.spec.ts
@@ -30,12 +30,12 @@ test.describe('public: activity notice', () => {
     // No notice until the triggering activity is chosen.
     await expect(form.activityNotices()).toHaveCount(0);
 
-    await form.toggleActivity('Private Event');
+    await form.toggleActivity('Private event');
     await expect(form.activityNotices()).toHaveText(NOTICE);
     await captureScreenshot(testInfo, page, '1-notice-shown');
 
     // Deselecting the activity removes the notice — it is purely advisory.
-    await form.toggleActivity('Private Event');
+    await form.toggleActivity('Private event');
     await expect(form.activityNotices()).toHaveCount(0);
   });
 });

--- a/e2e/tests/public/activity-notice.spec.ts
+++ b/e2e/tests/public/activity-notice.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { resetBackend, seedConstraint } from '../../fixtures/backend';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * An ACTIVITY_NOTICE constraint shows an advisory message when its trigger activity is
+ * selected (e.g. "a private event at Meteor costs money"), without blocking the booking.
+ * Representative of the form surfacing configured, non-enforcing notices.
+ */
+test.describe('public: activity notice', () => {
+  const NOTICE = 'A private event at Meteor has an additional charge.';
+
+  test.beforeEach(async ({ request }) => {
+    await resetBackend(request);
+    await seedConstraint(request, {
+      constraintType: 'ACTIVITY_NOTICE',
+      triggerActivity: 'PRIVATE_EVENT',
+      message: NOTICE,
+    });
+  });
+
+  test('shows the notice when the activity is selected and hides it when deselected', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+    await form.fillContact({ name: 'Nora Notice', email: 'nora.notice@example.com' });
+    await form.continue();
+    await form.expectStep('Activity Details');
+
+    // No notice until the triggering activity is chosen.
+    await expect(form.activityNotices()).toHaveCount(0);
+
+    await form.toggleActivity('Private Event');
+    await expect(form.activityNotices()).toHaveText(NOTICE);
+    await captureScreenshot(testInfo, page, '1-notice-shown');
+
+    // Deselecting the activity removes the notice — it is purely advisory.
+    await form.toggleActivity('Private Event');
+    await expect(form.activityNotices()).toHaveCount(0);
+  });
+});

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.8.3",
+      "version": "1.9.0",
       "dependencies": {
         "@azure/msal-browser": "^5.14.0",
         "@azure/msal-react": "^5.4.5",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/lib/guideContent.ts
+++ b/the-harry-list-admin/src/lib/guideContent.ts
@@ -346,6 +346,7 @@ Constraints are rules that enforce business logic on the reservation form. Each 
 - **Advance Booking** — requires a minimum number of days between booking and event date
 - **Time Restriction** — limits available time slots for certain activities
 - **Guest Minimum** — sets a minimum guest count for a specific location (e.g. Meteor minimum 1 person)
+- **Activity Notice** — shows an advisory message when an activity is selected, without blocking the booking (e.g. "A private event at Meteor has an additional charge")
 
 ### Adding a Constraint
 

--- a/the-harry-list-admin/src/pages/FormSettingsPage.tsx
+++ b/the-harry-list-admin/src/pages/FormSettingsPage.tsx
@@ -26,6 +26,7 @@ const CONSTRAINT_TYPES = [
   { value: 'ADVANCE_BOOKING', label: 'Advance Booking' },
   { value: 'GUEST_LIMIT', label: 'Guest Limit' },
   { value: 'GUEST_MINIMUM', label: 'Guest Minimum' },
+  { value: 'ACTIVITY_NOTICE', label: 'Activity Notice' },
 ];
 
 const ACTIVITIES = [
@@ -466,26 +467,30 @@ export function SettingsPage() {
                   </div>
                 )}
 
-                <div>
-                  <label className="block text-sm text-dark-400 mb-1">Target Value</label>
-                  <input
-                    type="text"
-                    data-testid="constraint-target"
-                    value={editingConstraint.targetValue || ''}
-                    onChange={e => setEditingConstraint({ ...editingConstraint, targetValue: e.target.value })}
-                    placeholder="e.g. EAT_A_LA_CARTE, HUBBLE, INSIDE"
-                    className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
-                  />
-                  <p className="text-xs text-dark-500 mt-1">
-                    {editingConstraint.constraintType === 'ACTIVITY_CONFLICT' && 'The conflicting activity'}
-                    {editingConstraint.constraintType === 'LOCATION_LOCK' && 'The locked location (HUBBLE or METEOR)'}
-                    {editingConstraint.constraintType === 'SEATING_LOCK' && 'The locked seating (INSIDE or OUTSIDE)'}
-                    {editingConstraint.constraintType === 'TIME_RESTRICTION' && 'e.g. EARLY_ACCESS'}
-                    {editingConstraint.constraintType === 'ADVANCE_BOOKING' && 'Leave empty (use numeric value)'}
-                    {editingConstraint.constraintType === 'GUEST_LIMIT' && 'Leave empty (use numeric value)'}
-                    {editingConstraint.constraintType === 'GUEST_MINIMUM' && 'The location this minimum applies to (HUBBLE or METEOR), or leave empty for all locations'}
-                  </p>
-                </div>
+                {/* ACTIVITY_NOTICE is advisory only — it needs just a trigger activity and
+                    a message, so the target value field is hidden for it. */}
+                {editingConstraint.constraintType !== 'ACTIVITY_NOTICE' && (
+                  <div>
+                    <label className="block text-sm text-dark-400 mb-1">Target Value</label>
+                    <input
+                      type="text"
+                      data-testid="constraint-target"
+                      value={editingConstraint.targetValue || ''}
+                      onChange={e => setEditingConstraint({ ...editingConstraint, targetValue: e.target.value })}
+                      placeholder="e.g. EAT_A_LA_CARTE, HUBBLE, INSIDE"
+                      className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
+                    />
+                    <p className="text-xs text-dark-500 mt-1">
+                      {editingConstraint.constraintType === 'ACTIVITY_CONFLICT' && 'The conflicting activity'}
+                      {editingConstraint.constraintType === 'LOCATION_LOCK' && 'The locked location (HUBBLE or METEOR)'}
+                      {editingConstraint.constraintType === 'SEATING_LOCK' && 'The locked seating (INSIDE or OUTSIDE)'}
+                      {editingConstraint.constraintType === 'TIME_RESTRICTION' && 'e.g. EARLY_ACCESS'}
+                      {editingConstraint.constraintType === 'ADVANCE_BOOKING' && 'Leave empty (use numeric value)'}
+                      {editingConstraint.constraintType === 'GUEST_LIMIT' && 'Leave empty (use numeric value)'}
+                      {editingConstraint.constraintType === 'GUEST_MINIMUM' && 'The location this minimum applies to (HUBBLE or METEOR), or leave empty for all locations'}
+                    </p>
+                  </div>
+                )}
 
                 {(editingConstraint.constraintType === 'ADVANCE_BOOKING' ||
                   editingConstraint.constraintType === 'GUEST_LIMIT' ||
@@ -531,6 +536,12 @@ export function SettingsPage() {
                     rows={2}
                     className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-white text-sm"
                   />
+                  {editingConstraint.constraintType === 'ACTIVITY_NOTICE' && (
+                    <p className="text-xs text-dark-500 mt-1">
+                      Shown as an informational note when the trigger activity is selected
+                      (e.g. "A private event at Meteor has an additional charge"). It does not block the booking.
+                    </p>
+                  )}
                 </div>
               </div>
 

--- a/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
+++ b/the-harry-list-admin/src/test/FormSettingsPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { FormSettingsPage } from '../pages/FormSettingsPage';
-import { fetchBlockedPeriods } from '../lib/api';
+import { fetchBlockedPeriods, createFormConstraint } from '../lib/api';
 
 vi.mock('../lib/usePermissions', () => ({
   usePermissions: () => ({
@@ -188,6 +188,41 @@ describe('FormSettingsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('New Constraint')).toBeInTheDocument();
+    });
+  });
+
+  it('hides the target value field and saves an Activity Notice constraint', async () => {
+    vi.mocked(createFormConstraint).mockResolvedValueOnce({
+      id: 9,
+      constraintType: 'ACTIVITY_NOTICE',
+      triggerActivity: 'PRIVATE_EVENT',
+      message: 'A private event at Meteor has an additional charge.',
+      enabled: true,
+    });
+
+    renderWithRouter(<FormSettingsPage />);
+    await waitFor(() => expect(screen.getByText('Add Constraint')).toBeInTheDocument(), { timeout: 3000 });
+    fireEvent.click(screen.getByText('Add Constraint'));
+    await waitFor(() => expect(screen.getByText('New Constraint')).toBeInTheDocument());
+
+    // Target Value is shown for the default (Activity Conflict) type.
+    expect(screen.getByTestId('constraint-target')).toBeInTheDocument();
+
+    // Switching to Activity Notice hides the target value field — only trigger + message remain.
+    fireEvent.change(screen.getByTestId('constraint-type'), { target: { value: 'ACTIVITY_NOTICE' } });
+    expect(screen.queryByTestId('constraint-target')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('constraint-trigger'), { target: { value: 'PRIVATE_EVENT' } });
+    fireEvent.change(screen.getByTestId('constraint-message'), {
+      target: { value: 'A private event at Meteor has an additional charge.' },
+    });
+    fireEvent.click(screen.getByTestId('save-constraint'));
+
+    await waitFor(() => expect(createFormConstraint).toHaveBeenCalled());
+    expect(vi.mocked(createFormConstraint).mock.calls[0][0]).toMatchObject({
+      constraintType: 'ACTIVITY_NOTICE',
+      triggerActivity: 'PRIVATE_EVENT',
+      message: 'A private event at Meteor has an additional charge.',
     });
   });
 

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.8.3</version>
+	<version>1.9.0</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/FormConstraintType.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/model/FormConstraintType.java
@@ -10,7 +10,9 @@ public enum FormConstraintType {
     TIME_RESTRICTION("Time Restriction"),
     ADVANCE_BOOKING("Advance Booking"),
     GUEST_LIMIT("Guest Limit"),
-    GUEST_MINIMUM("Guest Minimum");
+    GUEST_MINIMUM("Guest Minimum"),
+    /** Advisory only: shows a message when the trigger activity is selected (no enforcement). */
+    ACTIVITY_NOTICE("Activity Notice");
 
     private final String displayName;
 

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationService.java
@@ -80,6 +80,11 @@ public class ConstraintValidationService {
                     // no server-side enforcement needed (early slots are allowed
                     // when the triggering activity is selected)
                     break;
+                case ACTIVITY_NOTICE:
+                    // Advisory only: the frontend shows the message (e.g. "this option
+                    // costs money") when the trigger activity is selected. Nothing to
+                    // enforce server-side.
+                    break;
                 default:
                     break;
             }

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ConstraintValidationServiceTest.java
@@ -418,4 +418,28 @@ class ConstraintValidationServiceTest {
 
         assertTrue(violations.isEmpty());
     }
+
+    @Test
+    void validate_shouldNotEnforceActivityNotice() {
+        // ACTIVITY_NOTICE is advisory only — the frontend shows the message, but it must
+        // never block a submission even when its trigger activity is selected.
+        FormConstraint notice = FormConstraint.builder()
+                .constraintType(FormConstraintType.ACTIVITY_NOTICE)
+                .triggerActivity("PRIVATE_EVENT")
+                .message("A private event at Meteor has an additional charge.")
+                .enabled(true)
+                .build();
+
+        when(constraintRepository.findByEnabledTrue()).thenReturn(List.of(notice));
+
+        List<String> violations = service.validate(
+                Set.of(SpecialActivity.PRIVATE_EVENT),
+                BarLocation.METEOR,
+                SeatingArea.INSIDE,
+                LocalDate.now().plusDays(10),
+                LocalTime.of(20, 0),
+                30);
+
+        assertTrue(violations.isEmpty());
+    }
 }

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.8.3",
+      "version": "1.9.0",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.59.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-public/src/components/ReservationForm.test.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.test.tsx
@@ -96,6 +96,13 @@ const mockConstraints: FormConstraint[] = [
     message: 'Catering requires 14 days advance booking.',
     enabled: true,
   },
+  {
+    id: 7,
+    constraintType: 'ACTIVITY_NOTICE',
+    triggerActivity: 'PRIVATE_EVENT',
+    message: 'A private event at Meteor has an additional charge.',
+    enabled: true,
+  },
 ];
 
 const mockBlockedPeriods: BlockedPeriod[] = [];
@@ -456,6 +463,35 @@ describe('ReservationForm', () => {
       // CATERING_CORONA_ROOM should now be disabled
       const coronaButton = screen.getByRole('checkbox', { name: 'Catering for Corona Room Event' });
       expect(coronaButton).toBeDisabled();
+    });
+
+    it('shows an advisory notice when an activity with an ACTIVITY_NOTICE is selected', async () => {
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+
+      // No notice until the triggering activity is picked.
+      expect(screen.queryByTestId('activity-notice')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('checkbox', { name: 'Private Event' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-notice')).toHaveTextContent(
+          'A private event at Meteor has an additional charge.'
+        );
+      });
+    });
+
+    it('hides the advisory notice again when the activity is deselected', async () => {
+      const { user } = renderForm();
+      await waitForFormLoaded();
+      await goToStep2(user);
+
+      await user.click(screen.getByRole('checkbox', { name: 'Private Event' }));
+      await waitFor(() => expect(screen.getByTestId('activity-notice')).toBeInTheDocument());
+
+      await user.click(screen.getByRole('checkbox', { name: 'Private Event' }));
+      await waitFor(() => expect(screen.queryByTestId('activity-notice')).not.toBeInTheDocument());
     });
 
     it('shows location conflict for small groups with incompatible activity', async () => {

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -246,6 +246,14 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
     }
   }, [seatingLocked, setValue]);
 
+  // Advisory notices (e.g. "this option costs money") shown when a selected activity
+  // matches an ACTIVITY_NOTICE constraint. Purely informational — no enforcement.
+  const activityNotices = useMemo(() => {
+    return constraints
+      .filter(c => c.constraintType === 'ACTIVITY_NOTICE' && watchSpecialActivities.includes(c.triggerActivity))
+      .map(c => ({ id: c.id, message: c.message }));
+  }, [constraints, watchSpecialActivities]);
+
   // Calculate duration for long reservation warning
   const durationMinutes = useMemo(() => {
     if (!watchStartTime || !watchEndTime) return 0;
@@ -792,6 +800,20 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                     );
                   })}
                 </div>
+                {activityNotices.length > 0 && (
+                  <div className="mt-3 space-y-2" data-testid="activity-notices">
+                    {activityNotices.map(notice => (
+                      <div
+                        key={notice.id}
+                        data-testid="activity-notice"
+                        className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 flex items-start gap-2"
+                      >
+                        <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                        <span>{notice.message}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
 
               {/* Expected Guests */}

--- a/the-harry-list-public/src/types/reservation.ts
+++ b/the-harry-list-public/src/types/reservation.ts
@@ -61,7 +61,7 @@ export interface SelectOption {
 
 export interface FormConstraint {
   id: number;
-  constraintType: 'ACTIVITY_CONFLICT' | 'LOCATION_LOCK' | 'SEATING_LOCK' | 'TIME_RESTRICTION' | 'ADVANCE_BOOKING' | 'GUEST_LIMIT' | 'GUEST_MINIMUM';
+  constraintType: 'ACTIVITY_CONFLICT' | 'LOCATION_LOCK' | 'SEATING_LOCK' | 'TIME_RESTRICTION' | 'ADVANCE_BOOKING' | 'GUEST_LIMIT' | 'GUEST_MINIMUM' | 'ACTIVITY_NOTICE';
   triggerActivity: string;
   targetValue?: string;
   numericValue?: number;


### PR DESCRIPTION
## Add configurable Activity Notice constraint

### Summary
Adds a new `ACTIVITY_NOTICE` form constraint type that shows an advisory message when a guest selects a specific activity, without blocking the booking. This lets staff warn guests that an option costs money (for example a private event at Meteor) directly from the admin Form Settings UI, with no code change needed to add or edit the wording later.

### Why
Selecting the Meteor private event option should tell the guest it carries an additional charge. The existing constraint types all enforce something (conflicts, locks, limits); none could show a purely informational note, so a new advisory type was needed.

### Changes
Backend: new `ACTIVITY_NOTICE` value on `FormConstraintType`, treated as a no-op in `ConstraintValidationService` so it never blocks a submission server-side.

Public form: `ReservationForm` derives notices from the selected activities and renders matching `ACTIVITY_NOTICE` messages as info banners; they clear when the activity is deselected.

Admin: the constraint editor in `FormSettingsPage` offers the new type, hides the unused Target Value field for it, and adds a hint on the message field. The in-app help guide documents the type.

e2e: new `public/activity-notice` spec plus a page-object accessor and a coverage-map row.

### Database
No schema change. `constraint_type` is already a string column, so a notice is just a new row in `form_constraints`. Dev and e2e run `ddl-auto=update`; production runs `validate`, which still passes since no table or column changed.

### Testing
Backend 341 tests pass (1 new). Admin 146 pass (1 new), build and lint clean. Public 95 pass (2 new), build and lint clean. e2e typechecks; the full Dockerized e2e run should be done before merge.

### How to use
In Form Settings add a constraint of type Activity Notice, trigger PRIVATE_EVENT, message for example "A private event at Meteor has an additional charge."