### PR TITLE
v1.9.2

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -144,6 +144,7 @@ faster layers.
 | Soft / hard blocked periods | `blockedPeriods` + form tests | `ConstraintValidationServiceTest` | `public/soft-block`, `public/hard-block`, `admin/blocked-periods` |
 | Form constraints (all types) | form tests | `ConstraintValidationServiceTest` | `public/constraints-blocking`, `public/constraints-dynamic`, `admin/constraints-roundtrip` |
 | Activity notice (advisory, non-blocking) | `ReservationForm` + `FormSettingsPage` tests | `ConstraintValidationServiceTest` | `public/activity-notice` |
+| Privacy policy (GDPR notice + dialog) | `PrivacyPolicy` + `Footer` tests | — | `public/privacy-policy` |
 | Confirm a reservation (appears in admin) | `ReservationsPage`/detail tests | controller tests | `admin/reservation-lifecycle` #1 |
 | Edit / remove a reservation | `ReservationDetailPage` test | `Update`/`DeleteReservationServiceTest` | `admin/reservation-lifecycle` #2 |
 | Seating area (inside/outside) shown in detail (#292) | `ReservationDetailPage` test | — | `admin/reservation-lifecycle` #2 |

--- a/e2e/pages/ReservationFormPage.ts
+++ b/e2e/pages/ReservationFormPage.ts
@@ -78,6 +78,19 @@ export class ReservationFormPage {
     return this.page.getByTestId('activity-notice');
   }
 
+  // ---- Privacy policy ----
+  privacyDialog(): Locator {
+    return this.page.getByTestId('privacy-policy');
+  }
+
+  async openPrivacyFromFooter(): Promise<void> {
+    await this.page.getByTestId('footer-privacy-link').click();
+  }
+
+  async closePrivacy(): Promise<void> {
+    await this.page.getByTestId('privacy-policy-close').click();
+  }
+
   // ---- Blocked-period notice (soft or hard) ----
   blockedNotice(): Locator {
     return this.page.getByTestId('blocked-date-notice');

--- a/e2e/tests/public/privacy-policy.spec.ts
+++ b/e2e/tests/public/privacy-policy.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { ReservationFormPage } from '../../pages/ReservationFormPage';
+import { captureScreenshot } from '../../fixtures/evidence';
+
+/**
+ * Guests must be able to read how their data is handled before submitting personal details
+ * (GDPR). The privacy policy is reachable from the footer and opens in a dialog without
+ * leaving the form.
+ */
+test.describe('public: privacy policy', () => {
+  test('opens from the footer and closes again', async ({ page }, testInfo) => {
+    const form = new ReservationFormPage(page);
+    await form.goto();
+
+    // Not shown until requested.
+    await expect(form.privacyDialog()).toHaveCount(0);
+
+    await form.openPrivacyFromFooter();
+    await expect(form.privacyDialog()).toBeVisible();
+    await expect(form.privacyDialog()).toContainText('Privacy Policy');
+    await captureScreenshot(testInfo, page, '1-privacy-open');
+
+    await form.closePrivacy();
+    await expect(form.privacyDialog()).toHaveCount(0);
+  });
+});

--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "@azure/msal-browser": "^5.14.0",
         "@azure/msal-react": "^5.4.5",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.9.1</version>
+	<version>1.9.2</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.59.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-public/src/App.tsx
+++ b/the-harry-list-public/src/App.tsx
@@ -3,6 +3,7 @@ import { ReservationForm } from './components/ReservationForm';
 import { SuccessMessage } from './components/SuccessMessage';
 import { Header } from './components/Header';
 import { Footer } from './components/Footer';
+import { PrivacyPolicy } from './components/PrivacyPolicy';
 import { ThemeProvider } from './lib/ThemeContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
@@ -16,6 +17,7 @@ interface SubmissionResult {
 function App() {
   const [submitted, setSubmitted] = useState(false);
   const [submissionResult, setSubmissionResult] = useState<SubmissionResult | null>(null);
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
   const handleSuccess = (result: SubmissionResult) => {
     setSubmissionResult(result);
@@ -58,7 +60,7 @@ function App() {
               </div>
 
               {/* Form */}
-              <ReservationForm onSuccess={handleSuccess} />
+              <ReservationForm onSuccess={handleSuccess} onOpenPrivacy={() => setShowPrivacy(true)} />
             </>
           ) : (
             <SuccessMessage
@@ -69,7 +71,8 @@ function App() {
         </div>
       </main>
 
-      <Footer />
+      <Footer onOpenPrivacy={() => setShowPrivacy(true)} />
+      <PrivacyPolicy open={showPrivacy} onClose={() => setShowPrivacy(false)} />
     </div>
     </ThemeProvider>
     </ErrorBoundary>

--- a/the-harry-list-public/src/components/Footer.tsx
+++ b/the-harry-list-public/src/components/Footer.tsx
@@ -1,6 +1,10 @@
 import { ExternalLink } from 'lucide-react';
 
-export function Footer() {
+interface FooterProps {
+  onOpenPrivacy: () => void;
+}
+
+export function Footer({ onOpenPrivacy }: FooterProps) {
   return (
     <footer className="relative z-20 border-t border-dark-800/50 bg-dark-950/80 backdrop-blur-xl">
       <div className="container mx-auto px-4 py-8">
@@ -25,6 +29,14 @@ export function Footer() {
               Meteor Café
               <ExternalLink className="w-3 h-3" />
             </a>
+            <button
+              type="button"
+              onClick={onOpenPrivacy}
+              data-testid="footer-privacy-link"
+              className="text-dark-400 hover:text-hubble-400 transition-colors"
+            >
+              Privacy Policy
+            </button>
           </div>
 
           {/* Made with love */}

--- a/the-harry-list-public/src/components/PrivacyPolicy.test.tsx
+++ b/the-harry-list-public/src/components/PrivacyPolicy.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PrivacyPolicy } from './PrivacyPolicy';
+
+describe('PrivacyPolicy', () => {
+  it('renders nothing when closed', () => {
+    render(<PrivacyPolicy open={false} onClose={vi.fn()} />);
+    expect(screen.queryByTestId('privacy-policy')).not.toBeInTheDocument();
+  });
+
+  it('renders the policy when open', () => {
+    render(<PrivacyPolicy open onClose={vi.fn()} />);
+    expect(screen.getByTestId('privacy-policy')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Privacy Policy' })).toBeInTheDocument();
+  });
+
+  it('exposes the contact address as clickable mailto links', () => {
+    render(<PrivacyPolicy open onClose={vi.fn()} />);
+    const mailLinks = screen.getAllByRole('link', { name: 'privacy@hubble.cafe' });
+    expect(mailLinks.length).toBeGreaterThan(0);
+    mailLinks.forEach(link => expect(link).toHaveAttribute('href', 'mailto:privacy@hubble.cafe'));
+  });
+
+  it('closes via the close button', () => {
+    const onClose = vi.fn();
+    render(<PrivacyPolicy open onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('privacy-policy-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(<PrivacyPolicy open onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('privacy-policy-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close when the dialog body is clicked', () => {
+    const onClose = vi.fn();
+    render(<PrivacyPolicy open onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('privacy-policy'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<PrivacyPolicy open onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/the-harry-list-public/src/components/PrivacyPolicy.tsx
+++ b/the-harry-list-public/src/components/PrivacyPolicy.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'react';
+import { X, ShieldCheck } from 'lucide-react';
+
+/*
+ * Privacy policy shown to guests before they submit personal data.
+ *
+ * Keep the wording in sync with what the backend actually does: data collected, the
+ * retention period (DATA_RETENTION_DAYS), and the processors involved (Microsoft 365,
+ * Sentry, hosting). Have material changes reviewed for legal compliance.
+ */
+
+interface PrivacyPolicyProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const LAST_UPDATED = '2026-06-25';
+
+export function PrivacyPolicy({ open, onClose }: PrivacyPolicyProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  // Close on Escape and move focus to the dialog when it opens.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    closeRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+      data-testid="privacy-policy-backdrop"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="privacy-policy-title"
+        data-testid="privacy-policy"
+        onClick={e => e.stopPropagation()}
+        className="relative w-full max-w-2xl max-h-[85vh] overflow-y-auto rounded-2xl border border-dark-700 bg-dark-900 p-6 md:p-8 shadow-2xl"
+      >
+        <button
+          ref={closeRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close privacy policy"
+          data-testid="privacy-policy-close"
+          className="absolute top-4 right-4 text-dark-400 hover:text-white transition-colors"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        <div className="flex items-center gap-3 mb-6">
+          <div className="p-2 rounded-lg bg-hubble-500/20">
+            <ShieldCheck className="w-5 h-5 text-hubble-400" />
+          </div>
+          <h2 id="privacy-policy-title" className="text-xl font-title font-semibold text-white">
+            Privacy Policy
+          </h2>
+        </div>
+
+        <div className="space-y-5 text-sm text-dark-300 leading-relaxed">
+          <p className="text-dark-400">Last updated: {LAST_UPDATED}</p>
+
+          <section>
+            <h3 className="text-white font-medium mb-1">Who is responsible for your data</h3>
+            <p>
+              This reservation form is operated by Stichting Bar Potential ("we"), the foundation behind Hubble &amp; Meteor Community Cafés. For any privacy question or request you can reach us at{' '}
+              <a href="mailto:privacy@hubble.cafe" className="underline text-hubble-400 hover:text-hubble-300 transition-colors">privacy@hubble.cafe</a>.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-white font-medium mb-1">What we collect</h3>
+            <p>When you submit a reservation request we process the details you enter, including:</p>
+            <ul className="list-disc list-inside mt-1 space-y-0.5">
+              <li>Your name, email address, and (optionally) phone number and organisation</li>
+              <li>Your event details: title, description, date, time, number of guests, and location</li>
+              <li>Payment preference and, for invoices, billing details you provide</li>
+              <li>Any dietary notes or comments you add (please avoid sharing health details you would rather not disclose)</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-white font-medium mb-1">Why we use it and our legal basis</h3>
+            <p>
+              We use this information solely to handle your reservation request, contact you about it, and prepare for your event. The legal basis is taking steps at your request prior to, and performing, an agreement with you (GDPR Art. 6(1)(b)), and our legitimate interest in running the cafés (Art. 6(1)(f)). We do not use your data for marketing or sell it.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-white font-medium mb-1">Who can see it</h3>
+            <p>
+              Your request is visible to café staff. We rely on a small number of service providers that process data on our behalf: Microsoft 365 (to send and receive the confirmation email) and our error-monitoring provider (Sentry) to keep the site reliable. Hosting is provided by sentry.io (operated by Functional Software, Inc.). The reservation form itself uses no tracking cookies and no third-party advertising.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-white font-medium mb-1">How long we keep it</h3>
+            <p>
+              We keep reservation data in our database for up to 457 days after your event, after which it is automatically deleted. Some information also lives in emails; together with the community café web forms, these are deleted after 2 years. We may keep data longer where we must to meet a legal obligation (for example invoicing records).
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-white font-medium mb-1">Your rights</h3>
+            <p>
+              You have the right to access, correct, or delete your data, to object to or restrict its processing, and to data portability. To exercise any of these, contact us at{' '}
+              <a href="mailto:privacy@hubble.cafe" className="underline text-hubble-400 hover:text-hubble-300 transition-colors">privacy@hubble.cafe</a>. You also have the right to lodge a complaint with the Dutch Data Protection Authority (Autoriteit Persoonsgegevens, autoriteitpersoonsgegevens.nl).
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/the-harry-list-public/src/components/ReservationForm.test.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.test.tsx
@@ -126,11 +126,12 @@ function setupMocks() {
   vi.mocked(fetchBlockedPeriods).mockResolvedValue(mockBlockedPeriods);
 }
 
-function renderForm(onSuccess = vi.fn()) {
+function renderForm(onSuccess = vi.fn(), onOpenPrivacy = vi.fn()) {
   return {
     onSuccess,
+    onOpenPrivacy,
     user: userEvent.setup(),
-    ...render(<ReservationForm onSuccess={onSuccess} />),
+    ...render(<ReservationForm onSuccess={onSuccess} onOpenPrivacy={onOpenPrivacy} />),
   };
 }
 
@@ -807,6 +808,16 @@ describe('ReservationForm', () => {
       await waitFor(() => {
         expect(screen.getByText('Server error')).toBeInTheDocument();
       });
+    });
+
+    it('opens the privacy policy from the link by the terms checkbox', async () => {
+      const onOpenPrivacy = vi.fn();
+      const { user } = renderForm(vi.fn(), onOpenPrivacy);
+      await waitForFormLoaded();
+      await navigateToStep5(user);
+
+      await user.click(screen.getByTestId('form-privacy-link'));
+      expect(onOpenPrivacy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/the-harry-list-public/src/components/ReservationForm.tsx
+++ b/the-harry-list-public/src/components/ReservationForm.tsx
@@ -111,6 +111,7 @@ interface ReservationResult {
 
 interface ReservationFormProps {
   onSuccess: (result: ReservationResult) => void;
+  onOpenPrivacy: () => void;
 }
 
 const steps = [
@@ -137,7 +138,7 @@ const SPECIAL_ACTIVITY_DESCRIPTIONS: Record<string, string> = {
   PRIVATE_EVENT: 'Private/closed event (Meteor only)',
 };
 
-export function ReservationForm({ onSuccess }: ReservationFormProps) {
+export function ReservationForm({ onSuccess, onOpenPrivacy }: ReservationFormProps) {
   const [currentStep, setCurrentStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -1405,6 +1406,18 @@ export function ReservationForm({ onSuccess }: ReservationFormProps) {
                 </div>
               </label>
               {errors.termsAccepted && <p className="error-text mt-2">{errors.termsAccepted.message}</p>}
+              <p className="text-xs text-dark-500 mt-3">
+                We use the details you provide only to handle your reservation. See our{' '}
+                <button
+                  type="button"
+                  onClick={onOpenPrivacy}
+                  data-testid="form-privacy-link"
+                  className="underline text-hubble-400 hover:text-hubble-300 transition-colors"
+                >
+                  Privacy Policy
+                </button>
+                {' '}for how we handle your data.
+              </p>
             </div>
 
             {/* ALTCHA proof-of-work widget */}

--- a/the-harry-list-public/src/test/Footer.test.tsx
+++ b/the-harry-list-public/src/test/Footer.test.tsx
@@ -1,19 +1,26 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Footer } from '../components/Footer';
 
 describe('Footer', () => {
   it('renders the footer element', () => {
-    render(<Footer />);
+    render(<Footer onOpenPrivacy={() => {}} />);
     const footer = document.querySelector('footer');
     expect(footer).toBeInTheDocument();
   });
 
   it('contains copyright or contact information', () => {
-    render(<Footer />);
+    render(<Footer onOpenPrivacy={() => {}} />);
     // Footer should contain some text content
     const footer = document.querySelector('footer');
     expect(footer?.textContent?.length).toBeGreaterThan(0);
+  });
+
+  it('opens the privacy policy via its link', () => {
+    const onOpenPrivacy = vi.fn();
+    render(<Footer onOpenPrivacy={onOpenPrivacy} />);
+    fireEvent.click(screen.getByTestId('footer-privacy-link'));
+    expect(onOpenPrivacy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Add privacy policy to the public reservation form

### Summary
The public form collects personal data (name, email, phone, organisation, event and dietary details) but had no privacy policy, no link to one, and no real document behind the terms checkbox. This adds a GDPR-oriented privacy policy so guests are informed before they submit.

### Changes
Adds a `PrivacyPolicy` dialog (accessible: Escape, backdrop click, focus on open, role="dialog") covering who is responsible, what we collect, legal basis, processors (Microsoft 365, Sentry, hosting), retention, and data-subject rights including the Dutch DPA. It is linked from the footer and from a short notice next to the terms checkbox where data is collected. The contact address privacy@hubble.cafe is a clickable mailto link. Retention is documented as 457 days in the database and 2 years for email-stored data (alongside the community café web forms).

### Scope
Public app only. The admin portal is a staff-authenticated internal tool, not a data-subject-facing surface, so it is unchanged.

### Testing
Public unit tests pass (108), build and lint clean. New coverage: `PrivacyPolicy` dialog (open, close, backdrop, Escape, mailto links), a footer link test, and a form link test. Added e2e spec `public/privacy-policy` plus page-object accessors and a coverage-map row.

### Follow-up
Wording should get a final legal review, and the privacy@hubble.cafe inbox needs to be monitored since the policy directs data-subject requests there.