### PR TITLE
v1.9.1

### DIFF
--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@azure/msal-browser": "^5.14.0",
         "@azure/msal-react": "^5.4.5",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-admin/src/lib/translationCrashGuard.ts
+++ b/the-harry-list-admin/src/lib/translationCrashGuard.ts
@@ -1,0 +1,36 @@
+/**
+ * Mitigates a React crash triggered by in-browser page translators
+ * (Google Translate, Microsoft Translator, etc.). Those tools mutate and
+ * reparent text nodes outside of React's control, so when React later commits
+ * an update it can call `removeChild` / `insertBefore` against a node that has
+ * already been moved.
+ */
+export function installTranslationCrashGuard(): void {
+  if (typeof Node !== 'function' || !Node.prototype) return;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function <T extends Node>(this: Node, child: T): T {
+    if (child.parentNode !== this) {
+      if (import.meta.env.DEV) {
+        console.warn('[translationCrashGuard] skipped removeChild of a reparented node', child, this);
+      }
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function <T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null,
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (import.meta.env.DEV) {
+        console.warn('[translationCrashGuard] skipped insertBefore with a foreign reference node', referenceNode, this);
+      }
+      return newNode;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}

--- a/the-harry-list-admin/src/main.tsx
+++ b/the-harry-list-admin/src/main.tsx
@@ -6,10 +6,14 @@ import { BrowserRouter } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 import { msalConfig } from './lib/authConfig';
 import { setMsalInstance } from './lib/api';
+import { installTranslationCrashGuard } from './lib/translationCrashGuard';
 import App from './App';
 import './index.css';
 
 declare const __APP_VERSION__: string;
+
+// Must run before React renders — see translationCrashGuard for details.
+installTranslationCrashGuard();
 
 const sentryDsn = window.__RUNTIME_CONFIG__?.SENTRY_DSN || import.meta.env.VITE_SENTRY_DSN;
 if (sentryDsn && !sentryDsn.startsWith('__')) {
@@ -19,6 +23,13 @@ if (sentryDsn && !sentryDsn.startsWith('__')) {
     release: `the-harry-list-admin@${__APP_VERSION__}`,
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 0.1,
+    // Transient client-side network blips (offline, flaky connection,
+    // navigation aborts) — not actionable server/app bugs.
+    ignoreErrors: [
+      'Failed to fetch',
+      'NetworkError when attempting to fetch resource',
+      'Load failed',
+    ],
   });
 }
 

--- a/the-harry-list-admin/src/test/translationCrashGuard.test.ts
+++ b/the-harry-list-admin/src/test/translationCrashGuard.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { installTranslationCrashGuard } from '../lib/translationCrashGuard';
+
+describe('installTranslationCrashGuard', () => {
+  const originalRemoveChild = Node.prototype.removeChild;
+  const originalInsertBefore = Node.prototype.insertBefore;
+
+  beforeEach(() => {
+    installTranslationCrashGuard();
+  });
+
+  afterEach(() => {
+    // Restore globals so the patch doesn't leak into other suites.
+    Node.prototype.removeChild = originalRemoveChild;
+    Node.prototype.insertBefore = originalInsertBefore;
+  });
+
+  it('still removes a genuine child node', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    expect(parent.removeChild(child)).toBe(child);
+    expect(parent.childNodes.length).toBe(0);
+  });
+
+  it('does not throw when removing a node that was reparented away', () => {
+    const parent = document.createElement('div');
+    const orphan = document.createElement('span'); // never appended to parent
+
+    expect(() => parent.removeChild(orphan)).not.toThrow();
+    expect(parent.removeChild(orphan)).toBe(orphan);
+  });
+
+  it('still inserts before a genuine reference node', () => {
+    const parent = document.createElement('div');
+    const ref = document.createElement('span');
+    const inserted = document.createElement('b');
+    parent.appendChild(ref);
+
+    parent.insertBefore(inserted, ref);
+    expect(parent.firstChild).toBe(inserted);
+  });
+
+  it('does not throw when the reference node has a different parent', () => {
+    const parent = document.createElement('div');
+    const inserted = document.createElement('b');
+    const foreignRef = document.createElement('span');
+    document.createElement('div').appendChild(foreignRef);
+
+    expect(() => parent.insertBefore(inserted, foreignRef)).not.toThrow();
+    expect(parent.insertBefore(inserted, foreignRef)).toBe(inserted);
+  });
+
+  it('appends when the reference node is null', () => {
+    const parent = document.createElement('div');
+    const inserted = document.createElement('b');
+
+    expect(() => parent.insertBefore(inserted, null)).not.toThrow();
+    expect(parent.firstChild).toBe(inserted);
+  });
+});

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -28,6 +28,9 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<!-- Single clean @token@ for resource filtering; avoids the @@ delimiter
+		     collision that left the Sentry release literal/unversioned. -->
+		<sentry.release>the-harry-list-backend@${project.version}</sentry.release>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.9.0</version>
+	<version>1.9.1</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SentryConfig.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SentryConfig.java
@@ -38,6 +38,14 @@ public class SentryConfig {
             if (release != null && !release.isBlank()) {
                 options.setRelease(release);
             }
+            // Drop benign client-disconnect noise (broken pipe / aborted requests)
+            // so it doesn't drown out real server errors.
+            options.setBeforeSend((event, hint) -> {
+                if (SentryEventFilter.isClientDisconnect(event.getThrowable())) {
+                    return null;
+                }
+                return event;
+            });
         });
         log.info("Sentry initialized for environment: {}", environment);
     }

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SentryEventFilter.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/config/SentryEventFilter.java
@@ -1,0 +1,40 @@
+package com.pimvanleeuwen.the_harry_list_backend.config;
+
+/**
+ * Decides whether a captured throwable represents a benign client disconnect
+ * (the browser navigated away or closed the connection mid-response) rather
+ * than a real server fault.
+ *
+ * <p>These show up in Sentry as noise — typically
+ * {@code AsyncRequestNotUsableException} / {@code ClientAbortException} wrapping
+ * {@code java.io.IOException: Broken pipe} — and drown out genuine errors, so we
+ * drop them before sending.
+ */
+public final class SentryEventFilter {
+
+    private SentryEventFilter() {
+    }
+
+    /**
+     * @param throwable the captured exception (may be {@code null})
+     * @return {@code true} if the throwable, or any cause in its chain, is a
+     *         client disconnect that should not be reported to Sentry
+     */
+    public static boolean isClientDisconnect(Throwable throwable) {
+        Throwable current = throwable;
+        int guard = 0; // defend against pathological cause cycles
+        while (current != null && guard++ < 50) {
+            String name = current.getClass().getName();
+            if (name.endsWith("ClientAbortException")
+                    || name.endsWith("AsyncRequestNotUsableException")) {
+                return true;
+            }
+            String message = current.getMessage();
+            if (message != null && message.contains("Broken pipe")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/the-harry-list-backend/src/main/resources/application-prod.properties
+++ b/the-harry-list-backend/src/main/resources/application-prod.properties
@@ -63,7 +63,7 @@ app.initial-admin-oid=${INITIAL_ADMIN_OID:}
 sentry.dsn=${SENTRY_DSN:}
 sentry.environment=production
 sentry.traces-sample-rate=0.1
-sentry.release=the-harry-list-backend@@project.version@
+sentry.release=@sentry.release@
 
 # Calendar ICS Feed Configuration
 calendar.feed.token=${CALENDAR_FEED_TOKEN:}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/config/SentryEventFilterTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/config/SentryEventFilterTest.java
@@ -1,0 +1,53 @@
+package com.pimvanleeuwen.the_harry_list_backend.config;
+
+import org.apache.catalina.connector.ClientAbortException;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SentryEventFilterTest {
+
+    @Test
+    void detectsBrokenPipeNestedInCauseChain() {
+        Throwable ex = new RuntimeException("outer",
+                new IllegalStateException("middle", new IOException("Broken pipe")));
+
+        assertThat(SentryEventFilter.isClientDisconnect(ex)).isTrue();
+    }
+
+    @Test
+    void detectsClientAbortException() {
+        assertThat(SentryEventFilter.isClientDisconnect(
+                new ClientAbortException("connection reset"))).isTrue();
+    }
+
+    @Test
+    void detectsAsyncRequestNotUsableException() {
+        assertThat(SentryEventFilter.isClientDisconnect(
+                new AsyncRequestNotUsableException("ServletOutputStream failed to write"))).isTrue();
+    }
+
+    @Test
+    void allowsGenuineServerErrors() {
+        assertThat(SentryEventFilter.isClientDisconnect(
+                new IllegalStateException("real bug"))).isFalse();
+    }
+
+    @Test
+    void handlesNull() {
+        assertThat(SentryEventFilter.isClientDisconnect(null)).isFalse();
+    }
+
+    @Test
+    void doesNotLoopOnCyclicCauseChain() {
+        RuntimeException a = new RuntimeException("a");
+        RuntimeException b = new RuntimeException("b", a);
+        a.initCause(b); // cycle: a -> b -> a
+
+        // Neither is a disconnect; the guard must terminate rather than hang.
+        assertThat(SentryEventFilter.isClientDisconnect(a)).isFalse();
+    }
+}

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.59.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-public/src/lib/translationCrashGuard.ts
+++ b/the-harry-list-public/src/lib/translationCrashGuard.ts
@@ -1,0 +1,36 @@
+/**
+ * Mitigates a React crash triggered by in-browser page translators
+ * (Google Translate, Microsoft Translator, etc.). Those tools mutate and
+ * reparent text nodes outside of React's control, so when React later commits
+ * an update it can call `removeChild` / `insertBefore` against a node that has
+ * already been moved.
+ */
+export function installTranslationCrashGuard(): void {
+  if (typeof Node !== 'function' || !Node.prototype) return;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function <T extends Node>(this: Node, child: T): T {
+    if (child.parentNode !== this) {
+      if (import.meta.env.DEV) {
+        console.warn('[translationCrashGuard] skipped removeChild of a reparented node', child, this);
+      }
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function <T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null,
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (import.meta.env.DEV) {
+        console.warn('[translationCrashGuard] skipped insertBefore with a foreign reference node', referenceNode, this);
+      }
+      return newNode;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}

--- a/the-harry-list-public/src/main.tsx
+++ b/the-harry-list-public/src/main.tsx
@@ -3,8 +3,12 @@ import { createRoot } from 'react-dom/client'
 import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
+import { installTranslationCrashGuard } from './lib/translationCrashGuard'
 
 declare const __APP_VERSION__: string;
+
+// Must run before React renders — see translationCrashGuard for details.
+installTranslationCrashGuard();
 
 const sentryDsn = window.__RUNTIME_CONFIG__?.SENTRY_DSN || import.meta.env.VITE_SENTRY_DSN;
 if (sentryDsn && !sentryDsn.startsWith('__')) {
@@ -14,6 +18,13 @@ if (sentryDsn && !sentryDsn.startsWith('__')) {
     release: `the-harry-list-public@${__APP_VERSION__}`,
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 0.1,
+    // Transient client-side network blips (offline, flaky mobile, navigation
+    // aborts). Already handled by fetchWithRetry + in-app error UI — not bugs.
+    ignoreErrors: [
+      'Failed to fetch',
+      'NetworkError when attempting to fetch resource',
+      'Load failed',
+    ],
   });
 }
 

--- a/the-harry-list-public/src/test/translationCrashGuard.test.ts
+++ b/the-harry-list-public/src/test/translationCrashGuard.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { installTranslationCrashGuard } from '../lib/translationCrashGuard';
+
+describe('installTranslationCrashGuard', () => {
+  const originalRemoveChild = Node.prototype.removeChild;
+  const originalInsertBefore = Node.prototype.insertBefore;
+
+  beforeEach(() => {
+    installTranslationCrashGuard();
+  });
+
+  afterEach(() => {
+    // Restore globals so the patch doesn't leak into other suites.
+    Node.prototype.removeChild = originalRemoveChild;
+    Node.prototype.insertBefore = originalInsertBefore;
+  });
+
+  it('still removes a genuine child node', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    expect(parent.removeChild(child)).toBe(child);
+    expect(parent.childNodes.length).toBe(0);
+  });
+
+  it('does not throw when removing a node that was reparented away', () => {
+    const parent = document.createElement('div');
+    const orphan = document.createElement('span'); // never appended to parent
+
+    expect(() => parent.removeChild(orphan)).not.toThrow();
+    expect(parent.removeChild(orphan)).toBe(orphan);
+  });
+
+  it('still inserts before a genuine reference node', () => {
+    const parent = document.createElement('div');
+    const ref = document.createElement('span');
+    const inserted = document.createElement('b');
+    parent.appendChild(ref);
+
+    parent.insertBefore(inserted, ref);
+    expect(parent.firstChild).toBe(inserted);
+  });
+
+  it('does not throw when the reference node has a different parent', () => {
+    const parent = document.createElement('div');
+    const inserted = document.createElement('b');
+    const foreignRef = document.createElement('span');
+    document.createElement('div').appendChild(foreignRef);
+
+    expect(() => parent.insertBefore(inserted, foreignRef)).not.toThrow();
+    expect(parent.insertBefore(inserted, foreignRef)).toBe(inserted);
+  });
+
+  it('appends when the reference node is null', () => {
+    const parent = document.createElement('div');
+    const inserted = document.createElement('b');
+
+    expect(() => parent.insertBefore(inserted, null)).not.toThrow();
+    expect(parent.firstChild).toBe(inserted);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the production errors currently showing in Sentry. Three independent fixes plus a backend release-versioning correction so future events are properly tagged.

## What's fixed

### React crash from in-browser page translators (public + admin)
`NotFoundError: Failed to execute 'removeChild' on 'Node'`, triggered when Google Translate (and similar tools) reparent text nodes outside React's control, after which React crashes on its next commit. The `> font > font` wrappers and translated `aria-label`s in the Sentry breadcrumbs confirmed translation as the cause.

- Added `installTranslationCrashGuard()` (`src/lib/translationCrashGuard.ts`) to both frontends, wired in before render. It makes `removeChild`/`insertBefore` no-op instead of throw when a node has been reparented, so React recovers on the next render rather than white-screening.
- Site stays `lang="en"`. The content is English; the crash is client-side translation, not markup.

### Sentry noise filtering
- Backend: `ClientAbortException`, `AsyncRequestNotUsableException`, and `Broken pipe` are benign client disconnects (browser navigated away mid-response), not server faults. New `SentryEventFilter.isClientDisconnect()` walks the cause chain and drops them via `beforeSend`.
- Frontend (both): added `ignoreErrors` for transient network blips (`Failed to fetch`, `NetworkError...`, `Load failed`). These are already handled by `fetchWithRetry` plus the in-app error UI.

### Backend Sentry release versioning
Backend events were tagged `the-harry-list-backend@@project.version@` (literal/unversioned). Cause: the adjacent `@@` collided with Maven's `@...@` resource-filter delimiter. Fixed with a single clean token (`<sentry.release>` pom property plus `@sentry.release@`), verified via `mvn process-resources`, which now resolves to `the-harry-list-backend@1.9.1`.

## Testing
- Public: 100/100. Admin: 151/151. Both `tsc -b` clean.
- Backend: `SentryEventFilterTest` 6/6 (including nested and cyclic cause chains); build succeeds.
- Versioning resolution verified through `mvn process-resources`.