### PR TITLE
v1.9.4

### DIFF
--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "dependencies": {
         "@azure/msal-browser": "^5.14.0",
         "@azure/msal-react": "^5.4.5",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.9.3",
+  "version": "1.9.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.9.3</version>
+	<version>1.9.4</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationService.java
@@ -1,6 +1,7 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
 import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
@@ -17,6 +18,11 @@ import java.util.List;
 public class CreateReservationService implements Command<com.pimvanleeuwen.the_harry_list_backend.dto.Reservation, com.pimvanleeuwen.the_harry_list_backend.dto.Reservation> {
 
     private static final Logger log = LoggerFactory.getLogger(CreateReservationService.class);
+    /**
+     * Dedicated, PII-free analytics logger scraped into Loki (job=app-analytics).
+     * Only ever emit non-identifying, structured logfmt lines here never guest content.
+     */
+    private static final Logger analyticsLog = LoggerFactory.getLogger("analytics");
 
     private final ReservationRepository reservationRepository;
     private final ReservationMapper reservationMapper;
@@ -48,9 +54,10 @@ public class CreateReservationService implements Command<com.pimvanleeuwen.the_h
      */
     public ResponseEntity<com.pimvanleeuwen.the_harry_list_backend.dto.Reservation> executeWithEmail(
             com.pimvanleeuwen.the_harry_list_backend.dto.Reservation input, boolean sendEmail) {
-        log.info("LOGGING reservation.submitted contact='{}' email='{}' event='{}' date={} location={} guests={}",
-                input.getContactName(), input.getEmail(), input.getEventTitle(),
-                input.getEventDate(), input.getLocation(), input.getExpectedGuests());
+        // Note: never log name/email/phone here. These logs are centralized (Loki), so guest
+        // PII must not be written. Event/date/location/guests are operational context only.
+        log.info("LOGGING reservation.submitted event='{}' date={} location={} guests={}",
+                input.getEventTitle(), input.getEventDate(), input.getLocation(), input.getExpectedGuests());
 
         // Validate against dynamic constraints
         List<String> violations = constraintValidationService.validate(
@@ -78,6 +85,11 @@ public class CreateReservationService implements Command<com.pimvanleeuwen.the_h
         log.info("LOGGING reservation.created id={} confirmation='{}' event='{}' date={} location={}",
                 savedEntity.getId(), savedEntity.getConfirmationNumber(),
                 savedEntity.getEventTitle(), savedEntity.getEventDate(), savedEntity.getLocation());
+
+        // Privacy-safe analytics line scraped into Loki (job=app-analytics). PII-free by
+        // contract: only the event name and the bar location. See observability data contract.
+        BarLocation bar = savedEntity.getLocation() != null ? savedEntity.getLocation() : BarLocation.NO_PREFERENCE;
+        analyticsLog.info("APP_ANALYTICS event=reservation_created bar={}", bar.name());
 
         auditService.recordCreate(AuditEntityType.RESERVATION, savedEntity.getId(),
                 savedEntity.getConfirmationNumber() + " - " + savedEntity.getEventTitle(),

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationServiceTest.java
@@ -1,14 +1,19 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.pimvanleeuwen.the_harry_list_backend.dto.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.*;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -45,10 +50,33 @@ class CreateReservationServiceTest {
     private Reservation sampleDto;
     private com.pimvanleeuwen.the_harry_list_backend.model.Reservation sampleEntity;
 
+    private ListAppender<ILoggingEvent> analyticsAppender;
+    private ListAppender<ILoggingEvent> serviceAppender;
+    private Logger analyticsLogger;
+    private Logger serviceLogger;
+
     @BeforeEach
     void setUp() {
         sampleDto = createSampleDto();
         sampleEntity = createSampleEntity();
+
+        analyticsLogger = (Logger) LoggerFactory.getLogger("analytics");
+        serviceLogger = (Logger) LoggerFactory.getLogger(CreateReservationService.class);
+        analyticsAppender = attachAppender(analyticsLogger);
+        serviceAppender = attachAppender(serviceLogger);
+    }
+
+    @AfterEach
+    void tearDown() {
+        analyticsLogger.detachAppender(analyticsAppender);
+        serviceLogger.detachAppender(serviceAppender);
+    }
+
+    private static ListAppender<ILoggingEvent> attachAppender(Logger logger) {
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
     }
 
     @Test
@@ -68,6 +96,69 @@ class CreateReservationServiceTest {
         assertNotNull(response.getBody());
         verify(reservationRepository, times(1)).save(any());
         verify(auditService).recordCreate(eq(AuditEntityType.RESERVATION), eq(1L), any(), any(), any());
+    }
+
+    @Test
+    void execute_shouldEmitExactlyOnePrivacySafeAnalyticsLine() {
+        // Given
+        when(constraintValidationService.validate(any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+        when(reservationMapper.toEntity(any(Reservation.class))).thenReturn(sampleEntity);
+        when(reservationRepository.save(any())).thenReturn(sampleEntity);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        // When
+        createReservationService.execute(sampleDto);
+
+        // Then — exactly one line, in the agreed PII-free contract format.
+        List<ILoggingEvent> events = analyticsAppender.list;
+        assertEquals(1, events.size(), "Exactly one analytics line per reservation");
+        assertEquals("APP_ANALYTICS event=reservation_created bar=HUBBLE",
+                events.get(0).getFormattedMessage());
+    }
+
+    @Test
+    void execute_shouldFallBackToNoPreferenceWhenLocationNull() {
+        // Given a reservation persisted without a location.
+        sampleEntity.setLocation(null);
+        when(constraintValidationService.validate(any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+        when(reservationMapper.toEntity(any(Reservation.class))).thenReturn(sampleEntity);
+        when(reservationRepository.save(any())).thenReturn(sampleEntity);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        // When
+        createReservationService.execute(sampleDto);
+
+        // Then
+        assertEquals("APP_ANALYTICS event=reservation_created bar=NO_PREFERENCE",
+                analyticsAppender.list.get(0).getFormattedMessage());
+    }
+
+    @Test
+    void execute_shouldNeverLogGuestPii() {
+        // Given
+        when(constraintValidationService.validate(any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+        when(reservationMapper.toEntity(any(Reservation.class))).thenReturn(sampleEntity);
+        when(reservationRepository.save(any())).thenReturn(sampleEntity);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        // When
+        createReservationService.execute(sampleDto);
+
+        // Then — no name/email/phone in any analytics or service log line.
+        assertNoPii(analyticsAppender);
+        assertNoPii(serviceAppender);
+    }
+
+    private void assertNoPii(ListAppender<ILoggingEvent> appender) {
+        for (ILoggingEvent event : appender.list) {
+            String msg = event.getFormattedMessage();
+            assertFalse(msg.contains("John Doe"), "name leaked into log: " + msg);
+            assertFalse(msg.contains("john@example.com"), "email leaked into log: " + msg);
+            assertFalse(msg.contains("+31612345678"), "phone leaked into log: " + msg);
+        }
     }
 
     @Test

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.59.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.9.3",
+  "version": "1.9.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What does this PR do?
Add a dedicated `analytics` SLF4J logger that emits one logfmt line per created
reservation (APP_ANALYTICS event=reservation_created bar=<LOCATION>) for Loki
scraping, containing only the event name and bar location. Also remove guest
name and email from the existing reservation.submitted INFO line so no PII is
written to centralized logs. Covered by unit tests asserting the exact format,
the NO_PREFERENCE fallback, and the absence of PII.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] CI / DevOps
- [x] Other: Logging

## Checklist
- [x] I have tested this locally (Docker Compose)
- [x] All tests pass (Also Pipeline check)
- [x] No secrets or credentials are committed
- [x] README / docs updated (if needed)

