### PR TITLE
v1.10.1

### DIFF
--- a/the-harry-list-admin/package-lock.json
+++ b/the-harry-list-admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-admin",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-admin",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@azure/msal-browser": "^5.15.0",
         "@azure/msal-react": "^5.5.0",

--- a/the-harry-list-admin/package.json
+++ b/the-harry-list-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-admin",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/the-harry-list-backend/pom.xml
+++ b/the-harry-list-backend/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.pimvanleeuwen</groupId>
 	<artifactId>the-harry-list-backend</artifactId>
-	<version>1.10.0</version>
+	<version>1.10.1</version>
 	<name>the-harry-list-backend</name>
 	<description>The Harry List, reservation system for Stichting Bar Potential</description>
 	<url/>

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationController.java
@@ -14,6 +14,7 @@ import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository
 import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailTemplateService;
+import com.pimvanleeuwen.the_harry_list_backend.service.ReservationAnalytics;
 import com.pimvanleeuwen.the_harry_list_backend.service.ReservationMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -43,6 +44,8 @@ import java.util.Map;
 public class AdminReservationController {
 
     private static final Logger log = LoggerFactory.getLogger(AdminReservationController.class);
+    /** Dedicated, PII-free analytics logger scraped into Loki (job=app-analytics). */
+    private static final Logger analyticsLog = LoggerFactory.getLogger("analytics");
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
@@ -103,6 +106,12 @@ public class AdminReservationController {
                         reservation.setConfirmedBy(confirmedBy);
                     }
                     com.pimvanleeuwen.the_harry_list_backend.model.Reservation saved = reservationRepository.save(reservation);
+
+                    // Privacy-safe analytics: a coarse note that a status transition happened, for
+                    // the terminal/meaningful states only (PENDING re-opens are internal churn).
+                    if (status != ReservationStatus.PENDING) {
+                        analyticsLog.info(ReservationAnalytics.reservationStatusChangedLine(status, saved.getLocation()));
+                    }
 
                     log.info("AUDIT reservation.status_changed id={} confirmation='{}' event='{}' date={} status={}->{} user='{}'{}",
                             id, saved.getConfirmationNumber(), saved.getEventTitle(), saved.getEventDate(),

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationService.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationService.java
@@ -1,7 +1,6 @@
 package com.pimvanleeuwen.the_harry_list_backend.service;
 
 import com.pimvanleeuwen.the_harry_list_backend.model.AuditEntityType;
-import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
 import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
 import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
 import com.pimvanleeuwen.the_harry_list_backend.repository.ReservationRepository;
@@ -87,9 +86,8 @@ public class CreateReservationService implements Command<com.pimvanleeuwen.the_h
                 savedEntity.getEventTitle(), savedEntity.getEventDate(), savedEntity.getLocation());
 
         // Privacy-safe analytics line scraped into Loki (job=app-analytics). PII-free by
-        // contract: only the event name and the bar location. See observability data contract.
-        BarLocation bar = savedEntity.getLocation() != null ? savedEntity.getLocation() : BarLocation.NO_PREFERENCE;
-        analyticsLog.info("APP_ANALYTICS event=reservation_created bar={}", bar.name());
+        // contract: only coarse buckets (bar, weekday, time slot, guest band, lead time).
+        analyticsLog.info(ReservationAnalytics.reservationCreatedLine(savedEntity));
 
         auditService.recordCreate(AuditEntityType.RESERVATION, savedEntity.getId(),
                 savedEntity.getConfirmationNumber() + " - " + savedEntity.getEventTitle(),

--- a/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ReservationAnalytics.java
+++ b/the-harry-list-backend/src/main/java/com/pimvanleeuwen/the_harry_list_backend/service/ReservationAnalytics.java
@@ -1,0 +1,81 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Builds the PII-free {@code APP_ANALYTICS} logfmt lines that are scraped into Loki
+ * (job=app-analytics). Every value here is a coarse, non-identifying bucket: no name,
+ * email, phone, id or free text ever appears. Kept as a separate, pure helper so the
+ * bucket boundaries can be unit-tested directly.
+ */
+public final class ReservationAnalytics {
+
+    private ReservationAnalytics() {
+    }
+
+    /** ISO weekday (Mon=1 … Sun=7) rendered as a stable, sortable label. */
+    private static final String[] DAY_OF_WEEK = {
+            "1_Mon", "2_Tue", "3_Wed", "4_Thu", "5_Fri", "6_Sat", "7_Sun"
+    };
+
+    /** Bar location name, falling back to NO_PREFERENCE when unset. */
+    static String bar(BarLocation location) {
+        return (location != null ? location : BarLocation.NO_PREFERENCE).name();
+    }
+
+    static String dayOfWeek(LocalDate eventDate) {
+        return DAY_OF_WEEK[eventDate.getDayOfWeek().getValue() - 1];
+    }
+
+    /** Coarse part-of-day bucket from the start time. */
+    static String slot(LocalTime startTime) {
+        int minutes = startTime.getHour() * 60 + startTime.getMinute();
+        if (minutes < 12 * 60) return "1_morning";     // before 12:00
+        if (minutes < 17 * 60) return "2_afternoon";   // 12:00–16:59
+        if (minutes < 22 * 60) return "3_evening";     // 17:00–21:59
+        return "4_night";                              // 22:00 and later
+    }
+
+    /** Coarse guest-count bucket. */
+    static String guests(Integer expectedGuests) {
+        int g = expectedGuests != null ? expectedGuests : 0;
+        if (g < 20) return "1_lt20";
+        if (g < 50) return "2_20_50";
+        if (g < 100) return "3_50_100";
+        return "4_gte100";
+    }
+
+    /** Coarse lead-time bucket: whole days between the booking and the event date. */
+    static String lead(LocalDateTime createdAt, LocalDate eventDate) {
+        LocalDate bookedOn = (createdAt != null ? createdAt.toLocalDate() : LocalDate.now());
+        long days = ChronoUnit.DAYS.between(bookedOn, eventDate);
+        if (days < 7) return "1_same_week";   // also clamps negatives (event already passed)
+        if (days < 14) return "2_wk1_2";
+        if (days < 28) return "3_wk3_4";
+        return "4_gt_4wk";
+    }
+
+    /** The enriched reservation-created line. Contains only coarse buckets — no PII. */
+    public static String reservationCreatedLine(Reservation r) {
+        return "APP_ANALYTICS event=reservation_created"
+                + " bar=" + bar(r.getLocation())
+                + " dow=" + dayOfWeek(r.getEventDate())
+                + " slot=" + slot(r.getStartTime())
+                + " guests=" + guests(r.getExpectedGuests())
+                + " lead=" + lead(r.getCreatedAt(), r.getEventDate());
+    }
+
+    /** The status-change line. Contains only the new status and the bar — no PII. */
+    public static String reservationStatusChangedLine(ReservationStatus status, BarLocation location) {
+        return "APP_ANALYTICS event=reservation_status_changed"
+                + " status=" + status.name()
+                + " bar=" + bar(location);
+    }
+}

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/controller/AdminReservationControllerTest.java
@@ -1,5 +1,8 @@
 package com.pimvanleeuwen.the_harry_list_backend.controller;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pimvanleeuwen.the_harry_list_backend.dto.CateringEmailRequest;
@@ -11,8 +14,10 @@ import com.pimvanleeuwen.the_harry_list_backend.service.AuditService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailNotificationService;
 import com.pimvanleeuwen.the_harry_list_backend.service.EmailTemplateService;
 import com.pimvanleeuwen.the_harry_list_backend.service.ReservationMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -25,6 +30,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -65,12 +71,25 @@ class AdminReservationControllerTest {
     private Reservation sampleReservation;
     private com.pimvanleeuwen.the_harry_list_backend.dto.Reservation sampleDto;
 
+    private Logger analyticsLogger;
+    private ListAppender<ILoggingEvent> analyticsAppender;
+
     @BeforeEach
     void setUp() {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         sampleReservation = createSampleReservation();
         sampleDto = createSampleDto();
+
+        analyticsLogger = (Logger) LoggerFactory.getLogger("analytics");
+        analyticsAppender = new ListAppender<>();
+        analyticsAppender.start();
+        analyticsLogger.addAppender(analyticsAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        analyticsLogger.detachAppender(analyticsAppender);
     }
 
     @Test
@@ -214,6 +233,41 @@ class AdminReservationControllerTest {
         verify(reservationRepository).save(argThat(res ->
             res.getStatus() == ReservationStatus.COMPLETED
         ));
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldEmitPrivacySafeAnalyticsLineOnConfirm() throws Exception {
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "CONFIRMED"))
+            .andExpect(status().isOk());
+
+        assertEquals(1, analyticsAppender.list.size(), "One analytics line per terminal status change");
+        assertEquals("APP_ANALYTICS event=reservation_status_changed status=CONFIRMED bar=HUBBLE",
+                analyticsAppender.list.get(0).getFormattedMessage());
+    }
+
+    @Test
+    @WithMockUser(roles = "EDITOR")
+    void updateStatus_shouldNotEmitAnalyticsWhenReopenedToPending() throws Exception {
+        // A rejected reservation moved back to PENDING is internal churn — no analytics line.
+        sampleReservation.setStatus(ReservationStatus.REJECTED);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(sampleReservation));
+        when(reservationRepository.save(any())).thenReturn(sampleReservation);
+        when(reservationMapper.toDto(any())).thenReturn(sampleDto);
+
+        mockMvc.perform(patch("/api/admin/reservations/1/status")
+                .with(csrf())
+                .param("status", "PENDING")
+                .param("sendEmail", "false"))
+            .andExpect(status().isOk());
+
+        assertTrue(analyticsAppender.list.isEmpty(), "PENDING transitions must not emit an analytics line");
     }
 
     @Test

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationServiceTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/CreateReservationServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
@@ -110,10 +111,11 @@ class CreateReservationServiceTest {
         // When
         createReservationService.execute(sampleDto);
 
-        // Then — exactly one line, in the agreed PII-free contract format.
+        // Then — exactly one line, in the enriched PII-free contract format.
         List<ILoggingEvent> events = analyticsAppender.list;
         assertEquals(1, events.size(), "Exactly one analytics line per reservation");
-        assertEquals("APP_ANALYTICS event=reservation_created bar=HUBBLE",
+        assertEquals(
+                "APP_ANALYTICS event=reservation_created bar=HUBBLE dow=7_Sun slot=2_afternoon guests=3_50_100 lead=3_wk3_4",
                 events.get(0).getFormattedMessage());
     }
 
@@ -130,8 +132,9 @@ class CreateReservationServiceTest {
         // When
         createReservationService.execute(sampleDto);
 
-        // Then
-        assertEquals("APP_ANALYTICS event=reservation_created bar=NO_PREFERENCE",
+        // Then — only the bar changes; the rest of the buckets stay as configured.
+        assertEquals(
+                "APP_ANALYTICS event=reservation_created bar=NO_PREFERENCE dow=7_Sun slot=2_afternoon guests=3_50_100 lead=3_wk3_4",
                 analyticsAppender.list.get(0).getFormattedMessage());
     }
 
@@ -178,6 +181,10 @@ class CreateReservationServiceTest {
 
         com.pimvanleeuwen.the_harry_list_backend.model.Reservation capturedEntity =
                 new com.pimvanleeuwen.the_harry_list_backend.model.Reservation();
+        // eventDate/startTime are non-null in the real flow (DB constraints); set them so the
+        // post-save analytics line can be built.
+        capturedEntity.setEventDate(LocalDate.of(2026, 3, 15));
+        capturedEntity.setStartTime(LocalTime.of(16, 0));
 
         when(reservationMapper.toEntity(any(Reservation.class))).thenReturn(capturedEntity);
         when(reservationRepository.save(any())).thenAnswer(invocation -> {
@@ -236,6 +243,12 @@ class CreateReservationServiceTest {
         entity.setLocation(BarLocation.HUBBLE);
         entity.setPaymentOption(PaymentOption.INDIVIDUAL);
         entity.setStatus(ReservationStatus.PENDING);
+        // Fixed date/time/guests/created-at so the derived analytics buckets are deterministic:
+        // Sunday, 16:00 (afternoon), 50 guests (50_100), booked 14 days ahead (wk3_4).
+        entity.setEventDate(LocalDate.of(2026, 3, 15));
+        entity.setStartTime(LocalTime.of(16, 0));
+        entity.setExpectedGuests(50);
+        entity.setCreatedAt(LocalDateTime.of(2026, 3, 1, 10, 0));
         return entity;
     }
 }

--- a/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ReservationAnalyticsTest.java
+++ b/the-harry-list-backend/src/test/java/com/pimvanleeuwen/the_harry_list_backend/service/ReservationAnalyticsTest.java
@@ -1,0 +1,123 @@
+package com.pimvanleeuwen.the_harry_list_backend.service;
+
+import com.pimvanleeuwen.the_harry_list_backend.model.BarLocation;
+import com.pimvanleeuwen.the_harry_list_backend.model.Reservation;
+import com.pimvanleeuwen.the_harry_list_backend.model.ReservationStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Boundary tests for the PII-free analytics bucket logic. Each bucket edge is pinned so a
+ * future tweak to the thresholds can't silently drift the Loki dashboards.
+ */
+class ReservationAnalyticsTest {
+
+    // ---- bar ----
+
+    @Test
+    void bar_usesLocationNameAndFallsBackToNoPreference() {
+        assertEquals("HUBBLE", ReservationAnalytics.bar(BarLocation.HUBBLE));
+        assertEquals("METEOR", ReservationAnalytics.bar(BarLocation.METEOR));
+        assertEquals("NO_PREFERENCE", ReservationAnalytics.bar(BarLocation.NO_PREFERENCE));
+        assertEquals("NO_PREFERENCE", ReservationAnalytics.bar(null));
+    }
+
+    // ---- day of week (ISO Mon=1 … Sun=7) ----
+
+    @Test
+    void dayOfWeek_labelsEachWeekday() {
+        // Week of Mon 2026-03-16 … Sun 2026-03-22.
+        assertEquals("1_Mon", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 16)));
+        assertEquals("2_Tue", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 17)));
+        assertEquals("3_Wed", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 18)));
+        assertEquals("4_Thu", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 19)));
+        assertEquals("5_Fri", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 20)));
+        assertEquals("6_Sat", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 21)));
+        assertEquals("7_Sun", ReservationAnalytics.dayOfWeek(LocalDate.of(2026, 3, 22)));
+    }
+
+    // ---- slot ----
+
+    @Test
+    void slot_boundaries() {
+        assertEquals("1_morning", ReservationAnalytics.slot(LocalTime.of(0, 0)));
+        assertEquals("1_morning", ReservationAnalytics.slot(LocalTime.of(11, 59)));
+        assertEquals("2_afternoon", ReservationAnalytics.slot(LocalTime.of(12, 0)));
+        assertEquals("2_afternoon", ReservationAnalytics.slot(LocalTime.of(16, 59)));
+        assertEquals("3_evening", ReservationAnalytics.slot(LocalTime.of(17, 0)));
+        assertEquals("3_evening", ReservationAnalytics.slot(LocalTime.of(21, 59)));
+        assertEquals("4_night", ReservationAnalytics.slot(LocalTime.of(22, 0)));
+        assertEquals("4_night", ReservationAnalytics.slot(LocalTime.of(23, 59)));
+    }
+
+    // ---- guests ----
+
+    @Test
+    void guests_boundaries() {
+        assertEquals("1_lt20", ReservationAnalytics.guests(null));
+        assertEquals("1_lt20", ReservationAnalytics.guests(0));
+        assertEquals("1_lt20", ReservationAnalytics.guests(19));
+        assertEquals("2_20_50", ReservationAnalytics.guests(20));
+        assertEquals("2_20_50", ReservationAnalytics.guests(49));
+        assertEquals("3_50_100", ReservationAnalytics.guests(50));
+        assertEquals("3_50_100", ReservationAnalytics.guests(99));
+        assertEquals("4_gte100", ReservationAnalytics.guests(100));
+        assertEquals("4_gte100", ReservationAnalytics.guests(500));
+    }
+
+    // ---- lead ----
+
+    @Test
+    void lead_boundaries() {
+        LocalDateTime bookedOn = LocalDateTime.of(2026, 3, 1, 10, 0);
+        assertEquals("1_same_week", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 1)));  // 0 days
+        assertEquals("1_same_week", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 7)));  // 6 days
+        assertEquals("2_wk1_2", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 8)));      // 7 days
+        assertEquals("2_wk1_2", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 14)));     // 13 days
+        assertEquals("3_wk3_4", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 15)));     // 14 days
+        assertEquals("3_wk3_4", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 28)));     // 27 days
+        assertEquals("4_gt_4wk", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 29)));    // 28 days
+    }
+
+    @Test
+    void lead_clampsNegativesToSameWeek() {
+        LocalDateTime bookedOn = LocalDateTime.of(2026, 3, 10, 10, 0);
+        assertEquals("1_same_week", ReservationAnalytics.lead(bookedOn, LocalDate.of(2026, 3, 5))); // -5 days
+    }
+
+    @Test
+    void lead_fallsBackToNowWhenCreatedAtIsNull() {
+        assertEquals("1_same_week", ReservationAnalytics.lead(null, LocalDate.now()));
+        assertEquals("4_gt_4wk", ReservationAnalytics.lead(null, LocalDate.now().plusDays(40)));
+    }
+
+    // ---- full lines ----
+
+    @Test
+    void reservationCreatedLine_assemblesAllBuckets() {
+        Reservation r = new Reservation();
+        r.setLocation(BarLocation.HUBBLE);
+        r.setEventDate(LocalDate.of(2026, 3, 15));      // Sunday
+        r.setStartTime(LocalTime.of(16, 0));            // afternoon
+        r.setExpectedGuests(50);                        // 50_100
+        r.setCreatedAt(LocalDateTime.of(2026, 3, 1, 10, 0)); // 14 days -> wk3_4
+
+        assertEquals(
+                "APP_ANALYTICS event=reservation_created bar=HUBBLE dow=7_Sun slot=2_afternoon guests=3_50_100 lead=3_wk3_4",
+                ReservationAnalytics.reservationCreatedLine(r));
+    }
+
+    @Test
+    void reservationStatusChangedLine_hasStatusAndBar() {
+        assertEquals("APP_ANALYTICS event=reservation_status_changed status=CONFIRMED bar=HUBBLE",
+                ReservationAnalytics.reservationStatusChangedLine(ReservationStatus.CONFIRMED, BarLocation.HUBBLE));
+        // Null location (e.g. a rejected NO_PREFERENCE request) falls back to NO_PREFERENCE.
+        assertEquals("APP_ANALYTICS event=reservation_status_changed status=REJECTED bar=NO_PREFERENCE",
+                ReservationAnalytics.reservationStatusChangedLine(ReservationStatus.REJECTED, null));
+    }
+}

--- a/the-harry-list-public/package-lock.json
+++ b/the-harry-list-public/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-harry-list-public",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-harry-list-public",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@sentry/react": "^10.62.0",

--- a/the-harry-list-public/package.json
+++ b/the-harry-list-public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "the-harry-list-public",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What does this PR do?
Expand the reservation_created analytics line with coarse, non-identifying buckets (weekday, time slot, guest band, lead time) alongside the bar, and add a reservation_status_changed event for CONFIRMED/REJECTED/CANCELLED/COMPLETED transitions (PENDING re-opens are skipped). Both go to the dedicated `analytics` logger and contain no name/email/phone/id/free-text. Extract the bucket logic into a small tested ReservationAnalytics helper. Audit log and all existing behaviour unchanged. Covered by boundary unit tests and emitted-line assertions.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] CI / DevOps
- [ ] Other: <!-- describe -->

## Checklist
- [x] I have tested this locally (Docker Compose)
- [x] All tests pass (Also Pipeline check)
- [x] No secrets or credentials are committed
- [x] README / docs updated (if needed)

